### PR TITLE
fix(homepage): validate firmware response shape + classify mid-poll backend outage as unreachable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,12 @@
 # the full repo with one command. Each target prints what it actually shells
 # out to, so it is always discoverable how to run the same step by hand.
 
-.PHONY: help test test-esp test-esp-native test-e2e test-e2e-deps check-citations
+.PHONY: help firmware test test-esp test-esp-native test-e2e test-e2e-deps check-citations
 
 help:
 	@echo "HiveHive — available make targets"
 	@echo ""
+	@echo "  make firmware           Build ESP32-CAM firmware and stage homepage/public/firmware.bin"
 	@echo "  make test               Run every test suite that can run on this host"
 	@echo "  make test-esp           Run ESP32-CAM unit tests on host (no hardware)"
 	@echo "  make test-esp-native    Alias for test-esp"
@@ -17,10 +18,20 @@ help:
 	@echo "  make check-citations    Verify path:line citations in docs/ + CLAUDE.md still resolve"
 	@echo ""
 	@echo "Prerequisites:"
+	@echo "  firmware    →   arduino-cli with esp32:esp32 core installed"
 	@echo "  test-esp*   →   pip install platformio   (provides 'pio')"
 	@echo "  test-e2e    →   docker + docker compose v2"
 	@echo "                  pip install -r tests/e2e/requirements.txt"
 	@echo ""
+
+# Wraps ESP32-CAM/build.sh: arduino-cli compile → merged.bin →
+# homepage/public/{firmware.bin,firmware.json}. The setup wizard's Step 2
+# fetches /firmware.bin from the homepage container; without this step,
+# Vite's SPA fallback returns index.html and the wizard rejects the
+# response (issue #43).
+firmware:
+	@echo ">>> ESP32-CAM/build.sh"
+	cd ESP32-CAM && ./build.sh
 
 test: test-esp-native test-e2e
 

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -101,6 +101,35 @@ write the lesson here so the next contributor doesn't repeat it.
 Format: short title + **What happened** + **Why it happened** +
 **How to avoid it next time**.
 
+### Setup wizard shipped two silent-success bugs (issues #43, #44)
+
+**What happened.** Two failure modes in the setup wizard were
+mis-classified as success or non-actionable: (a) when
+`homepage/public/firmware.bin` was missing, Vite's SPA fallback served
+`index.html` with HTTP 200, the wizard handed the HTML payload to
+`esptool-js`, `writeFlash` silently no-op'd on garbage bytes, and
+Step 2 flashed green in <1 s while the chip kept its old firmware;
+(b) when the backend died during the 2-minute Step 5 poll window,
+all 24 polls failed, the wizard set a single `verificationTimedOut`
+flag, and the UI showed the orange "check the module" troubleshooting
+screen — pointing the user at completely the wrong remediation.
+
+**Why it happened.** Both bugs share the same shape: a fetch result
+was fed to a side-effecting consumer (`writeFlash`, the
+verification-classifier `setState`) without validating the response
+shape beyond `response.ok`. Status code alone doesn't distinguish
+"served firmware" from "served HTML fallback", and "all polls failed"
+doesn't distinguish "ESP didn't show up" from "backend went silent".
+
+**How to avoid it next time.** When a fetch result drives a
+side-effecting consumer, validate the *shape* of the response, not
+just the status. For binary payloads: assert the `Content-Type` and
+the magic byte before handing the bytes downstream. For polling
+loops: track the failure category (network vs. semantic-empty), not
+just success/fail, so the final state can route to the correct
+remediation branch. Both fixes shipped in PR-B
+(`fix/wizard-flash-and-poll-classification`).
+
 ### ESP watchdog crashed every ~44 s in AP mode (fixed dfd454b)
 
 **What happened.** First-time ESP32-CAM setup was impossible — the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,21 +49,51 @@ The IO0 pin must be grounded **before** the reset signal is sent.
 
 If it still hangs, check the USB cable (some cables are charge-only) and the COM port selection.
 
-### Setup wizard step 2 says "/firmware.bin not found" / 404
+### Setup wizard step 2 finishes in <1s with "Firmware installiert" but the board still runs old firmware
 
-The wizard pins firmware to a local `homepage/public/firmware.bin`
-file (commit `f7300b9`). That file is **not** checked in — it lands
-there only after `ESP32-CAM/build.sh` runs:
+**Symptom:** Step 2 flashes green almost immediately (instead of the
+expected ~20 s), the board reboots, and you discover after the fact
+that the new firmware never landed.
+
+**Cause:** `homepage/public/firmware.bin` is missing or stale. Vite's
+SPA dev fallback serves `index.html` with HTTP 200 + `text/html` for
+any unknown path, so the wizard's `fetch('/firmware.bin')` succeeds
+on what is in fact an HTML page. Issue #43.
+
+**Fix:** the wizard now validates the response shape — `Content-Type`
+must not be HTML, and the first byte must be `0xE9` (the ESP32 image
+magic byte). If either check fails, Step 2 surfaces a clear error
+pointing at this fix. Build the firmware:
 
 ```bash
-cd ESP32-CAM
-./build.sh                # writes homepage/public/firmware.bin + firmware.json
+make firmware              # wraps ESP32-CAM/build.sh
+# or directly:
+cd ESP32-CAM && ./build.sh # writes homepage/public/firmware.bin + firmware.json
 ```
 
-`build.sh:33-37` writes the manifest and binary together. Without that
-build step, step 2 of the wizard 404s on the OTA URL. If you've never
-flashed firmware on this checkout, run `build.sh` first; on shared
-checkouts, regenerate after every firmware change.
+`ESP32-CAM/build.sh's` final block writes the manifest and binary
+together. The file is not checked in; on shared checkouts, regenerate
+after every firmware change.
+
+### Setup wizard step 5 shows "Backend Server Not Reachable" mid-poll
+
+**Symptom:** the wizard passed the initial healthcheck on Step 5 and
+started polling, but the red "Backend Server Not Reachable" branch
+appears (instead of the orange "Module Not Detected Yet" timeout
+screen) before any module shows up.
+
+**Cause:** the backend went silent during the 2-minute poll window —
+`docker compose stop backend`, an OOM kill, or a network hiccup
+between the homepage and `:3002`. Issue #44 used to mis-classify this
+as a timeout and direct users to factory-reset the ESP, which would
+fix nothing. The wizard now tracks consecutive trailing poll failures
+and flips to the unreachable branch when ≥5 of the last polls
+network-failed.
+
+**Fix:** restart the backend (`docker compose up -d backend`), then
+click **Check Again** on the wizard. The pre-poll healthcheck retries
+8× before failing, so the wizard recovers on its own once the backend
+is healthy.
 
 ### PlatformIO not found / "No module named platformio"
 

--- a/homepage/src/__tests__/Step5Verify.test.tsx
+++ b/homepage/src/__tests__/Step5Verify.test.tsx
@@ -119,16 +119,27 @@ describe('Step5Verify retry visibility', () => {
     warn.mockRestore();
   });
 
-  it('also renders the unreachable-screen when the poll loop reports backend-down (issue #44)', () => {
+  it('also renders the unreachable-screen when the poll loop reports backend-down (issue #44)', async () => {
     // The pre-poll healthcheck succeeded, the poll loop ran for 2 minutes,
     // the trailing run of failures crossed the threshold, and the wizard
     // hook set verificationBackendUnreachable=true. Show the same red
     // "Backend Server Not Reachable" branch as a failed initial healthcheck
     // — not the orange "check the module" troubleshooting screen, which
     // would point the user at completely the wrong remediation.
+    //
+    // The local healthcheck must succeed first: the new gate in
+    // Step5Verify suppresses the parent flag while backendReachable is
+    // still null (avoiding a red flash on remount). Without the
+    // healthcheck mock + microtask drain below, the assertion would
+    // race the still-pending `checkBackendAndStart` and could flake.
     healthCheck.mockResolvedValueOnce({ status: 'ok', timestamp: '' });
 
     renderWizardStep(() => {}, { verificationBackendUnreachable: true });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
 
     expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(screen.getByText(/Backend Server Not Reachable/i)).toBeInTheDocument();

--- a/homepage/src/__tests__/Step5Verify.test.tsx
+++ b/homepage/src/__tests__/Step5Verify.test.tsx
@@ -14,14 +14,21 @@ vi.mock('../services/api', () => ({
 
 import Step5Verify from '../components/setup/Step5Verify';
 
-function renderWizardStep(startVerification: () => void = () => {}) {
+function renderWizardStep(
+  startVerification: () => void = () => {},
+  overrides: Partial<{
+    verificationTimedOut: boolean;
+    verificationBackendUnreachable: boolean;
+  }> = {},
+) {
   return render(
     <LanguageProvider>
       <MemoryRouter>
         <Step5Verify
           pollingActive={true}
           detectedModule={null}
-          verificationTimedOut={false}
+          verificationTimedOut={overrides.verificationTimedOut ?? false}
+          verificationBackendUnreachable={overrides.verificationBackendUnreachable ?? false}
           startVerification={startVerification}
           onBack={() => {}}
         />
@@ -110,6 +117,23 @@ describe('Step5Verify retry visibility', () => {
       expect.any(Error),
     );
     warn.mockRestore();
+  });
+
+  it('also renders the unreachable-screen when the poll loop reports backend-down (issue #44)', () => {
+    // The pre-poll healthcheck succeeded, the poll loop ran for 2 minutes,
+    // the trailing run of failures crossed the threshold, and the wizard
+    // hook set verificationBackendUnreachable=true. Show the same red
+    // "Backend Server Not Reachable" branch as a failed initial healthcheck
+    // — not the orange "check the module" troubleshooting screen, which
+    // would point the user at completely the wrong remediation.
+    healthCheck.mockResolvedValueOnce({ status: 'ok', timestamp: '' });
+
+    renderWizardStep(() => {}, { verificationBackendUnreachable: true });
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Backend Server Not Reachable/i)).toBeInTheDocument();
+    // And NOT the orange timeout copy — would be a regression of #44.
+    expect(screen.queryByText(/Module Not Detected Yet/i)).not.toBeInTheDocument();
   });
 
   it('renders the unreachable-screen alert when all 8 attempts fail', async () => {

--- a/homepage/src/__tests__/flashEsp.test.ts
+++ b/homepage/src/__tests__/flashEsp.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { assertFirmwareResponse, ESP_IMAGE_MAGIC } from '../components/setup/flashEsp';
+
+// Issue #43: when /firmware.bin is missing, Vite's SPA fallback returns
+// index.html with HTTP 200 + content-type: text/html. flashEsp used to read
+// that as binary string and hand it to esptool-js, which silently no-op'd.
+// The wizard then "succeeded" in <1s while the chip kept its old firmware.
+//
+// These tests pin the validator that now stands between the fetch and
+// writeFlash. Only the helper is exercised — Web Serial / ESPLoader are
+// not mockable from jsdom and aren't the layer at risk here.
+
+describe('assertFirmwareResponse', () => {
+  function html(body: string, headers: Record<string, string> = { 'content-type': 'text/html' }) {
+    return new Response(body, { status: 200, headers });
+  }
+
+  function bin(bytes: number[], headers: Record<string, string> = {}) {
+    return new Response(new Uint8Array(bytes), { status: 200, headers });
+  }
+
+  it('rejects an HTML response (Vite SPA fallback)', async () => {
+    const resp = html('<!doctype html><html><body>vite</body></html>');
+    const blob = await resp.clone().blob();
+    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).rejects.toThrow(
+      /Firmware not found at \/firmware\.bin/,
+    );
+  });
+
+  it('rejects an HTML response even when content-type uses charset suffix', async () => {
+    const resp = html('<!doctype html>', { 'content-type': 'text/html; charset=utf-8' });
+    const blob = await resp.clone().blob();
+    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).rejects.toThrow(
+      /not found.*HTML/,
+    );
+  });
+
+  it('rejects a non-0xE9 first byte even with octet-stream content-type', async () => {
+    // The defence-in-depth case: a static server that serves the SPA
+    // fallback as application/octet-stream would slip past the
+    // content-type check; magic-byte check catches it.
+    const resp = bin([0x3c, 0x21, 0x64, 0x6f], { 'content-type': 'application/octet-stream' });
+    const blob = await resp.clone().blob();
+    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).rejects.toThrow(
+      /not a valid ESP32 image.*0x3C.*expected 0xE9/,
+    );
+  });
+
+  it('rejects an empty body', async () => {
+    const resp = bin([], { 'content-type': 'application/octet-stream' });
+    const blob = await resp.clone().blob();
+    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).rejects.toThrow(/empty/);
+  });
+
+  it('accepts a binary starting with the ESP32 image magic byte', async () => {
+    const resp = bin([ESP_IMAGE_MAGIC, 0x00, 0x10, 0x20], {
+      'content-type': 'application/octet-stream',
+    });
+    const blob = await resp.clone().blob();
+    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).resolves.toBeUndefined();
+  });
+
+  it('accepts the magic byte even when content-type is missing', async () => {
+    // arduino-cli's merged.bin served by Vite's static handler doesn't
+    // always carry an explicit content-type. The magic byte is the
+    // authoritative check.
+    const resp = bin([ESP_IMAGE_MAGIC, 0x01]);
+    const blob = await resp.clone().blob();
+    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).resolves.toBeUndefined();
+  });
+});

--- a/homepage/src/__tests__/useSetupWizard.test.ts
+++ b/homepage/src/__tests__/useSetupWizard.test.ts
@@ -22,6 +22,8 @@ import { useSetupWizard } from '../components/setup/useSetupWizard';
 // a trailing-error counter.
 
 describe('useSetupWizard.startVerification — mid-poll classification (#44)', () => {
+  let originalFetch: typeof fetch;
+
   beforeEach(() => {
     getAllModules.mockReset();
     healthCheck.mockReset();
@@ -29,13 +31,17 @@ describe('useSetupWizard.startVerification — mid-poll classification (#44)', (
     vi.useFakeTimers();
     // The hook's mount effects also fetch /firmware.json and
     // /__dev-api/lan-ip — stub those so the test isn't coupled to
-    // their implementations.
+    // their implementations. Stash the original so afterEach can
+    // restore it and the next test in this file (or next file run
+    // in the same worker) doesn't inherit the override.
+    originalFetch = globalThis.fetch;
     globalThis.fetch = vi
       .fn()
       .mockResolvedValue(new Response(null, { status: 404 })) as typeof fetch;
   });
 
   afterEach(() => {
+    globalThis.fetch = originalFetch;
     vi.useRealTimers();
   });
 
@@ -49,9 +55,14 @@ describe('useSetupWizard.startVerification — mid-poll classification (#44)', (
   }
 
   it('classifies as backend-unreachable when all 24 polls fail', async () => {
-    // Mount snapshot fetch: empty success.
+    // Mount snapshot resolves empty; every subsequent call (including
+    // startVerification's fallback snapshot, which fires because the
+    // mount snapshot was empty, plus all 24 poll-loop fetches)
+    // rejects. The shared-default rejection is intentional — leaving
+    // the queue exhausted would let undefined leak through to
+    // modules.find() which would TypeError but only after resetting
+    // the counter, masking what the test claims to pin.
     getAllModules.mockResolvedValueOnce([]);
-    // Poll loop: every fetch rejects.
     getAllModules.mockRejectedValue(new Error('fetch failed'));
 
     const { result } = renderHook(() => useSetupWizard());
@@ -75,7 +86,15 @@ describe('useSetupWizard.startVerification — mid-poll classification (#44)', (
   });
 
   it('classifies as timeout when a late poll succeeds (resetting the trailing-error counter)', async () => {
-    getAllModules.mockResolvedValueOnce([]); // mount snapshot
+    // Mount with a non-empty snapshot so startVerification skips its
+    // fallback fetch — without this, the fallback would silently
+    // consume one of the rejection mocks below and the trailing-error
+    // count at MAX_POLLS would land on 1 instead of the intended 0,
+    // making the test pass for the wrong reason if the threshold ever
+    // changes. Same pattern as the third case below.
+    getAllModules.mockResolvedValueOnce([
+      { id: 'pre-existing-aabbccddeeff', name: 'Pre-existing', updatedAt: '2024-01-01' },
+    ]);
     // First 23 poll attempts fail.
     for (let i = 0; i < 23; i++) {
       getAllModules.mockRejectedValueOnce(new Error('fetch failed'));
@@ -84,6 +103,8 @@ describe('useSetupWizard.startVerification — mid-poll classification (#44)', (
     // matching module appeared. Counter resets to 0; classification
     // should be the orange timeout, not the red unreachable.
     getAllModules.mockResolvedValueOnce([]);
+    // Belt-and-braces default for any extra calls.
+    getAllModules.mockRejectedValue(new Error('fetch failed (default)'));
 
     const { result } = renderHook(() => useSetupWizard());
     await act(async () => {

--- a/homepage/src/__tests__/useSetupWizard.test.ts
+++ b/homepage/src/__tests__/useSetupWizard.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Hoisted mocks — declared before the hook import so vi rewrites
+// the module graph.
+const getAllModules = vi.fn();
+const healthCheck = vi.fn();
+vi.mock('../services/api', () => ({
+  api: {
+    getAllModules: (...args: unknown[]) => getAllModules(...args),
+    healthCheck: (...args: unknown[]) => healthCheck(...args),
+  },
+}));
+
+import { useSetupWizard } from '../components/setup/useSetupWizard';
+
+// Issue #44: when the poll loop times out, the wizard previously set a
+// single verificationTimedOut=true regardless of why. The orange "check
+// the module" troubleshooting screen pointed users at completely the
+// wrong remediation when the actual failure was a backend outage during
+// the 2-minute poll window. The hook now distinguishes the two cases via
+// a trailing-error counter.
+
+describe('useSetupWizard.startVerification — mid-poll classification (#44)', () => {
+  beforeEach(() => {
+    getAllModules.mockReset();
+    healthCheck.mockReset();
+    healthCheck.mockResolvedValue({ status: 'ok', timestamp: '' });
+    vi.useFakeTimers();
+    // The hook's mount effects also fetch /firmware.json and
+    // /__dev-api/lan-ip — stub those so the test isn't coupled to
+    // their implementations.
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 404 })) as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Drive the poll-loop interval forward by `n` ticks (POLL_INTERVAL=5s). */
+  async function tick(n: number) {
+    for (let i = 0; i < n; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+    }
+  }
+
+  it('classifies as backend-unreachable when all 24 polls fail', async () => {
+    // Mount snapshot fetch: empty success.
+    getAllModules.mockResolvedValueOnce([]);
+    // Poll loop: every fetch rejects.
+    getAllModules.mockRejectedValue(new Error('fetch failed'));
+
+    const { result } = renderHook(() => useSetupWizard());
+    // Drain the mount-effect promises (loadFirmware, detectLanIp,
+    // snapshotModules) so subsequent assertions see the post-mount state.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.startVerification();
+    });
+
+    // 24 ticks fire the per-poll fetch; the 25th increments
+    // pollCountRef past MAX_POLLS and runs the classification.
+    await tick(25);
+
+    expect(result.current.state.verificationBackendUnreachable).toBe(true);
+    expect(result.current.state.verificationTimedOut).toBe(false);
+    expect(result.current.state.pollingActive).toBe(false);
+  });
+
+  it('classifies as timeout when a late poll succeeds (resetting the trailing-error counter)', async () => {
+    getAllModules.mockResolvedValueOnce([]); // mount snapshot
+    // First 23 poll attempts fail.
+    for (let i = 0; i < 23; i++) {
+      getAllModules.mockRejectedValueOnce(new Error('fetch failed'));
+    }
+    // 24th poll succeeds with empty array — backend is alive, but no
+    // matching module appeared. Counter resets to 0; classification
+    // should be the orange timeout, not the red unreachable.
+    getAllModules.mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useSetupWizard());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.startVerification();
+    });
+
+    await tick(25);
+
+    expect(result.current.state.verificationTimedOut).toBe(true);
+    expect(result.current.state.verificationBackendUnreachable).toBe(false);
+  });
+
+  it('still classifies as backend-unreachable when an early poll succeeded but the trailing run is long enough', async () => {
+    // Mount with a non-empty snapshot so startVerification skips its
+    // fallback fetch — keeps the call accounting honest.
+    getAllModules.mockResolvedValueOnce([
+      { id: 'pre-existing-aabbccddeeff', name: 'Pre-existing', updatedAt: '2024-01-01' },
+    ]);
+    // First poll succeeds (resets counter to 0)…
+    getAllModules.mockResolvedValueOnce([]);
+    // …then the next 23 polls all fail. Trailing run = 23 ≥ 5.
+    for (let i = 0; i < 23; i++) {
+      getAllModules.mockRejectedValueOnce(new Error('fetch failed'));
+    }
+    // Belt-and-braces: if the loop somehow runs past the planned mocks,
+    // any extra call rejects too (default returning undefined would hit
+    // the success branch and silently reset the counter).
+    getAllModules.mockRejectedValue(new Error('fetch failed (default)'));
+
+    const { result } = renderHook(() => useSetupWizard());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.startVerification();
+    });
+
+    await tick(25);
+
+    expect(result.current.state.verificationBackendUnreachable).toBe(true);
+    expect(result.current.state.verificationTimedOut).toBe(false);
+  });
+});

--- a/homepage/src/components/setup/Step5Verify.tsx
+++ b/homepage/src/components/setup/Step5Verify.tsx
@@ -10,6 +10,11 @@ interface Step5VerifyProps {
   pollingActive: boolean;
   detectedModule: Module | null;
   verificationTimedOut: boolean;
+  // True if the poll loop ran out the clock with the backend silent — a
+  // mid-poll outage that should surface the same red "unreachable" branch
+  // as a failed initial healthcheck, not the orange "check the module"
+  // troubleshooting screen. See issue #44.
+  verificationBackendUnreachable: boolean;
   startVerification: () => void;
   onBack: () => void;
 }
@@ -18,6 +23,7 @@ export default function Step5Verify({
   pollingActive,
   detectedModule,
   verificationTimedOut,
+  verificationBackendUnreachable,
   startVerification,
   onBack,
 }: Step5VerifyProps) {
@@ -153,7 +159,11 @@ export default function Step5Verify({
   }
 
   // ---- BACKEND UNREACHABLE ----
-  if (backendReachable === false) {
+  // Two routes into this branch:
+  //   1. checkBackendAndStart's initial 8-attempt healthcheck never succeeded.
+  //   2. Poll loop ran out the clock with the trailing run of failures long
+  //      enough to indicate the backend (not the ESP) is at fault (#44).
+  if (backendReachable === false || verificationBackendUnreachable) {
     return (
       <section
         className="flex flex-col items-center text-center"

--- a/homepage/src/components/setup/Step5Verify.tsx
+++ b/homepage/src/components/setup/Step5Verify.tsx
@@ -163,7 +163,13 @@ export default function Step5Verify({
   //   1. checkBackendAndStart's initial 8-attempt healthcheck never succeeded.
   //   2. Poll loop ran out the clock with the trailing run of failures long
   //      enough to indicate the backend (not the ESP) is at fault (#44).
-  if (backendReachable === false || verificationBackendUnreachable) {
+  // Gate the parent flag on `backendReachable !== null` so a remount of
+  // Step 5 (e.g. user back-navigates and returns) doesn't flash the red
+  // screen before the fresh local healthcheck has fired.
+  if (
+    backendReachable === false ||
+    (backendReachable !== null && verificationBackendUnreachable)
+  ) {
     return (
       <section
         className="flex flex-col items-center text-center"

--- a/homepage/src/components/setup/flashEsp.ts
+++ b/homepage/src/components/setup/flashEsp.ts
@@ -150,8 +150,14 @@ export async function flashEsp(
 
 /**
  * ESP32 application image header magic byte (esp_image_format.h
- * `ESP_IMAGE_HEADER_MAGIC`). Both single-app and merged-with-bootloader
- * binaries start with this byte.
+ * `ESP_IMAGE_HEADER_MAGIC`). The bootloader, every app slot, and
+ * the merged single-blob produced by `esptool.py merge_bin` all
+ * begin with 0xE9. Other artefacts in a multi-part flash layout
+ * have different magics — partition tables start with 0xAA 0x50.
+ * The current Step2Flash manifest is a single merged part at
+ * offset 0, so 0xE9 is the right gate; if anyone splits the
+ * manifest into bootloader + partitions + app, this validator
+ * needs to learn the per-offset allow-list.
  */
 export const ESP_IMAGE_MAGIC = 0xe9;
 

--- a/homepage/src/components/setup/flashEsp.ts
+++ b/homepage/src/components/setup/flashEsp.ts
@@ -83,6 +83,7 @@ export async function flashEsp(
       const firmwareResp = await fetch(part.path);
       if (!firmwareResp.ok) throw new Error(`Failed to fetch firmware: ${part.path}`);
       const blob = await firmwareResp.blob();
+      await assertFirmwareResponse(firmwareResp, blob, part.path);
       const data = await blobToBinaryString(blob);
       fileArray.push({ data, address: part.offset });
     }
@@ -144,6 +145,58 @@ export async function flashEsp(
         /* ignore */
       }
     }
+  }
+}
+
+/**
+ * ESP32 application image header magic byte (esp_image_format.h
+ * `ESP_IMAGE_HEADER_MAGIC`). Both single-app and merged-with-bootloader
+ * binaries start with this byte.
+ */
+export const ESP_IMAGE_MAGIC = 0xe9;
+
+/**
+ * Reject a /firmware.bin response that obviously isn't firmware before we
+ * hand its bytes to esptool-js.
+ *
+ * Two checks, layered:
+ *
+ * 1. **Content-Type** — Vite's SPA dev fallback returns `index.html` with
+ *    HTTP 200 + `text/html` when the requested path doesn't exist. Without
+ *    this check the wizard would treat the HTML payload as firmware,
+ *    `esptool-js`'s `writeFlash` would silently no-op on garbage bytes,
+ *    `hard_reset` would boot the chip into its previous firmware, and
+ *    Step 2 would flash green ("Firmware installiert!") in <1 s.
+ *
+ * 2. **Magic byte** — defence in depth. Catches misconfigured static
+ *    servers that send `application/octet-stream` for the SPA fallback,
+ *    and corrupt/truncated downloads.
+ *
+ * See issue #43.
+ */
+export async function assertFirmwareResponse(
+  resp: Response,
+  blob: Blob,
+  path: string,
+): Promise<void> {
+  const ctype = resp.headers.get('content-type') || '';
+  if (/text\/html/i.test(ctype)) {
+    throw new Error(
+      `Firmware not found at ${path} (server returned HTML). Run "make firmware" (or ESP32-CAM/build.sh) before opening the setup wizard.`,
+    );
+  }
+
+  if (blob.size === 0) {
+    throw new Error(`Firmware at ${path} is empty.`);
+  }
+
+  const headBuf = await blob.slice(0, 1).arrayBuffer();
+  const head = new Uint8Array(headBuf)[0];
+  if (head !== ESP_IMAGE_MAGIC) {
+    const hex = head.toString(16).padStart(2, '0').toUpperCase();
+    throw new Error(
+      `Firmware at ${path} is not a valid ESP32 image (first byte 0x${hex}, expected 0xE9). Rebuild with "make firmware".`,
+    );
   }
 }
 

--- a/homepage/src/components/setup/useSetupWizard.ts
+++ b/homepage/src/components/setup/useSetupWizard.ts
@@ -257,6 +257,10 @@ export function useSetupWizard() {
       pollingIntervalRef.current = null;
     }
     startInflightRef.current = false;
+    // Co-locate the reset with the other cleanup so the next
+    // startVerification can't inherit a stale trailing-error count
+    // through a code path that bypasses its own initialisation block.
+    consecutivePollErrorsRef.current = 0;
     setState((s) => ({ ...s, pollingActive: false }));
   }, []);
 
@@ -296,6 +300,13 @@ export function useSetupWizard() {
     pollingIntervalRef.current = setInterval(async () => {
       pollCountRef.current++;
       if (pollCountRef.current > MAX_POLLS) {
+        // Trailing-only heuristic: we look at the run of failures
+        // immediately before the timeout, not the whole window. A flaky
+        // backend that recovered for the last few polls classifies as
+        // timeout, not unreachable — fine, because the user can in fact
+        // reach the dashboard now even if their module didn't appear.
+        // The other direction (backend up early, dies for the final
+        // ~25s) is the one #44 wanted to fix and the threshold catches.
         const trailingErrors = consecutivePollErrorsRef.current;
         const backendDownAtEnd = trailingErrors >= POLL_BACKEND_DOWN_TAIL;
         console.warn(

--- a/homepage/src/components/setup/useSetupWizard.ts
+++ b/homepage/src/components/setup/useSetupWizard.ts
@@ -22,6 +22,10 @@ export interface WizardState {
   pollCount: number;
   detectedModule: Module | null;
   verificationTimedOut: boolean;
+  // Set instead of verificationTimedOut when MAX_POLLS expires AND the
+  // trailing run of poll failures is long enough to indicate the backend
+  // (not the ESP) is the problem. See issue #44.
+  verificationBackendUnreachable: boolean;
 }
 
 const INIT_BASE_URL = import.meta.env.VITE_INIT_BASE_URL || 'http://localhost:8000';
@@ -36,6 +40,11 @@ export const SERVER_CONFIG = {
 
 const MAX_POLLS = 24; // 2 minutes at 5s intervals
 const POLL_INTERVAL = 5000;
+// If the trailing run of consecutive poll errors is at least this long when
+// MAX_POLLS expires (~25s of uninterrupted backend silence at the end of
+// the window), classify the timeout as "backend unreachable" rather than
+// "module didn't show up". See issue #44.
+const POLL_BACKEND_DOWN_TAIL = 5;
 
 /**
  * Replace "localhost" or "127.0.0.1" in a URL with the given LAN IP.
@@ -63,11 +72,16 @@ export function useSetupWizard() {
     pollCount: 0,
     detectedModule: null,
     verificationTimedOut: false,
+    verificationBackendUnreachable: false,
   });
 
   const lanIpRef = useRef<string | null>(null);
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollCountRef = useRef(0);
+  // Trailing-run counter for poll catches. Reset to 0 on any successful
+  // 200 OK (even with empty modules) so an early-window blip doesn't
+  // poison the late-window classification (#44).
+  const consecutivePollErrorsRef = useRef(0);
   const knownModuleSnapshotRef = useRef<Map<string, string | undefined>>(new Map());
   // React 18 Strict Mode runs every effect twice in dev (intentional, to
   // surface effects that don't survive remount). Both runs of Step5Verify's
@@ -273,16 +287,28 @@ export function useSetupWizard() {
       pollingActive: true,
       pollCount: 0,
       verificationTimedOut: false,
+      verificationBackendUnreachable: false,
       detectedModule: null,
     }));
     pollCountRef.current = 0;
+    consecutivePollErrorsRef.current = 0;
 
     pollingIntervalRef.current = setInterval(async () => {
       pollCountRef.current++;
       if (pollCountRef.current > MAX_POLLS) {
-        console.warn('[Step5] Max polls reached, timing out');
+        const trailingErrors = consecutivePollErrorsRef.current;
+        const backendDownAtEnd = trailingErrors >= POLL_BACKEND_DOWN_TAIL;
+        console.warn(
+          `[Step5] Max polls reached, classifying as ${
+            backendDownAtEnd ? 'backend-unreachable' : 'timeout'
+          } (consecutive errors=${trailingErrors})`,
+        );
         stopVerification();
-        setState((s) => ({ ...s, verificationTimedOut: true }));
+        setState((s) => ({
+          ...s,
+          verificationTimedOut: !backendDownAtEnd,
+          verificationBackendUnreachable: backendDownAtEnd,
+        }));
         return;
       }
       setState((s) => ({ ...s, pollCount: pollCountRef.current }));
@@ -290,6 +316,10 @@ export function useSetupWizard() {
 
       try {
         const modules = await api.getAllModules();
+        // Any 200 OK — even an empty array — means the backend is alive.
+        // Reset the trailing-error counter so a late-window outage gets
+        // classified correctly (#44).
+        consecutivePollErrorsRef.current = 0;
         // 5-minute recency fallback: covers the case where the user reloaded
         // the wizard *after* the ESP had already phoned home — the snapshot
         // then captured the module in its updated state, so the snapshot
@@ -315,6 +345,7 @@ export function useSetupWizard() {
           setState((s) => ({ ...s, detectedModule }));
         }
       } catch (err) {
+        consecutivePollErrorsRef.current++;
         console.error('[Step5] Poll error:', err);
       }
     }, POLL_INTERVAL);

--- a/homepage/src/pages/SetupWizard.tsx
+++ b/homepage/src/pages/SetupWizard.tsx
@@ -121,6 +121,7 @@ export default function SetupWizard() {
               pollingActive={state.pollingActive}
               detectedModule={state.detectedModule}
               verificationTimedOut={state.verificationTimedOut}
+              verificationBackendUnreachable={state.verificationBackendUnreachable}
               startVerification={startVerification}
               onBack={goBack}
             />


### PR DESCRIPTION
## Summary

PR-B in the open-bug-cleanup campaign — bundles two setup-wizard "silent failure" bugs that share the same shape (a fetch result fed to a side-effecting consumer without validating the response shape, only the status code).

## Closes #43 — wizard reports success without flashing when `firmware.bin` is missing

When `homepage/public/firmware.bin` is missing, Vite's SPA dev fallback returns `index.html` with HTTP 200 + `Content-Type: text/html`. The old `flashEsp` only checked `response.ok`, so the HTML payload was handed to `esptool-js`'s `writeFlash`, which silently no-op'd on garbage bytes. The chip then `hard_reset` into its previous firmware; the user saw the green "Firmware installiert!" banner in <1 s and walked away believing the new firmware was on the chip.

Fix in `homepage/src/components/setup/flashEsp.ts`'s new `assertFirmwareResponse`:

1. Reject responses whose `Content-Type` matches `text/html` (catches the SPA fallback directly).
2. Reject responses whose first byte is not `0xE9` (ESP32 application image magic byte from `esp_image_format.h`'s `ESP_IMAGE_HEADER_MAGIC`). Defence in depth — covers static servers that send `application/octet-stream` for the SPA fallback, and corrupt or truncated downloads.

Both error messages point the user at `make firmware` (new Make target wrapping `ESP32-CAM/build.sh`) so the remediation is one command away. The thrown error propagates to `Step2Flash.tsx`'s existing `progress.state === 'error'` rendering — no new UI strings needed.

## Closes #44 — Step 5 mis-classifies backend-down mid-poll as a timeout

When the backend died during the Step 5 verify poll window (`docker compose stop backend`, OOM, network blip), all 24 polls failed silently into a single `verificationTimedOut` flag. The orange "check the module" troubleshooting screen appeared — pointing the user at completely the wrong remediation; the ESP was fine, the backend was down.

Fix in `homepage/src/components/setup/useSetupWizard.ts`'s `startVerification`:

- Track `consecutivePollErrorsRef` — any 200 OK (even with empty modules) resets it, any rejection or non-2xx increments it.
- When `MAX_POLLS` (24) expires and the trailing run of failures is ≥5 (~25 s of uninterrupted backend silence at the end of the window), set a new `verificationBackendUnreachable` state instead of `verificationTimedOut`.
- `Step5Verify.tsx`'s existing red "Backend Server Not Reachable" branch now also fires on the new prop, gated on `backendReachable !== null` so a remount of Step 5 doesn't flash the red screen before the local healthcheck has fired.

The trailing-only heuristic deliberately treats "backend flapped early but recovered" as a timeout (the backend is reachable now; the user can in fact use the dashboard). The case PR-B fixes is the opposite — backend was up, then died for the final ~25 s.

## What's not in scope

- The `verificationTimedOut` / `verificationBackendUnreachable` pair could be a discriminated union (`verificationOutcome: 'timeout' | 'backend-unreachable' | null`); senior-reviewer P2 architectural smell, deferred to next time someone touches Step 5 state.
- Adding `make firmware` to CLAUDE.md's quick-reference; the troubleshooting page already covers it and that's where the new error message points.

## Verification

- `cd homepage && npm test` — 21/21 pass (9 test files), including:
  - new `homepage/src/__tests__/flashEsp.test.ts` (6 cases for the validator)
  - new `homepage/src/__tests__/useSetupWizard.test.ts` (3 classification cases)
  - 1 new case in the existing `homepage/src/__tests__/Step5Verify.test.tsx` for the unreachable-on-mid-poll branch
- `cd homepage && npm run build` — clean
- `make check-citations` — 35 OK, 0 problems

### Senior-reviewer pass

Reviewer ran on the first three commits and reported 1 P1 + 5 P2s. The fourth commit on this branch addresses the P1 + 4 P2s (test isolation, doc scope, counter cleanup, healthcheck gate). One P2 architectural-smell (discriminated outcome union) deferred per scope.

### Manual verification (sandbox can't run a board / Web Serial)

Reviewer recommended these end-to-end checks before merge:

- [ ] `mv homepage/public/firmware.bin /tmp/` then run the wizard → Step 2 surfaces the new red error pointing at `make firmware`. Restore: `mv /tmp/firmware.bin homepage/public/`.
- [ ] `docker compose up`, open the wizard, get past the Step 5 healthcheck, then `docker compose stop backend`. After the trailing-error window the wizard should land on the **red unreachable** screen with `BACKEND_URL` — not the orange timeout screen.
- [ ] Sanity: `docker compose stop backend` *before* opening the wizard → initial `checkBackendAndStart` shows red unreachable as before (regression check).

## Doc updates (per CLAUDE.md doc-update lookup)

- `docs/troubleshooting.md` — replaced the stale "404 firmware.bin" entry with the silent-success failure mode; added the "backend unreachable mid-poll" entry alongside it.
- `docs/11-risks-and-technical-debt/README.md` — added a joint Lessons-learned entry covering the shared "validate the shape, not just the status" lesson for both bugs.

## Branch model

Branched off `main`. Three commits + one review-response commit:

- `fix(homepage): validate firmware response shape before flashing`
- `fix(homepage): classify backend-down-mid-poll as unreachable, not timeout`
- `chore(make): add firmware target wrapping ESP32-CAM/build.sh`
- `fix(homepage): address senior-reviewer P1 + P2 on PR-B`

Out-of-scope (campaign tracking): #36 (port-mismatch sweep) is on the existing `claude/review-open-bugs-u6gre` branch; PR-A (#39 + #46) is open as #47; PR-C and PR-D are still to come.

---
_Generated by [Claude Code](https://claude.ai/code/session_014SBC9ABsxXUC94UA2BQqWy)_