### PR TITLE
fix(esp): feed TASK_WDT inside postImage read loops (closes #42, #53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,6 @@ homepage/coverage/
 # DuckDB
 *.duckdb
 *.duckdb.wal
+
+# Stray docker-compose / process logs at repo root
+/error.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ How to run it:
 
 ## Open-issue roadmap
 
-Derived from the open issues as of 2026-05-10. Each section below maps to one planned PR. **Delete the section when the PR is opened** — that is the signal that the issues are in review and no longer need to live here. After completion / deletion of the last section, remove this open-issue roadmap section entirely.
+Derived from the open issues as of 2026-05-10. Each section below maps to one planned PR. **Delete the section when the PR is opened** — that is the signal that the issues are in review and no longer need to live here. (PR A — the issue-#42 / #53 WDT fix — was the first to open and was deleted from this section; the list now starts at PR B.) After completion / deletion of the last section, remove this open-issue roadmap section entirely.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,4 +217,6 @@ Do after the WDT fix (closes #42 / #53) and firmware housekeeping (PR D) are mer
 
 ---
 
+## Branch model
+
 See [CONTRIBUTING.md](CONTRIBUTING.md). Quick form: branch off `main` with typed prefix (`feat/`, `fix/`, `docs/`, `refactor/`, `chore/`, `test/`, `ci/`); first commit line `<type>: <imperative summary>` ≤ ~72 chars; PRs require all CI green.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,70 @@ How to run it:
 - Address every P0 before pushing for review. P1s should be fixed or have an explicit "out of scope, tracked in issue #N" justification. P2s are nits and may be deferred.
 - Treat its findings as input, not as a verdict. If it claims something is wrong, verify against the code yourself — but do not dismiss without checking.
 
-## Branch model
+## Open-issue roadmap
+
+Derived from the open issues as of 2026-05-10. Each section below maps to one planned PR. **Delete the section when the PR is opened** — that is the signal that the issues are in review and no longer need to live here. After completion / deletion of the last section, remove this open-issue roadmap section entirely.
+
+---
+
+### PR B — `fix/esp-api-key-hardcoded` (urgent — closes #18)
+
+Google Maps API key is hardcoded in `ESP32-CAM/esp_init.cpp` and already public on GitHub. Revoke the key in Google Cloud Console first (before the PR), then make it configurable.
+
+**Recommended approach:** inject at build time via `platformio.ini` `build_flags` env var (`-DGEO_API_KEY=\"$(GEO_API_KEY)\"`), exclude from version control, document in `docs/08-crosscutting-concepts/auth.md`.
+
+---
+
+### PR C — `fix/service-layer-correctness` (closes #58, #33)
+
+Two independent backend/service correctness gaps — no ESP dependency.
+
+**#58 — `image-service` missing `/record_image` call:**
+
+- Add `_record_image_upload` step to `UploadPipeline.run` in `image-service/services/upload_pipeline.py` that POSTs to duckdb-service's `/record_image` after `_persist_image` succeeds.
+- On failure: log the error (do not swallow silently, per lessons-learned "every cross-service catch block must answer two questions"). The caller still sees a 200 — the image is persisted; the DB row failure is non-fatal but must be observable.
+- Verify: after the fix, a bare `curl -F ... /upload` must produce a visible row in the admin page.
+
+**#33 — Backend tests for destructive admin endpoints:**
+
+- Add supertest cases for `DELETE /api/modules/:id` and `DELETE /api/images/:filename` in `backend/tests/`, mirroring the pattern in `backend/tests/admin-logs.test.ts`.
+- Cover: upstream URL construction, method forwarding, upstream status forwarded verbatim, and the malformed-id 400 path.
+
+---
+
+### PR D — `fix/esp-firmware-housekeeping` (closes #19, #20, #36)
+
+Four surgical ESP32 firmware fixes, all low-risk, no hardware required beyond cross-compile.
+
+- **#20** — Raise default `cfg_interval_ms` from 300 to 60 000 (1 min) in `ESP32-CAM/host.cpp`. Add a comment in the config form describing the battery-life tradeoff.
+- **#19** — `ESP32-CAM/host.cpp`'s `saveConfig` and `ESP32-CAM/esp_init.cpp`'s `loadConfig`: increase `StaticJsonDocument<512>` to `<1024>`. Add a guard that `serializeJson` returns > 0 before calling `setESPConfigured(true)`.
+- **#36 Bug 1** — Capture `fb->len` into a local variable before `esp_camera_fb_return(fb)` in `ESP32-CAM/ESP32-CAM.ino`'s warm-up frame loops (two symmetric blocks). Log the local, not the pointer.
+- **#36 Bug 2** — Wrap incoming `mac` in `ModuleId.model_validate(...).root` before the DB write in `duckdb-service/routes/heartbeats.py`, mirroring `upload_image` in `image-service/app.py`.
+- **#36 Bug 3** — Make `ESP32-CAM/VERSION` the sole firmware-version source via `platformio.ini` build flag (`-DFIRMWARE_VERSION=...`). Remove the `#define` guards in `esp_init.h` and `client.cpp`. `build.sh` continues to read `VERSION` directly.
+
+If Bug 3 proves fiddly (cross-file coordination across `platformio.ini`, `esp_init.h`, `client.cpp`, `build.sh`), split it into its own PR rather than blocking the other three.
+
+---
+
+### PR E — `fix/captive-portal-debt` (closes #56, #57)
+
+Two follow-ups from PR #47's captive-portal work. No new behaviour — UX clarification and test coverage only.
+
+**#56** — Replace the misleading GPIO0 reconfigure hint in `ESP32-CAM/ESP32-CAM.ino`'s `setup()` with text that advertises the auto-fallback trigger ("change WiFi credentials so the device fails to join — it will auto-fall-back to the captive portal after 3 attempts"). Update `docs/11-risks-and-technical-debt/README.md` lessons-learned entry.
+
+**#57** — Extract `resolveKeepCurrentField(submitted, current)` helper into `ESP32-CAM/lib/form_query/` (already host-testable). `runAccessPoint` calls it for the password field. Add 4 Unity tests in `test/test_native_form_query/`: empty submitted → returns current; whitespace-only → returns current; non-empty → returns trimmed submitted; both empty → returns empty.
+
+---
+
+### PR F — `feat/esp-ota` (later — closes #26)
+
+OTA firmware update support. Requires a one-time breaking partition table change (USB flash required to get the first OTA-capable binary onto hardware). Do after the WDT fix (PR A) and firmware housekeeping (PR D) to ensure a stable baseline.
+
+**Phase 1:** ArduinoOTA — update partition table to "Minimal SPIFFS with OTA", add `ArduinoOTA.begin()` in `setup()` and `ArduinoOTA.handle()` in the main loop. LAN-only.
+**Phase 2:** HTTP OTA — periodic version-check + self-update from a hosted `.bin` (e.g. GitHub Release asset). Enables remote updates without LAN access.
+
+Do after the WDT fix (closes #42/#53) and firmware housekeeping (PR D) are merged, to ensure a stable firmware baseline.
+
+---
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Quick form: branch off `main` with typed prefix (`feat/`, `fix/`, `docs/`, `refactor/`, `chore/`, `test/`, `ci/`); first commit line `<type>: <imperative summary>` ≤ ~72 chars; PRs require all CI green.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,12 +208,12 @@ Two follow-ups from PR #47's captive-portal work. No new behaviour — UX clarif
 
 ### PR F — `feat/esp-ota` (later — closes #26)
 
-OTA firmware update support. Requires a one-time breaking partition table change (USB flash required to get the first OTA-capable binary onto hardware). Do after the WDT fix (PR A) and firmware housekeeping (PR D) to ensure a stable baseline.
+OTA firmware update support. Requires a one-time breaking partition table change (USB flash required to get the first OTA-capable binary onto hardware).
 
 **Phase 1:** ArduinoOTA — update partition table to "Minimal SPIFFS with OTA", add `ArduinoOTA.begin()` in `setup()` and `ArduinoOTA.handle()` in the main loop. LAN-only.
 **Phase 2:** HTTP OTA — periodic version-check + self-update from a hosted `.bin` (e.g. GitHub Release asset). Enables remote updates without LAN access.
 
-Do after the WDT fix (closes #42/#53) and firmware housekeeping (PR D) are merged, to ensure a stable firmware baseline.
+Do after the WDT fix (closes #42 / #53) and firmware housekeeping (PR D) are merged, to ensure a stable firmware baseline.
 
 ---
 

--- a/ESP32-CAM/client.cpp
+++ b/ESP32-CAM/client.cpp
@@ -206,6 +206,7 @@ int postImage(esp_config_t *esp_config) {
   while (client.connected()) {
     String line = client.readStringUntil('\n');
     if (line == "\r" || line.length() == 0) break;
+    esp_task_wdt_reset();
   }
 
   hf::breadcrumbSet("postImage:read_body");
@@ -216,8 +217,11 @@ int postImage(esp_config_t *esp_config) {
       char c = client.read();
       response += c;
       start = millis();
+      esp_task_wdt_reset();
     } else if (millis() - start > 5000) {
       break;
+    } else {
+      delay(1);
     }
   }
 

--- a/docs/06-runtime-view/esp-reliability.md
+++ b/docs/06-runtime-view/esp-reliability.md
@@ -209,12 +209,13 @@ even so, multi-month deployment with continuous writes adds up enough to
 make the wear-out boundary an unbounded design question. RTC slow memory
 is RAM, not flash — zero wear cost, side-steps the question entirely.
 
-This is a diagnostic mechanism for issue #42 (recurring `reset_reason=7`
-in normal STA-mode operation). Once the offending blocking call is
-identified from a few days of field telemetry, a follow-up PR will add
-a targeted `setTimeout()` and/or `esp_task_wdt_reset()` at that site
-and the breadcrumb will revert to its dormant role of catching future
-regressions.
+This mechanism was used to diagnose issue #42 (recurring `reset_reason=7`
+in normal STA-mode operation). Hardware testing reproduced the WDT
+consistently; recovery boots consistently showed breadcrumb `postImage:read_body`.
+The fix (`esp_task_wdt_reset()` inside the header-read loop and the
+body-read loop in `client.cpp`'s `postImage`) landed in the same PR that
+ships this file. The breadcrumb library remains in place as general-purpose
+diagnostic infrastructure for future regressions.
 
 ### LED legend
 

--- a/docs/06-runtime-view/esp-reliability.md
+++ b/docs/06-runtime-view/esp-reliability.md
@@ -212,9 +212,11 @@ is RAM, not flash — zero wear cost, side-steps the question entirely.
 This mechanism was used to diagnose issue #42 (recurring `reset_reason=7`
 in normal STA-mode operation). Hardware testing reproduced the WDT
 consistently; recovery boots consistently showed breadcrumb `postImage:read_body`.
-The fix added `esp_task_wdt_reset()` inside the header-read loop and the
-body-read loop in `client.cpp`'s `postImage`. The breadcrumb library
-remains in place as general-purpose diagnostic infrastructure for future
+The fix added `esp_task_wdt_reset()` inside the header-read loop and
+inside the `if (client.available())` branch of the body-read polling
+loop in `client.cpp`'s `postImage` (plus `delay(1)` in the same loop's
+else branch to stop the polling spin). The breadcrumb library remains
+in place as general-purpose diagnostic infrastructure for future
 regressions.
 
 ### LED legend

--- a/docs/06-runtime-view/esp-reliability.md
+++ b/docs/06-runtime-view/esp-reliability.md
@@ -212,10 +212,10 @@ is RAM, not flash — zero wear cost, side-steps the question entirely.
 This mechanism was used to diagnose issue #42 (recurring `reset_reason=7`
 in normal STA-mode operation). Hardware testing reproduced the WDT
 consistently; recovery boots consistently showed breadcrumb `postImage:read_body`.
-The fix (`esp_task_wdt_reset()` inside the header-read loop and the
-body-read loop in `client.cpp`'s `postImage`) landed in the same PR that
-ships this file. The breadcrumb library remains in place as general-purpose
-diagnostic infrastructure for future regressions.
+The fix added `esp_task_wdt_reset()` inside the header-read loop and the
+body-read loop in `client.cpp`'s `postImage`. The breadcrumb library
+remains in place as general-purpose diagnostic infrastructure for future
+regressions.
 
 ### LED legend
 

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -746,3 +746,40 @@ an `esp_task_wdt_reset()` call if the loop can iterate for more than a few
 seconds. The write-body loop in `client.cpp`'s `postImage` is the reference
 model — feed the watchdog on each chunk write; follow the same pattern for
 each chunk (or byte) read.
+
+### Hardware-test misdiagnosis: assumed cadence without reading the constant (PR for #42)
+
+**What happened.** During hardware verification of the WDT-feed fix above,
+docker logs showed exactly one heartbeat from the module after first boot,
+then silence for 8+ minutes. A "silent hang in `sendHeartbeat`" hypothesis
+was built on top of that observation: a follow-up issue was filed (#59,
+since closed), Serial-debug instrumentation was added on a debug branch,
+and a fresh diagnostic cycle was walked through. The instrumentation
+immediately showed the loop iterating cleanly every 30 s, with the line
+`[DBG] iter=2 heartbeat skipped (interval not reached)`. The "missing"
+heartbeats were not missing — `ESP32-CAM/ESP32-CAM.ino`'s
+`HEARTBEAT_INTERVAL_MS` is `(60UL * 60UL * 1000UL)`, **one hour**, not the
+30 s loop-tick cadence assumed during the diagnosis. There was no hang;
+the WDT fix was working as designed all along.
+
+**Why it happened.** The Docker log shape ("one heartbeat then silence")
+was equally consistent with two explanations: (a) a real hang, and (b) a
+1-hour heartbeat interval. The reviewer picked (a) because the active
+investigation context was about hangs, and never grep'd for the cadence
+constant to disambiguate. The matching error log
+(`WiFiClient.cpp setSocketOption() fail on -1, errno: 9`) on every connect
+reinforced the wrong hypothesis by looking causal when it was incidental.
+Costs: one fork-the-fork branch, ~20 lines of instrumentation, a noise PR
+filed on the upstream issue tracker, and a contributor's evening.
+
+**How to avoid it next time.** Before building a theory on top of
+"behaviour X happens with cadence Y," `git grep` for the constant that
+defines Y and confirm the value. For HiveHive specifically: any timing-
+related claim about ESP firmware behaviour (heartbeat cadence, capture
+schedule, retry backoff, sleep length) must be backed by reading the
+relevant `#define` or constant in `ESP32-CAM/`. Same rule applies to
+backend polling intervals (`backend/src/`) and silence-watcher thresholds
+(`duckdb-service/`). Generalisation: the "Documentation drifted from code"
+lesson 100+ lines above is about not assuming a documented value matches
+code; this is the runtime sibling — don't assume an observed cadence
+matches the model in your head. Read the constant.

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -747,20 +747,21 @@ seconds. The write-body loop in `client.cpp`'s `postImage` is the reference
 model — feed the watchdog on each chunk write; follow the same pattern for
 each chunk (or byte) read.
 
-### Hardware-test misdiagnosis: assumed cadence without reading the constant (PR for #42)
+### Hardware-test misdiagnosis: assumed cadence without reading the constant (PR for [#42](https://github.com/schutera/highfive/issues/42))
 
 **What happened.** During hardware verification of the WDT-feed fix above,
 docker logs showed exactly one heartbeat from the module after first boot,
 then silence for 8+ minutes. A "silent hang in `sendHeartbeat`" hypothesis
-was built on top of that observation: a follow-up issue was filed (#59,
-since closed), Serial-debug instrumentation was added on a debug branch,
-and a fresh diagnostic cycle was walked through. The instrumentation
-immediately showed the loop iterating cleanly every 30 s, with the line
-`[DBG] iter=2 heartbeat skipped (interval not reached)`. The "missing"
-heartbeats were not missing — `ESP32-CAM/ESP32-CAM.ino`'s
-`HEARTBEAT_INTERVAL_MS` is `(60UL * 60UL * 1000UL)`, **one hour**, not the
-30 s loop-tick cadence assumed during the diagnosis. There was no hang;
-the WDT fix was working as designed all along.
+was built on top of that observation: a follow-up issue was filed
+([#59](https://github.com/schutera/highfive/issues/59), since closed),
+Serial-debug instrumentation was added on a debug branch, and a fresh
+diagnostic cycle was walked through. The instrumentation immediately showed
+the loop iterating cleanly every 30 s, with the line `[DBG] iter=2
+heartbeat skipped (interval not reached)`. The "missing" heartbeats were
+not missing — `ESP32-CAM/ESP32-CAM.ino`'s `HEARTBEAT_INTERVAL_MS` is
+`(60UL * 60UL * 1000UL)`, **one hour**, not the 30 s loop-tick cadence
+assumed during the diagnosis. There was no hang; the WDT fix was working
+as designed all along.
 
 **Why it happened.** The Docker log shape ("one heartbeat then silence")
 was equally consistent with two explanations: (a) a real hang, and (b) a
@@ -768,9 +769,17 @@ was equally consistent with two explanations: (a) a real hang, and (b) a
 investigation context was about hangs, and never grep'd for the cadence
 constant to disambiguate. The matching error log
 (`WiFiClient.cpp setSocketOption() fail on -1, errno: 9`) on every connect
-reinforced the wrong hypothesis by looking causal when it was incidental.
-Costs: one fork-the-fork branch, ~20 lines of instrumentation, a noise PR
-filed on the upstream issue tracker, and a contributor's evening.
+looked causal to the silence-hypothesis when it was incidental to it — the
+errno-9 is a real, separate socket-state issue (see the WDT-feed lesson
+directly above), but it does not cause a hang; the connect succeeds and
+the upload completes. Costs of the misdiagnosis: one fork-the-fork branch,
+~20 lines of instrumentation, a noise PR filed on the upstream issue
+tracker, and a contributor's evening. A second, related test-completeness
+miss landed in the same session: the 3 loop iterations observed only
+exercised `postImage` once (per `firstCaptureDone` plus daily-noon-only
+recapture), so the trickle-data scenario the WDT fix targets was not
+artificially re-induced — the verification proves the fix doesn't regress
+the happy path, not that it cures the original failure mode under load.
 
 **How to avoid it next time.** Before building a theory on top of
 "behaviour X happens with cadence Y," `git grep` for the constant that
@@ -779,7 +788,11 @@ related claim about ESP firmware behaviour (heartbeat cadence, capture
 schedule, retry backoff, sleep length) must be backed by reading the
 relevant `#define` or constant in `ESP32-CAM/`. Same rule applies to
 backend polling intervals (`backend/src/`) and silence-watcher thresholds
-(`duckdb-service/`). Generalisation: the "Documentation drifted from code"
-lesson 100+ lines above is about not assuming a documented value matches
-code; this is the runtime sibling — don't assume an observed cadence
-matches the model in your head. Read the constant.
+(`duckdb-service/`). Generalisation: the
+`Documentation drifted from code in PR 27 first-pass review` lesson above
+is about not assuming a documented value matches code; this is the runtime
+sibling — don't assume an observed cadence matches the model in your head.
+Read the constant. For verification: when a hardware test is meant to
+exercise a specific failure mode, confirm the test path actually reaches
+that mode (e.g. by injecting the failure on the server side) rather than
+asserting "no regression on the happy path" and calling the fix verified.

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -731,8 +731,8 @@ silence exit from ever triggering. The loop can run for >60 s with no
 Note: every boot also logged `WiFiClient.cpp setSocketOption() fail on -1,
 errno: 9, "Bad file number"`, indicating the socket is in an error state
 across reconnects. The WDT-feed fix stops the reboot symptom; the
-underlying socket-state corruption is a separate issue not yet addressed
-and should be tracked in a follow-up.
+underlying socket-state corruption is tracked separately at
+[issue #60](https://github.com/schutera/highfive/issues/60).
 
 **Why it happened.** The write-body loop in the same function already had
 `esp_task_wdt_reset()` inside it (added for the same reason in an earlier
@@ -745,9 +745,12 @@ the trickle-data scenario surfaced on real hardware.
 an `esp_task_wdt_reset()` call if the loop can iterate for more than a few
 seconds. The write-body loop in `client.cpp`'s `postImage` is the reference
 model — feed the watchdog on each chunk write; follow the same pattern for
-each chunk (or byte) read.
+each chunk (or byte) read. The same fix also added `delay(1)` in the
+body-read polling loop's else branch to stop the loop from CPU-spinning
+between byte arrivals — `delay(1)` is the Arduino-on-ESP32 way to yield
+to other FreeRTOS tasks while waiting on a non-blocking poll.
 
-### Hardware-test misdiagnosis: assumed cadence without reading the constant (PR for [#42](https://github.com/schutera/highfive/issues/42))
+### Hardware-test misdiagnosis: assumed cadence without reading the constant (issue #42)
 
 **What happened.** During hardware verification of the WDT-feed fix above,
 docker logs showed exactly one heartbeat from the module after first boot,
@@ -777,7 +780,10 @@ the upload completes. Costs of the misdiagnosis: one fork-the-fork branch,
 tracker, and a contributor's evening. A second, related test-completeness
 miss landed in the same session: the 3 loop iterations observed only
 exercised `postImage` once (per `firstCaptureDone` plus daily-noon-only
-recapture), so the trickle-data scenario the WDT fix targets was not
+recapture) and `sendHeartbeat` once (per `HEARTBEAT_INTERVAL_MS = 1 hour`
+gating it on iteration 2 and 3). The 90 s test window was therefore
+mostly the no-network-call branch of `loop()` running and `delay(30000)`
+returning. The trickle-data scenario the WDT fix targets was not
 artificially re-induced — the verification proves the fix doesn't regress
 the happy path, not that it cures the original failure mode under load.
 

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -745,10 +745,14 @@ the trickle-data scenario surfaced on real hardware.
 an `esp_task_wdt_reset()` call if the loop can iterate for more than a few
 seconds. The write-body loop in `client.cpp`'s `postImage` is the reference
 model — feed the watchdog on each chunk write; follow the same pattern for
-each chunk (or byte) read. The same fix also added `delay(1)` in the
-body-read polling loop's else branch to stop the loop from CPU-spinning
-between byte arrivals — `delay(1)` is the Arduino-on-ESP32 way to yield
-to other FreeRTOS tasks while waiting on a non-blocking poll.
+each chunk (or byte) read. Pair the feed with `client.setTimeout(N)` where
+`N < TASK_WDT_TIMEOUT_S` so a single blocking read can't itself exhaust the
+budget (the existing `setTimeout(8000)` at `postImage`'s static-init block
+already does this — it is the other half of the same defence). The same
+fix also added `delay(1)` in the body-read polling loop's else branch to
+stop the loop from CPU-spinning between byte arrivals — `delay(1)` is the
+Arduino-on-ESP32 way to yield to other FreeRTOS tasks while waiting on a
+non-blocking poll.
 
 ### Hardware-test misdiagnosis: assumed cadence without reading the constant (issue #42)
 
@@ -779,9 +783,10 @@ the upload completes. Costs of the misdiagnosis: one fork-the-fork branch,
 ~20 lines of instrumentation, a noise PR filed on the upstream issue
 tracker, and a contributor's evening. A second, related test-completeness
 miss landed in the same session: the 3 loop iterations observed only
-exercised `postImage` once (per `firstCaptureDone` plus daily-noon-only
-recapture) and `sendHeartbeat` once (per `HEARTBEAT_INTERVAL_MS = 1 hour`
-gating it on iteration 2 and 3). The 90 s test window was therefore
+exercised `postImage` once (the `firstCaptureDone` flag prevents another
+non-noon recapture, and the test wasn't at noon so the noon path didn't
+fire either) and `sendHeartbeat` once (the one-hour interval kept iter 2
+and 3 in the skip-heartbeat branch). The 90 s test window was therefore
 mostly the no-network-call branch of `loop()` running and `delay(30000)`
 returning. The trickle-data scenario the WDT fix targets was not
 artificially re-induced — the verification proves the fix doesn't regress

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -16,76 +16,8 @@ Highlights worth knowing about even if you're not assigned:
 | [#19](https://github.com/schutera/highfive/issues/19) | `StaticJsonDocument` size in ESP firmware                                    | Risk of silent truncation on telemetry growth.                                                                                                                                              |
 | [#20](https://github.com/schutera/highfive/issues/20) | Capture interval is hardcoded                                                | Should be configurable via the AP form.                                                                                                                                                     |
 | [#26](https://github.com/schutera/highfive/issues/26) | OTA firmware update support                                                  | Today every firmware update requires physical USB. Tracked as a feature request with a recommended ArduinoOTA-first phasing.                                                                |
-| [#42](https://github.com/schutera/highfive/issues/42) | Recurring task-watchdog reboots (`reset_reason=7`)                           | ESP reboots every other boot under STA mode. Telemetry-first instrumentation landed (RTC_NOINIT stage breadcrumb) — see "Active investigation" below; surgical fix waits on a few days of field data identifying the culprit. |
 | [#56](https://github.com/schutera/highfive/issues/56) | GPIO0 reconfigure trigger lands in DOWNLOAD_BOOT (and corrupts flash)        | Documented user path drops the chip into ROM bootloader; finger-roll variant reproduces a flash-read-err loop requiring re-flash. WiFi-fail auto-fallback is the working trigger today.     |
 | [#57](https://github.com/schutera/highfive/issues/57) | Extract captive-portal `/save` logic into a host-testable helper             | The keep-current-on-empty contract has three layers (HTML attr, JS validator, server check); the server half is currently un-unit-testable. Land before adding a second keep-current field. |
-
-## Active investigation: #42 task-watchdog reboots
-
-**Symptom**: every other boot on AI Thinker ESP32-CAM-MB reports
-`reset_reason=7` (TASK_WDT) in normal STA-mode operation; reproducible
-immediately after `pio run -t erase && pio run -t upload`. Suspects
-per the issue: `getGeolocation` (Google Geolocation API), `initNewModuleOnServer`
-(duckdb-service `/new_module`), `postImage`'s body-read loop, or
-`sendHeartbeat`. None of the four currently calls `esp_task_wdt_reset()`
-mid-call, and the first two use the legacy `HTTPClient` `begin/POST/getString`
-pattern with no explicit `setTimeout()`.
-
-**Why this lives in "Active investigation" rather than "Lessons learned"**:
-the lesson hasn't been earned yet — we don't know what's hanging, only
-that something is. The lesson registers the **diagnosis approach** to
-prove out, not the root cause, which is still unknown by design.
-
-**What the telemetry-first PR shipped** (branch
-`feat/esp-wdt-stage-breadcrumb`, commit message
-`feat(esp): add RTC_NOINIT stage-breadcrumb library + native tests`):
-
-- New library `ESP32-CAM/lib/breadcrumb/` — a 64-byte stage name in
-  RTC slow memory via `RTC_NOINIT_ATTR`. RTC slow memory survives
-  software resets (TASK_WDT, panic, `ESP.restart()`) but is wiped on
-  power-on. NVS would have served the same shape but the loop()-side
-  breadcrumbs update every ~30 s; even with NVS wear-levelling, that
-  rate makes the wear-out boundary an unbounded design question for
-  multi-month deployment. RTC slow memory is RAM, not flash — zero
-  wear cost, side-steps the question entirely.
-- Each long-running call in `setup()` / `loop()` / `client.cpp` /
-  `esp_init.cpp` (network I/O, NTP poll, SPIFFS `loadConfig`, camera
-  init) calls `breadcrumbSet("section:name")` on entry. Single slot,
-  last writer wins.
-- On boot, `setup()` reads + clears the slot **first** (before any
-  in-boot `breadcrumbSet` could clobber it) and buffers the recovered
-  value. After `logbufInit()` runs, the value is logged via
-  `logf("[BOOT] last_stage_before_reboot=%s")` and attached to every
-  subsequent telemetry sidecar JSON via the new optional
-  `last_stage_before_reboot` field on the inner `payload`. The admin
-  Telemetry view (`TelemetryRow` in
-  `homepage/src/components/ModulePanel.tsx`) renders it as a "stage at
-  previous reboot" row next to the existing `reset` row when present.
-- The sidecar field is **omitted** when no breadcrumb survived, keeping
-  the pre-#42 wire shape byte-for-byte intact for clean boots.
-
-Mechanism documented in
-[`docs/06-runtime-view/esp-reliability.md`](../06-runtime-view/esp-reliability.md#8-stage-breadcrumb-cross-reboot-diagnostic)
-"safety net 8".
-
-**What the follow-up PR will do** (after a few days of field data):
-
-- Identify the offending stage from the trended `last_stage_before_reboot`
-  values across the fleet.
-- At that exact section, add a targeted `esp_task_wdt_reset()` and/or
-  explicit `setTimeout()` so the call can't block past the 60 s budget
-  undetected.
-- Keep the breadcrumb library in place — it's general-purpose
-  diagnostic infrastructure now, not single-issue scaffolding.
-- Close #42 when the fix is verified by a deployment cycle showing
-  `reset_reason=7` no longer fires in normal operation.
-
-**Why a CI gate isn't the right shape here**: the bug is observable
-only on real hardware in real network conditions (slow Google response,
-concurrent WiFi traffic). A unit test of the breadcrumb library alone
-doesn't catch a regression of the actual hang. The native tests in
-`test_native_breadcrumb/` cover the library's invariants; the field
-verification cycle proves the diagnostic + fix.
 
 ## Field-name drift
 
@@ -782,3 +714,35 @@ discipline, and realistic component-test fixtures. The rules earned
 their own slot in the project orientation rather than living only as
 post-mortem prose so the next contributor sees them before writing
 the bug, not after.
+
+### TASK_WDT in `postImage:read_body` — WiFiClient read loops must feed the watchdog (issues #42, #53)
+
+**What happened.** The ESP32 rebooted via TASK_WDT on every other boot
+during normal STA-mode operation (`reset_reason=7`). The stage-breadcrumb
+library in `ESP32-CAM/lib/breadcrumb/` (RTC slow memory, survives software
+resets) identified `postImage:read_body` as the stage consistently active
+when the watchdog fired. The response-body reading loop in `client.cpp`'s
+`postImage` uses `WiFiClient.read()` in a polling loop with a 5-second
+silence-based exit (`millis() - start > 5000`). When the server sends
+trickle data, each received byte resets `start = millis()`, preventing the
+silence exit from ever triggering. The loop can run for >60 s with no
+`esp_task_wdt_reset()` call — the WDT fires.
+
+Note: every boot also logged `WiFiClient.cpp setSocketOption() fail on -1,
+errno: 9, "Bad file number"`, indicating the socket is in an error state
+across reconnects. The WDT-feed fix stops the reboot symptom; the
+underlying socket-state corruption is a separate issue not yet addressed
+and should be tracked in a follow-up.
+
+**Why it happened.** The write-body loop in the same function already had
+`esp_task_wdt_reset()` inside it (added for the same reason in an earlier
+PR) but the two read loops (headers and body) were never given the same
+treatment. The write → feed / read → no-feed asymmetry was invisible until
+the trickle-data scenario surfaced on real hardware.
+
+**How to avoid it next time.** Any loop that calls blocking or polling
+`WiFiClient` methods (`readStringUntil`, `readBytes`, `read`) must contain
+an `esp_task_wdt_reset()` call if the loop can iterate for more than a few
+seconds. The write-body loop in `client.cpp`'s `postImage` is the reference
+model — feed the watchdog on each chunk write; follow the same pattern for
+each chunk (or byte) read.


### PR DESCRIPTION
## Summary

- Adds `esp_task_wdt_reset()` inside the header-read `while` loop and the body-read `if (client.available())` branch in `ESP32-CAM/client.cpp`'s `postImage`. Closes #42 (recurring `reset_reason=7`) and #53 (the surgical-fix follow-up).
- Adds `delay(1)` in the body-read else branch to stop the polling spin while waiting for the next byte.
- Bundles the stage-breadcrumb diagnostic infrastructure (RTC slow memory survives software resets) that pinpointed `postImage:read_body` as the offending stage during hardware testing.
- Chapter-11 lessons-learned: WDT-feed asymmetry, plus a hardware-test misdiagnosis lesson (assumed 30 s heartbeat cadence without reading the constant — actually 1 hour).

## Test plan

- [x] `pio run -e esp32cam` — clean compile
- [x] Hardware verified on AI Thinker ESP32-CAM-MB (COM9): boot, first heartbeat + first capture succeed, loop iterates every 30 s, `reset_reason=7` no longer observed, no panics
- [x] `make check-citations` — 26 OK, 0 problems
- [x] Four rounds of `senior-reviewer` feedback addressed (P1 + P2 each round)
- [x] Test-completeness caveat: the 3-iteration verification only exercised `postImage` once and `sendHeartbeat` once — see chapter-11 lesson for the test-completeness limitation

## Related

- Issue #60 — follow-up: `WiFiClient.cpp setSocketOption(): fail on -1, errno: 9, "Bad file number"` on every connect. Underlying socket-state issue surfaced during the hardware test; this PR does not address it.
- Issue #59 — closed as not-planned (was a misdiagnosis during hardware testing; lesson captured in chapter 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
