### PR TITLE
fix(esp): close #15 — boot-time heartbeat for post-reflash dashboard refresh

### DIFF
--- a/ESP32-CAM/ESP32-CAM.ino
+++ b/ESP32-CAM/ESP32-CAM.ino
@@ -206,6 +206,20 @@ void setup() {
   initNewModuleOnServer(&esp_config);
   logf("[STAGE] initNewModuleOnServer took=%lums", millis() - stageStartMs);
 
+  // Boot-time heartbeat (#15): plant freshness signal before slow
+  // camera init so the dashboard reflects the post-reflash / daily-
+  // reboot live state in seconds, not after the full setup pipeline.
+  // Gate `lastHeartbeatMs` stamping on success so a failed boot POST
+  // falls through to the loop's `lastHeartbeatMs == 0` retry branch.
+  // `sendHeartbeat` fails quiet — chapter-11 "Post-reflash dashboard
+  // latency" carries the full rationale.
+  hf::breadcrumbSet("setup:sendHeartbeat:boot");
+  stageStartMs = millis();
+  if (sendHeartbeat(&esp_config) == 0) {
+    lastHeartbeatMs = millis();
+  }
+  logf("[STAGE] sendHeartbeat:boot took=%lums", millis() - stageStartMs);
+
   /*
     Camera init AFTER all WiFi/network operations to avoid DMA conflicts
   */
@@ -402,8 +416,14 @@ void loop() {
     ESP.restart();
   }
 
-  // Hourly heartbeat so the dashboard knows the module is alive between
-  // images. Tiny payload, no camera work, fails-quiet — never restarts.
+  // Hourly telemetry heartbeat so the dashboard's lastSeenAt stays
+  // fresh between captures. Tiny payload, no camera work, fails-quiet
+  // — never restarts. The setup-time boot heartbeat (#15) primes
+  // `lastHeartbeatMs` before this branch is ever reached, so the
+  // `lastHeartbeatMs == 0` short-circuit below is now a defence-in-depth
+  // path for the case where the boot heartbeat's POST failed — the
+  // first loop iteration still gets a chance to plant the freshness
+  // signal in `module_heartbeats`.
   if (millis() - lastHeartbeatMs > HEARTBEAT_INTERVAL_MS || lastHeartbeatMs == 0) {
     hf::breadcrumbSet("loop:sendHeartbeat");
     sendHeartbeat(&esp_config);

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -232,10 +232,16 @@ export class ModuleReadModel {
       // misleading the user with red 'offline'.
       //
       // Note: an earlier draft gated this on `!m.updated_at`, but
-      // `updated_at` is set permanently at module registration and never
-      // refreshes — so the 'unknown' branch was unreachable for the
+      // `updated_at` refreshes on every module-registration call via
+      // the `ON CONFLICT (id) DO UPDATE SET ... updated_at = NOW()`
+      // branch in `duckdb-service/routes/modules.py`'s `add_module`,
+      // which firmware fires unconditionally in setup() on every
+      // boot. So a `!m.updated_at` guard was unreachable for the
       // exact population the fix was for. Switched to gating on the
-      // would-be-offline outcome itself.
+      // would-be-offline outcome itself. (The first draft of this
+      // comment said `updated_at` "never refreshes" — corrected by
+      // the #15 fix's senior-review against the DDL. See chapter-11
+      // "Post-reflash dashboard latency" for the full incident.)
       let status: 'online' | 'offline' | 'unknown';
       if (isOnline) {
         status = 'online';

--- a/docs/06-runtime-view/image-upload-flow.md
+++ b/docs/06-runtime-view/image-upload-flow.md
@@ -111,7 +111,14 @@ sequenceDiagram
    surfaced on `Module.latestHeartbeat`
    ([ADR-004](../09-architecture-decisions/adr-004-heartbeat-snapshot-in-contracts.md)).
    This path does not run on every upload and is not gated by image
-   uploads succeeding.
+   uploads succeeding. A **boot-time heartbeat** also fires from
+   `ESP32-CAM/ESP32-CAM.ino`'s `setup` immediately after
+   `initNewModuleOnServer` returns (fail-quiet — fires regardless of
+   the registration call's outcome, defence-in-depth for the case
+   where registration's HTTP POST failed), before the slow camera
+   init — the #15 fix that lets the dashboard reflect a reflashed or
+   daily-rebooted module within seconds rather than after the next
+   capture.
 
 ## Persistence invariant
 

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -1104,3 +1104,119 @@ site — tracked at follow-up
 [#66](https://github.com/schutera/highfive/issues/66) alongside the
 dead-weight discovery [#65](https://github.com/schutera/highfive/issues/65)
 above.
+
+### Post-reflash dashboard latency: status is derived, not stored (#15)
+
+**What happened.** After flashing a new firmware build onto a
+module via USB, the dashboard kept showing the module as 'offline'
+for 30–90 seconds after the flash completed and the device was
+clearly alive (Serial monitor showed `[BOOT]`, WiFi connected, the
+operator could see network traffic). The status only flipped to
+'online' once the first daily capture fired its post-upload
+aggregate heartbeat. For a once-on-boot + daily-noon capture
+cadence, that meant operators stared at a stale 'offline' badge
+through most of the reflash workflow.
+
+**Why it happened — and where the narrative had to be corrected.**
+The dashboard's `Module.status` is **derived** server-side in
+`backend/src/database.ts`'s `fetchAndAssemble` from the freshest
+of three timestamps — `image_uploads.uploaded_at`,
+`module_configs.updated_at`, and the latest
+`module_heartbeats.received_at` — with a 2 h window.
+`module_configs.status` itself, despite the believable name, is
+never read by the dashboard (separate dead-weight issue tracked
+at [#69](https://github.com/schutera/highfive/issues/69)).
+
+The senior-reviewer of this PR caught a load-bearing factual
+error in the first draft of this entry **and** in the in-source
+comment at `backend/src/database.ts`'s `fetchAndAssemble` (the
+"earlier draft gated `'unknown'` on `!m.updated_at`" note): both
+asserted that `updated_at` "never refreshes after registration."
+That is false. `duckdb-service/routes/modules.py`'s `add_module`
+contains an `ON CONFLICT (id) DO UPDATE SET ... status =
+EXCLUDED.status, ... updated_at = NOW()` branch that fires on
+every call. Firmware calls `initNewModuleOnServer` unconditionally
+in `setup()` on every boot, so both `status` and `updated_at` are
+rewritten on every reflash and every daily reboot. That UPSERT
+plants a freshness signal in `module_configs.updated_at` long
+before the boot heartbeat fires, and the dashboard's `lastSeenAt`
+candidate set picks it up.
+
+So why is the boot heartbeat still warranted? **Three reasons,
+none of them about `lastSeenAt` freshness:**
+
+1. **Defense-in-depth for the registration POST failing.** The
+   `initNewModuleOnServer` HTTP call can fail (network race,
+   server transient unavailability). If registration fails AND
+   we wait for the loop's first-iteration heartbeat, the
+   dashboard sees a stale `updated_at` for the full setup
+   pipeline duration (30+ s). The boot heartbeat plants a
+   second, independent freshness signal in `module_heartbeats`
+   so the dashboard recovers even if registration didn't.
+2. **Fresh telemetry for the panel that the UPSERT doesn't
+   reach.** Heartbeat rows carry `battery`, `rssi`, `uptime_ms`,
+   `free_heap`, and `fw_version` — and surface as
+   `Module.latestHeartbeat` (per ADR-004), which the
+   `/heartbeats_summary` query reads strictly from
+   `module_heartbeats`, never from `module_configs`. The
+   registration UPSERT _does_ write `module_configs.battery_level`
+   on every boot, but that column feeds a different DTO field;
+   the telemetry panel itself doesn't read it. So `rssi`,
+   `uptime_ms`, `free_heap`, and `fw_version` are not written
+   anywhere on the boot path at all, and `battery` on the panel
+   would still show the pre-reflash heartbeat value until the
+   hourly cadence ticks. The boot heartbeat refreshes the panel
+   within seconds. (The first draft of this bullet said "none of
+   which the UPSERT refreshes" — that was wrong about
+   `battery_level`; corrected here against the DDL.)
+3. **The hourly cadence isn't aware of boots.** `lastHeartbeatMs
+== 0` short-circuits the first iteration, but that iteration
+   runs after the full setup pipeline — WiFi + geolocation +
+   registration + camera init + 3-frame warm-up + NTP sync,
+   consistently 30+ s and sometimes more on real hardware. The
+   boot heartbeat closes that window for the telemetry panel,
+   even though the status badge was already covered by the
+   registration UPSERT.
+
+**How to avoid it next time.** Two complementary rules:
+
+1. **Plant freshness signals early — including ones the next
+   table over already provides.** When two write paths
+   contribute to the same derived field (here `lastSeenAt`),
+   firing both early is cheap belt-and-braces. The #15 fix
+   inserts a `sendHeartbeat(&esp_config)` call immediately after
+   `initNewModuleOnServer()` returns, before the slow camera
+   init begins, so the boot signal is independent of the
+   registration POST succeeding **and** carries fresh telemetry
+   that the registration UPSERT doesn't. Same fix serves the
+   ADR-007 daily-reboot path with no extra code. The general
+   rule: when verifying a state-derivation bug, enumerate every
+   write path that contributes to the derived field and confirm
+   each one's behaviour from the actual DDL, not from comments.
+   The first draft of this entry shipped a "`updated_at` never
+   refreshes" claim that the `ON CONFLICT` UPSERT directly
+   contradicts.
+2. **Stored-vs-derived state needs a named owner.** The
+   `module_configs.status` column is currently dead weight — it
+   exists, it has a CHECK constraint (`'online' | 'offline'`),
+   it is written once, it is never read by the dashboard. Either
+   make it the authoritative source (with a writer at every
+   liveness-event seam) or remove it from the schema. Leaving it
+   in place encourages the next contributor to "update status"
+   in some new code path and discover only at integration time
+   that the dashboard ignores their writes. Tracked at
+   [#69](https://github.com/schutera/highfive/issues/69)
+   for resolution; recommended fix is dropping the column rather
+   than retrofitting writers (same shape as
+   [#65](https://github.com/schutera/highfive/issues/65)'s
+   `CAPTURE_INTERVAL` recommendation, filed during PR D's
+   senior-review).
+
+When a field exists on a schema but no read path consults it, the
+design has a third party who left and didn't come back; either wire
+it through or remove it, but don't leave it in the table as a
+debugging hazard. Two such dead-weight fields are tracked today:
+[#65](https://github.com/schutera/highfive/issues/65) (`CAPTURE_INTERVAL`
+in `esp_config_t`) and
+[#69](https://github.com/schutera/highfive/issues/69)
+(`module_configs.status`).


### PR DESCRIPTION
## Summary

Closes **#15** — "After firmware reflashing the offline status of the module remains static until the next image upload."

### What changed

**Firmware (`ESP32-CAM/ESP32-CAM.ino`, +18 / -1)**

Inserted a single `sendHeartbeat(&esp_config)` call in `setup()` between `initNewModuleOnServer()` and the slow camera init. Gated the `lastHeartbeatMs = millis()` stamp on success so a failed boot POST falls through to the loop's existing `lastHeartbeatMs == 0` retry branch on the next iteration — instead of silently deferring the dashboard refresh for an hour.

**Backend (`backend/src/database.ts`, +9 / -3)**

Corrected the matching stale in-source comment at `fetchAndAssemble` that claimed `updated_at` "never refreshes" — the `add_module` UPSERT writes it on every boot via `ON CONFLICT (id) DO UPDATE`. The comment now points at chapter-11 for the full incident.

**Docs (`docs/06-runtime-view/image-upload-flow.md` +7/-2, `docs/11-risks-and-technical-debt/README.md` +112/0)**

New chapter-11 entry "Post-reflash dashboard latency: status is derived, not stored (#15)" with the standard What/Why/How structure. The "How to avoid" section ships two complementary rules — including the meta-rule for enumerating every write path against the actual DDL, since the first three drafts of this entry shipped false claims the senior-reviewer caught against the schema. Runtime-view section 5 gets a sentence describing the boot heartbeat.

### Why this is needed even though the registration UPSERT already refreshes `module_configs.updated_at`

The chapter-11 entry walks through the three load-bearing reasons in detail. In short:

1. **Defense-in-depth** for the registration POST failing — heartbeat plants an independent freshness signal in `module_heartbeats` so the dashboard recovers even if registration didn't.
2. **Fresh telemetry for the panel the UPSERT doesn't reach** — `Module.latestHeartbeat` reads strictly from `module_heartbeats` (per `duckdb-service/routes/heartbeats.py`'s `get_heartbeats_summary`), so RSSI/uptime/free_heap/fw_version (and the panel's `battery`) stay stale until the hourly cadence ticks without this fix.
3. **The hourly cadence isn't aware of boots** — the loop's `lastHeartbeatMs == 0` short-circuit fires on first iteration, but that iteration only runs after the full setup pipeline (30+ s dominated by camera init + warm-up + NTP).

### Follow-up issue filed

- **[#69](https://github.com/schutera/highfive/issues/69)** — `module_configs.status` column is dead-weight. Discovered during this PR's senior-review. The column is rewritten on every boot via the UPSERT, but only ever to `'online'`, and the dashboard's derived `Module.status` never reads it. Same dead-weight shape as #65's `CAPTURE_INTERVAL`; recommended resolution is dropping the column.

## Test plan — all verified, no deferred items

- [x] **Rebase onto current `main`** — applied cleanly with one conflict in `docs/11-risks-and-technical-debt/README.md` resolved by concatenating PR-C's `record_image` entry, PR-D's roadmap-drift entry (from main), and this PR's new "Post-reflash dashboard latency" entry. Auto-merge in `image-upload-flow.md` was clean. Code in `ESP32-CAM.ino` and `database.ts` untouched by main since the branch point.
- [x] `make check-citations` → **12 OK, 0 problems** on the rebased tip.
- [x] `pio run -e esp32cam` → **SUCCESS in 15.23 s**, 1118 KB binary, linker resolves the new `sendHeartbeat(&esp_config)` call site.
- [x] `pio test -e native` → **96/96 tests passed in 10.09 s** locally (MinGW-w64 16.1.0 installed via winget for this run; persistent on PATH now).
- [x] **Hardware verification on a real ESP32-CAM** flashed from this branch (MAC `e89fa9f23a08`, board name `fierce-apricot-specht`, against the local docker stack on `192.168.178.25:8000`):
  - Serial log shows the new `[STAGE] sendHeartbeat:boot took=63ms` line firing **between** `initNewModuleOnServer` and `[ESP] INITIALIZING CAMERA` — proves the ordering claim from the chapter-11 entry.
  - `[heartbeat] HTTP/1.1 200 OK` immediately above it — server accepted the boot POST.
  - Reproducible after RST: second boot logged `sendHeartbeat:boot took=60ms` with the same 200 OK.
- [x] **DuckDB cross-check** — `GET /heartbeats/e89fa9f23a08?limit=3` returns two rows from the two boots, both with non-null `rssi=-63`, `fw_version="carpenter"`, `free_heap=223000`. Most-recent row shows `uptime_ms=7466` (~7.5 s), which is the boot-heartbeat firing window the PR is for; **pre-PR this value would have stayed at the previous hourly-cadence reading until the next 1-h tick**.
- [x] **Backend cross-check** — `GET /api/modules/e89fa9f23a08` returns `latestHeartbeat: { receivedAt: 2026-05-13T19:28:31.855927, battery: 90, rssi: -63, uptimeMs: 7466, freeHeap: 223000, fwVersion: "carpenter" }` and `status: "online"`. This is the exact shape the AdminPage panel renders at `homepage/src/pages/AdminPage.tsx`'s `latestHeartbeat` block.

## Senior-reviewer rounds

Five rounds against this branch per CLAUDE.md's standard gate. Final verdict: **"PR is ready to ship."**

The arc itself earned a meta-lesson in chapter 11: the first three drafts of the entry shipped DDL-vs-comment drift that the reviewer caught only by reading the actual SQL.

1. **Round 1** caught a P1 — the loop's "defence-in-depth" comment was false because `lastHeartbeatMs = millis()` was unconditional. Fixed: gated on `sendHeartbeat == 0` success.
2. **Round 2** caught fabricated cross-references in the chapter-11 entry ("Dead-weight discovery entry above", bare "#65", "PR D"). Fixed: explicit GitHub URLs.
3. **Round 3** caught the **load-bearing factual error** — chapter-11 (and the inherited in-source comment) claimed `updated_at` "never refreshes after registration." Verified against `add_module`'s `ON CONFLICT (id) DO UPDATE SET ... updated_at = NOW()` UPSERT, which has been in place since 2026-03-30 (well before #15 was filed). Rewrote the entry to acknowledge the UPSERT and reframe the heartbeat's role as defense-in-depth + telemetry refresh, not freshness-signal-plant.
4. **Round 4** caught a precision error in reason #2 — "none of which the UPSERT refreshes" was false for `battery_level`. Rewrote to distinguish what the column stores vs what the `Module.latestHeartbeat` panel reads.
5. **Round 5** verification: reason-#2 paragraph is DDL-accurate; the reviewer confirmed by reading `duckdb-service/routes/heartbeats.py`'s `get_heartbeats_summary` (reads strictly from `module_heartbeats`, never joins `module_configs`) and `backend/src/database.ts`'s mapping (`hbEntry.battery` → `latestHeartbeat.battery`, separately from `m.battery_level` → `batteryLevel` DTO field).

## Relationship to other open PRs

PRs #64 / #67 / #68 have all merged to `main` since this branch was cut; this PR was rebased on top with one structural conflict in `docs/11-risks-and-technical-debt/README.md` resolved cleanly.

https://claude.ai/code/session_01GBLHPWYfkcQsUZPZkj9hzn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBLHPWYfkcQsUZPZkj9hzn)_
