### PR TITLE
docs(roadmap): add PR G + fix(esp): captive-portal & upload-path cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,18 @@ Derived from the open issues as of 2026-05-10. Each section below maps to one pl
 
 ---
 
+### PR G — `refactor/firmware-defaults` (closes #65, #66)
+
+Two PR-D senior-review fallouts that share the same surface: `CAPTURE_INTERVAL` is stored but never consumed by the capture scheduler (#65), and `host.cpp` + `esp_init.cpp` carry an intentional-but-fragile dual-reader asymmetry on the same SPIFFS keys (#66). Both cluster in the same firmware files, ship together.
+
+**#65 — recommended Option B (remove the dead form field).** The captive-portal "Capture Interval (ms)" knob has no runtime effect; `ESP32-CAM/ESP32-CAM.ino`'s `loop` schedules captures purely on `firstCaptureDone` + daily-noon clock. Drop the input from `host.cpp`'s `sendConfigForm`, the JSON read/write in `host.cpp`'s `loadConfig` and `saveConfig`, the `cfg_interval_ms` global and `/save` POST handler floor, and the `esp_config_t::CAPTURE_INTERVAL` load in `esp_init.cpp`'s `loadConfig`. Update `docs/07-deployment-view/esp-flashing.md`'s "Capture interval — currently informational only" callout to reflect the removal and update the chapter-11 entry's "Dead-weight discovery" paragraph. Option A (wire it through `loop` as a millis-based interval) is left open as a separate feature PR if the project later wants operator-configurable cadence — meaningful scheduler refactor that interacts with ADR-007's daily-reboot logic and should ship with hardware verification.
+
+**#66 — extract `ESP32-CAM/firmware_defaults.h`** with named constants for the remaining dual-read fields. After #65 removes the `CAPTURE_INTERVAL` pair, the asymmetry surface shrinks; sweep `RESOLUTION`, `VFLIP`, `BRIGHTNESS`, `SATURATION` (currently asymmetric or absent `|` fallbacks) and unify each at its form-prefill / production-fallback sites. References from `host.cpp` (form prefill defaults) and `esp_init.cpp` (production fallbacks) drop bare literals in favour of named constants. Kills the dual-reader-asymmetry bug class the codebase has paid for once already (chapter-11 "Telemetry sidecar envelope drift").
+
+Order relative to PR F is open.
+
+---
+
 ### PR F — `feat/esp-ota` (later — closes #26)
 
 OTA firmware update support. Requires a one-time breaking partition table change (USB flash required to get the first OTA-capable binary onto hardware).

--- a/ESP32-CAM/client.cpp
+++ b/ESP32-CAM/client.cpp
@@ -43,34 +43,6 @@ String createFileName() {
 }
 
 /*
-  Prints circle detection JSON response
-*/
-void printResponse(String response) {
-  DynamicJsonDocument doc(1024);
-  DeserializationError error = deserializeJson(doc, response);
-
-  if (error) {
-    Serial.print("------ JSON parse error: ");
-    Serial.println(error.c_str());
-    return;
-  }
-
-  Serial.println("----------------------------------------------------------------------");
-  Serial.printf("--------------------- %d circles found ---------------------\n", doc["circles"].size());
-  for (int i = 0; i < doc["circles"].size(); i++) {
-    int radius = doc["circles"][i]["radius"];
-    const char* status = doc["circles"][i]["status"];
-    int x = doc["circles"][i]["x"];
-    int y = doc["circles"][i]["y"];
-
-    Serial.printf("Circle[%d]: radius=%d, status=%s, pos=(%d,%d)\n", i+1, radius, status, x, y);
-  }
-
-  const char* message = doc["message"];
-  Serial.printf("Response message: %s\n", message);
-}
-
-/*
   POST image + mac + battery + telemetry logs to the Flask /upload endpoint
 */
 int postImage(esp_config_t *esp_config) {
@@ -209,13 +181,19 @@ int postImage(esp_config_t *esp_config) {
     esp_task_wdt_reset();
   }
 
+  // Drain the response body so the socket is properly cleared (keep-alive
+  // reuse expects an empty inbound buffer). The body's contents are not
+  // consumed — image-service's /upload response shape is informational and
+  // the HTTP status code below is what drives success/failure logic. An
+  // older debug helper (`printResponse`) attempted to parse the body for
+  // a now-defunct `circles` field and logged "JSON parse error:
+  // InvalidInput" on every successful upload; removed in favour of this
+  // honest drain.
   hf::breadcrumbSet("postImage:read_body");
-  String response = "";
   unsigned long start = millis();
   while (client.connected() || client.available()) {
     if (client.available()) {
-      char c = client.read();
-      response += c;
+      client.read();
       start = millis();
       esp_task_wdt_reset();
     } else if (millis() - start > 5000) {
@@ -224,8 +202,6 @@ int postImage(esp_config_t *esp_config) {
       delay(1);
     }
   }
-
-  printResponse(response);
 
   int code = -4;
   if (status.startsWith("HTTP/1.1 ")) {

--- a/ESP32-CAM/client.cpp
+++ b/ESP32-CAM/client.cpp
@@ -102,15 +102,6 @@ int postImage(esp_config_t *esp_config) {
 
   hf::Url url = hf::parseUrl(std::string(UPLOAD_URL));
 
-  // Initialize client
-  static bool clientInitialized = false;
-  if (!clientInitialized) {
- //   client.setInsecure();
-    client.setNoDelay(true);
-    client.setTimeout(8000);
-    clientInitialized = true;
-  }
-
   Serial.printf("---- trying to send image to: %s:%u\n",
                 url.host.c_str(), (unsigned)url.port);
   // Issue #42 instrumentation: breadcrumb at each section boundary
@@ -130,6 +121,13 @@ int postImage(esp_config_t *esp_config) {
       logbufNoteHttpCode(-2);
       return -2;
     }
+    // Set socket options AFTER connect so the underlying fd exists.
+    // Setting them on a not-yet-connected WiFiClient triggers a
+    // harmless but noisy "[E] WiFiClient.cpp:320 setSocketOption():
+    // fail on -1, errno: 9, Bad file number" from the Arduino-ESP32
+    // framework — the previous code paid that cost on every boot.
+    client.setNoDelay(true);
+    client.setTimeout(8000);
   }
 
   // POST headers

--- a/ESP32-CAM/host.cpp
+++ b/ESP32-CAM/host.cpp
@@ -179,9 +179,14 @@ void saveConfig() {
   ----------------------------------
 */
 void sendConfigForm(WiFiClient &client, bool saved = false) {
-  // Optional: split cfg_upload_url into base + endpoint for pre-filling
+  // Split cfg_*_url into base + endpoint for pre-filling. When the URL is
+  // empty (first-boot / post-erase), prefill the endpoint with the wire-
+  // protocol constant so the operator doesn't have to retype "upload" /
+  // "new_module" on every fresh onboarding. These paths are pinned by
+  // `image-service/app.py`'s `upload_image` route and
+  // `duckdb-service/routes/modules.py`'s `add_module` route respectively.
   String uploadBase = cfg_upload_url;
-  String uploadEndpoint = "";
+  String uploadEndpoint = "upload";
   int lastSlash = uploadBase.lastIndexOf('/');
   if (lastSlash > 7) { // after "http://", "https://"
     uploadEndpoint = uploadBase.substring(lastSlash + 1);
@@ -189,7 +194,7 @@ void sendConfigForm(WiFiClient &client, bool saved = false) {
   }
 
   String initBase = cfg_init_url;
-  String initEndpoint = "";
+  String initEndpoint = "new_module";
   int lastSlashInit = initBase.lastIndexOf('/');
   if (lastSlashInit > 7) { // after "http://", "https://"
     initEndpoint = initBase.substring(lastSlashInit + 1);


### PR DESCRIPTION
## Summary

Four surgical changes — one docs, three ESP firmware — all surfaced by PR #70's hardware verification session:

1. **Docs (CLAUDE.md, +12/-0)** — adds the **PR G** roadmap entry for `refactor/firmware-defaults` that will close **#65** (drop the dead-weight `CAPTURE_INTERVAL` field from `esp_config_t`) and **#66** (extract `firmware_defaults.h` to kill dual-reader asymmetry).
2. **Firmware (`ESP32-CAM/host.cpp`, +8/-3)** — prefills the captive-portal "Initialization Endpoint" and "Upload Endpoint" inputs with the wire-protocol constants (`new_module` / `upload`) instead of empty strings. UX paper-cut: operator had to retype `/new_module` and `/upload` on every fresh erase + reflash even though those paths are pinned by `duckdb-service/routes/modules.py`'s `add_module` and `image-service/app.py`'s `upload_image`.
3. **Firmware (`ESP32-CAM/client.cpp` printResponse cleanup, +9/-33)** — delete the stale `printResponse(String response)` helper and its single call site. It tried to parse the upload response for a now-defunct `doc["circles"]` field; logged `------ JSON parse error: InvalidInput` on every successful upload. Replaces the response-accumulating `String response += c` loop with a plain socket drain — same keep-alive behaviour, no unused-string allocation. HTTP-status-driven success path unchanged.
4. **Firmware (`ESP32-CAM/client.cpp` socket options after connect, +7/-9)** — move `client.setNoDelay(true)` and `client.setTimeout(8000)` into the post-`connect()` branch so the framework's `setsockopt` calls land on a valid socket fd. Previously called from a `static bool clientInitialized` block at the top of `postImage`, before the first connect — guaranteed `setsockopt(-1, TCP_NODELAY, ...)` with `EBADF`, logged as `[E][WiFiClient.cpp:320] setSocketOption(): fail on -1, errno: 9, "Bad file number"` on every boot's first capture+post. Bonus correctness: options are now applied after each fresh connect, not just once, so a keep-alive drop+reconnect properly reinstates them.

## Why bundled

All four surfaced during PR #70's hardware session. Three of them quiet first-capture-post serial noise that was masking real failure signals. Squash-on-merge collapses them into one merge commit. Splitting into four separate PRs would cost more in CI/review overhead than the fixes themselves.

## Rebase notes

The original cherry-picked commit re-introduced the PR-C / PR-D / PR-E roadmap sections that had correctly been deleted from `main` when those PRs opened. Rebase onto current `main` kept only the new PR-G section and dropped the stale re-additions. Net effect on CLAUDE.md: +12 lines for the new PR-G section.

## Test plan — all verified, no deferred items

- [x] **Rebase onto current `main`** — conflict in `CLAUDE.md` resolved by dropping the stale PR-C/D/E sections (already on main), keeping only the new PR-G entry.
- [x] `make check-citations` → **12 OK, 0 problems**.
- [x] Pre-push hooks green (citations, stale-reset-prose, no-hardcoded-api-keys).
- [x] `pio run -e esp32cam` → **SUCCESS in 6.52 s** on the final commit.
- [x] `pio test -e native` → **96/96 tests passed in 5.22 s**.
- [x] **All 8 CI gates green** on the tip commit (run [25822855269](https://github.com/schutera/highfive/actions/runs/25822855269)).
- [x] **Hardware verification — captive-portal endpoint prefill** — `pio run -t erase` + `pio run -t upload` on COM9; opened `http://192.168.4.1`; **"Initialization Endpoint" pre-filled with `new_module`, "Upload Endpoint" pre-filled with `upload`** (was empty on fresh erase). Completed the form, device registered, boot heartbeat fired with HTTP 200, first image upload succeeded.
- [x] **Hardware verification — `printResponse` removal** — reflashed, watched the first capture+post block; the `------ JSON parse error: InvalidInput` line is gone. Upload still returns `responded with status: 200 / Success`.
- [x] **Hardware verification — socket options after connect** — reflashed, watched the first capture+post block; the `[ NNNN][E][WiFiClient.cpp:320] setSocketOption(): fail on -1, errno: 9, "Bad file number"` line is gone. Upload still works as expected.

## Related

- **#65** — `CAPTURE_INTERVAL` is dead-weight (write-only, never read by the scheduler). Closed by future PR-G (this PR only adds the roadmap entry; it does not close the issues).
- **#66** — extract shared `firmware_defaults.h` to kill dual-reader asymmetry. Closed by future PR-G.
- **#67 ([PR D](https://github.com/schutera/highfive/pull/67))** — fix/esp-firmware-housekeeping, where #65/#66 were surfaced during senior-review.
- **#70 ([PR H](https://github.com/schutera/highfive/pull/70))** — fix/boot-heartbeat, where the captive-portal-endpoint-prefill paper-cut, the false `JSON parse error` log, and the `WiFiClient setSocketOption EBADF` log were all surfaced during hardware testing.

https://claude.ai/code/session_01GBLHPWYfkcQsUZPZkj9hzn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBLHPWYfkcQsUZPZkj9hzn)_
