### PR TITLE
fix: Step 2 wizard end-to-end on Windows (closes #99, closes #100, closes #107)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Per-service unit tests (what CI runs):
 
 ```bash
 cd backend        && npm ci && npm test                       # vitest + supertest, 17 tests
-cd homepage       && npm ci && npm test                       # vitest + jsdom, 8 smoke tests
+cd homepage       && npm ci && npm test                       # vitest + jsdom, 102 tests (17 files)
 cd duckdb-service && pip install -r requirements-dev.txt && pytest tests/ -q   # 24 tests
 cd image-service  && pip install -r requirements-dev.txt && pytest tests/ -q   # 31 tests
 cd ESP32-CAM      && pio test -e native                       # Unity host tests, 114 tests
@@ -182,7 +182,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Quick form: branch off `main` with typed
 
 ## In-flight multi-PR series
 
-One PR remaining to clear cofade's open issues (PR A merged — addressed #99, #100, #107). Auto-close keywords (`closes` / `fixes` / `resolves`) are intentionally avoided in this section — see the "Critical rules" entry above on auto-close-keyword leakage. The bullet ships with a self-removal clause: when PR B lands, this whole section goes too.
+One PR remaining to clear cofade's open issues. PR A (Step 2 wizard end-to-end on Windows — addressed #99, #100, #107) shipped its bullet-removal in its final commit; when PR B lands, this whole section goes too. Auto-close keywords (`closes` / `fixes` / `resolves`) are intentionally avoided in this section — see the "Critical rules" entry above on auto-close-keyword leakage.
 
 - **PR B — `module_configs` write-path semantics** (addresses #97, #105): not started. Two commits, one PR. Commit 1 splits `updated_at`'s overloaded semantics (#97 — row-metadata vs liveness signal; today every metadata UPDATE silently bumps `lastSeenAt` in [`backend/src/database.ts`'s `fetchAndAssemble`](backend/src/database.ts)). Commit 2 fixes [`duckdb-service/routes/modules.py`'s `set_display_name`](duckdb-service/routes/modules.py) so it works on modules with `nest_data` rows (#105 — DuckDB FK quirk surfaced through a Flask stacked-rollback bug). Regression tests pin both shapes. _This bullet ships removed in PR B's final commit._
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ The user's shell is **PowerShell 5.1** on Windows. When providing manual testing
 - Set ports/hosts as variables first: `$PORT = "COM9"` — never use angle-bracket placeholders like `<COMx>` (PowerShell parses `<` as a redirection operator).
 - Write files with explicit encoding: `"value" | Out-File -NoNewline -Encoding ascii path\to\file` — PowerShell's default `>` redirect writes UTF-16 LE with BOM, which breaks Python `read_text(encoding="utf-8")`.
 - No `&&` chaining — use `;` or `if ($?) { ... }`.
-- Bash scripts (`build.sh`, `make`) run via `bash <script>` from PowerShell.
+- Bash scripts (`build.sh`, `make`) run via `bash <script>` from PowerShell. `ESP32-CAM/build.sh` auto-detects `%LOCALAPPDATA%/Arduino15`, `esptool.exe`, and `python` (vs `python3`) on Windows, so `bash ESP32-CAM/build.sh` works with arduino-cli's default install — no env overrides or manual `esptool.py` copy needed (#99).
 
 ## Dev helper scripts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Quick form: branch off `main` with typed
 
 ## In-flight multi-PR series
 
-One PR remaining to clear cofade's open issues. PR A (Step 2 wizard end-to-end on Windows — addressed #99, #100, #107) shipped its bullet-removal in its final commit; when PR B lands, this whole section goes too. Auto-close keywords (`closes` / `fixes` / `resolves`) are intentionally avoided in this section — see the "Critical rules" entry above on auto-close-keyword leakage.
+One PR remaining to clear cofade's open issues; when PR B lands, this whole section goes too. Auto-close keywords (`closes` / `fixes` / `resolves`) are intentionally avoided in this section — see the "Critical rules" entry above on auto-close-keyword leakage.
 
 - **PR B — `module_configs` write-path semantics** (addresses #97, #105): not started. Two commits, one PR. Commit 1 splits `updated_at`'s overloaded semantics (#97 — row-metadata vs liveness signal; today every metadata UPDATE silently bumps `lastSeenAt` in [`backend/src/database.ts`'s `fetchAndAssemble`](backend/src/database.ts)). Commit 2 fixes [`duckdb-service/routes/modules.py`'s `set_display_name`](duckdb-service/routes/modules.py) so it works on modules with `nest_data` rows (#105 — DuckDB FK quirk surfaced through a Flask stacked-rollback bug). Regression tests pin both shapes. _This bullet ships removed in PR B's final commit._
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ These are the most-violated rules from past incidents. Full list in [`docs/02-co
 - **Never hardcode `localhost`** in inter-service URLs — use the Docker service name.
 - **Never ship the dev API key (`hf_dev_key_2026`)** as a production fallback. Override `HIGHFIVE_API_KEY`. Code-side guards catch the obvious shapes; the residual gap (`NODE_ENV=development` is an intentional off-ramp the operator owns) is the reason this prose entry stays. Full off-ramp semantics: [auth.md → "The secret"](docs/08-crosscutting-concepts/auth.md#the-secret).
 - **Never trust commit messages over code when documenting behaviour.** When writing or reviewing arc42 chapters, ADRs, or runtime-view docs, read the actual files in `ESP32-CAM/`, `duckdb-service/`, etc. — commit messages summarise intent, not what shipped. Prefer `path's <symbol>` or `path::symbol` over `path:line`; the latter drift silently. Run `make check-citations` before invoking the reviewer. Lesson recorded in [chapter 11](docs/11-risks-and-technical-debt/README.md) "Lessons learned".
+- **Never write `close[sd]?` / `fix(es|ed)?` / `resolve[sd]?` next to `#N` in commit message _bodies_ or PR _descriptions_ — only in titles.** GitHub's auto-close scanner regex-matches the literal pattern anywhere in a merging PR's text without reading context, so a commit body explaining why an auto-close-keyword leak is bad — by quoting `(closes #100, #99)` — still closes #100 on merge. When discussing the mechanism, use `addresses` / `references` / `for #N` (no keyword); save the actual `closes #N` for the PR title and the commit-subject line of the implementing commit. Verify before push: `git log <merge-base>..HEAD --pretty=full | grep -nE "(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+#"` — every match must be in a subject line or PR title, never a body paragraph. Incident: PR #104's fix commit body documented the buggy `(closes #100, #99)` antipattern by quoting it verbatim; the quoted occurrence closed #100 _and_ #97 prematurely on merge.
 
 ## Mandatory end-of-implementation gate
 
@@ -178,3 +179,13 @@ See [`scripts/README.md`](scripts/README.md) for the full list and prerequisites
 ## Branch model
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Quick form: branch off `main` with typed prefix (`feat/`, `fix/`, `docs/`, `refactor/`, `chore/`, `test/`, `ci/`); first commit line `<type>: <imperative summary>` ≤ ~72 chars; PRs require all CI green.
+
+## In-flight multi-PR series
+
+Two PRs to clear cofade's remaining open issues, grouped by cohesion. Auto-close keywords (`closes` / `fixes` / `resolves`) are intentionally avoided in this section — see the "Critical rules" entry above on auto-close-keyword leakage. Each bullet ships with a self-removal clause: when a PR lands, that bullet is removed in the PR's final commit. When both PRs land, this whole section goes too.
+
+- **PR A — Step 2 wizard end-to-end on Windows** (addresses #99, #100, #107): not started. Revives branch `fix/windows-host-parity` (`adf1a08`, 5 commits already on origin from the closed PR #106 attempt) and adds an #107 fix on top so [`flashEsp.ts`'s `assertFirmwareResponse`](homepage/src/components/setup/flashEsp.ts) accepts the `merge_bin` byte-0 layout (byte 0 = 0xFF + byte 0x1000 = 0xE9). T7 of the test plan — hardware-side Step 2 flash on a real ESP32-CAM — is the acceptance gate, not optional. _This bullet ships removed in PR A's final commit._
+
+- **PR B — `module_configs` write-path semantics** (addresses #97, #105): not started. Two commits, one PR. Commit 1 splits `updated_at`'s overloaded semantics (#97 — row-metadata vs liveness signal; today every metadata UPDATE silently bumps `lastSeenAt` in [`backend/src/database.ts`'s `fetchAndAssemble`](backend/src/database.ts)). Commit 2 fixes [`duckdb-service/routes/modules.py`'s `set_display_name`](duckdb-service/routes/modules.py) so it works on modules with `nest_data` rows (#105 — DuckDB FK quirk surfaced through a Flask stacked-rollback bug). Regression tests pin both shapes. _This bullet ships removed in PR B's final commit._
+
+Out of repo: #80 (nginx HSTS on production — server config, not a code change here).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,9 +182,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Quick form: branch off `main` with typed
 
 ## In-flight multi-PR series
 
-Two PRs to clear cofade's remaining open issues, grouped by cohesion. Auto-close keywords (`closes` / `fixes` / `resolves`) are intentionally avoided in this section — see the "Critical rules" entry above on auto-close-keyword leakage. Each bullet ships with a self-removal clause: when a PR lands, that bullet is removed in the PR's final commit. When both PRs land, this whole section goes too.
-
-- **PR A — Step 2 wizard end-to-end on Windows** (addresses #99, #100, #107): not started. Revives branch `fix/windows-host-parity` (`adf1a08`, 5 commits already on origin from the closed PR #106 attempt) and adds an #107 fix on top so [`flashEsp.ts`'s `assertFirmwareResponse`](homepage/src/components/setup/flashEsp.ts) accepts the `merge_bin` byte-0 layout (byte 0 = 0xFF + byte 0x1000 = 0xE9). T7 of the test plan — hardware-side Step 2 flash on a real ESP32-CAM — is the acceptance gate, not optional. _This bullet ships removed in PR A's final commit._
+One PR remaining to clear cofade's open issues (PR A merged — addressed #99, #100, #107). Auto-close keywords (`closes` / `fixes` / `resolves`) are intentionally avoided in this section — see the "Critical rules" entry above on auto-close-keyword leakage. The bullet ships with a self-removal clause: when PR B lands, this whole section goes too.
 
 - **PR B — `module_configs` write-path semantics** (addresses #97, #105): not started. Two commits, one PR. Commit 1 splits `updated_at`'s overloaded semantics (#97 — row-metadata vs liveness signal; today every metadata UPDATE silently bumps `lastSeenAt` in [`backend/src/database.ts`'s `fetchAndAssemble`](backend/src/database.ts)). Commit 2 fixes [`duckdb-service/routes/modules.py`'s `set_display_name`](duckdb-service/routes/modules.py) so it works on modules with `nest_data` rows (#105 — DuckDB FK quirk surfaced through a Flask stacked-rollback bug). Regression tests pin both shapes. _This bullet ships removed in PR B's final commit._
 

--- a/ESP32-CAM/build.sh
+++ b/ESP32-CAM/build.sh
@@ -148,7 +148,20 @@ echo "Verified: FIRMWARE_VERSION=${VERSION} is in the binary as a plain string."
 # rather than guess: a wrong-core merge produces a binary that boots on
 # some AI Thinker units and bricks others.
 ESP32_CORE_VERSION="${ESP32_CORE_VERSION:-2.0.17}"
-ARDUINO_DATA_DIR="${ARDUINO_DATA_DIR:-$HOME/.arduino15}"
+# Cross-platform default for arduino-cli's data directory: Windows
+# stores it under %LOCALAPPDATA%/Arduino15; macOS under
+# ~/Library/Arduino15; Linux under ~/.arduino15. Honour an explicit
+# ARDUINO_DATA_DIR override first (CI sets this), else probe in that
+# order. The :- defaults are required because set -u is on (line 2).
+if [ -z "${ARDUINO_DATA_DIR:-}" ]; then
+  if [ -n "${LOCALAPPDATA:-}" ] && [ -d "${LOCALAPPDATA}/Arduino15" ]; then
+    ARDUINO_DATA_DIR="${LOCALAPPDATA}/Arduino15"
+  elif [ -d "${HOME}/Library/Arduino15" ]; then
+    ARDUINO_DATA_DIR="${HOME}/Library/Arduino15"
+  else
+    ARDUINO_DATA_DIR="${HOME}/.arduino15"
+  fi
+fi
 # boot_app0 is core-version-pinned (lives under the core install dir).
 # esptool_py is shipped as a separate tool by arduino-cli; only one
 # version is installed per core, but if the user has multiple cores
@@ -156,11 +169,30 @@ ARDUINO_DATA_DIR="${ARDUINO_DATA_DIR:-$HOME/.arduino15}"
 # highest by sort -V; merge_bin's CLI is stable across the 4.x line so
 # this is safe.
 ESPTOOL_DIR="$(find "${ARDUINO_DATA_DIR}/packages/esp32/tools/esptool_py" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort -V -r | head -1)"
-ESPTOOL="${ESPTOOL_DIR}/esptool.py"
+# arduino-cli ships esptool.py on Linux/macOS and (typically) both
+# esptool.exe and esptool.py on Windows. Prefer the .exe when present:
+# it bundles a matching Python interpreter and esptool module, whereas
+# .py depends on the system Python having a compatible `esptool`
+# module installed — on a box where pip installs a newer esptool, the
+# vendored 4.5.1 esptool.py crashes with `module 'esptool' has no
+# attribute '_main'`. On Linux/macOS there is no .exe so the loop
+# falls through to .py with no behaviour change. The existence check
+# below catches the "core not installed" case.
+ESPTOOL=""
+for candidate in "${ESPTOOL_DIR}/esptool.exe" "${ESPTOOL_DIR}/esptool.py"; do
+  if [ -f "${candidate}" ]; then
+    ESPTOOL="${candidate}"
+    break
+  fi
+done
 BOOT_APP0="${ARDUINO_DATA_DIR}/packages/esp32/hardware/esp32/${ESP32_CORE_VERSION}/tools/partitions/boot_app0.bin"
-if [ ! -f "${ESPTOOL}" ] || [ ! -f "${BOOT_APP0}" ]; then
+if [ -z "${ESPTOOL}" ] || [ ! -f "${BOOT_APP0}" ]; then
   echo "ERROR: missing arduino-cli toolchain pieces:" >&2
-  echo "       esptool   ${ESPTOOL} (exists: $([ -f "${ESPTOOL}" ] && echo yes || echo NO))" >&2
+  if [ -z "${ESPTOOL}" ]; then
+    echo "       esptool   not found under ${ESPTOOL_DIR:-<empty>} (tried esptool.py and esptool.exe)" >&2
+  else
+    echo "       esptool   ${ESPTOOL} (exists: yes)" >&2
+  fi
   echo "       boot_app0 ${BOOT_APP0} (exists: $([ -f "${BOOT_APP0}" ] && echo yes || echo NO))" >&2
   echo "       Run: arduino-cli core install esp32:esp32@${ESP32_CORE_VERSION}" >&2
   exit 1
@@ -176,7 +208,38 @@ FLASH_MODE="${FLASH_MODE:-dio}"
 FLASH_FREQ="${FLASH_FREQ:-80m}"
 FLASH_SIZE="${FLASH_SIZE:-4MB}"
 
-python3 "${ESPTOOL}" --chip esp32 merge_bin \
+# Resolve a working interpreter. On Linux/macOS this is python3. On
+# Windows-from-python.org it is `python`. We MUST validate each
+# candidate by actually running `--version` because Windows ships an
+# MS Store stub at python3.exe that is on PATH (so `command -v` finds
+# it) but exits non-zero with "Python wurde nicht gefunden" when
+# invoked. Probing with --version catches the stub. If ESPTOOL is the
+# Windows .exe we invoke it directly and skip Python entirely.
+if [[ "${ESPTOOL}" == *.exe ]]; then
+  MERGE_CMD=( "${ESPTOOL}" )
+else
+  PYTHON=""
+  for candidate in python3 python; do
+    candidate_path="$(command -v "${candidate}" || true)"
+    if [ -n "${candidate_path}" ] && "${candidate_path}" --version >/dev/null 2>&1; then
+      PYTHON="${candidate_path}"
+      break
+    fi
+  done
+  if [ -z "${PYTHON}" ]; then
+    echo "ERROR: no working python3/python interpreter found on PATH." >&2
+    echo "       Tried: python3, python (in that order). Each was either" >&2
+    echo "       absent or failed --version (the Microsoft Store stub at" >&2
+    echo "       python3.exe is a known offender: on PATH but exits non-zero" >&2
+    echo "       with 'Python wurde nicht gefunden')." >&2
+    echo "       On Windows, install Python from python.org and ensure it" >&2
+    echo "       is on PATH ahead of the MS Store alias." >&2
+    exit 1
+  fi
+  MERGE_CMD=( "${PYTHON}" "${ESPTOOL}" )
+fi
+
+"${MERGE_CMD[@]}" --chip esp32 merge_bin \
   -o "${BUILD_DIR}/ESP32-CAM.ino.merged.bin" \
   --flash_mode "${FLASH_MODE}" --flash_freq "${FLASH_FREQ}" --flash_size "${FLASH_SIZE}" \
   0x1000  "${BUILD_DIR}/ESP32-CAM.ino.bootloader.bin" \

--- a/ESP32-CAM/build.sh
+++ b/ESP32-CAM/build.sh
@@ -194,7 +194,7 @@ BOOT_APP0="${ARDUINO_DATA_DIR}/packages/esp32/hardware/esp32/${ESP32_CORE_VERSIO
 if [ -z "${ESPTOOL}" ] || [ ! -f "${BOOT_APP0}" ]; then
   echo "ERROR: missing arduino-cli toolchain pieces:" >&2
   if [ -z "${ESPTOOL}" ]; then
-    echo "       esptool   not found under ${ESPTOOL_DIR:-<empty>} (tried esptool.py and esptool.exe)" >&2
+    echo "       esptool   not found under ${ESPTOOL_DIR:-<empty>} (tried esptool.exe then esptool.py)" >&2
   else
     echo "       esptool   ${ESPTOOL} (exists: yes)" >&2
   fi

--- a/ESP32-CAM/build.sh
+++ b/ESP32-CAM/build.sh
@@ -167,8 +167,13 @@ fi
 # version is installed per core, but if the user has multiple cores
 # installed there could be multiple esptool_py versions. We pick the
 # highest by sort -V; merge_bin's CLI is stable across the 4.x line so
-# this is safe.
-ESPTOOL_DIR="$(find "${ARDUINO_DATA_DIR}/packages/esp32/tools/esptool_py" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort -V -r | head -1)"
+# this is safe. The `|| true` is required because `set -o pipefail`
+# would otherwise abort the script when the esptool_py directory
+# doesn't exist (Windows user has arduino-cli but not the esp32 core)
+# — find exits 1, pipefail propagates, and the helpful error message
+# below never fires. Empty result flows into the ESPTOOL existence
+# check.
+ESPTOOL_DIR="$(find "${ARDUINO_DATA_DIR}/packages/esp32/tools/esptool_py" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort -V -r | head -1 || true)"
 # arduino-cli ships esptool.py on Linux/macOS and (typically) both
 # esptool.exe and esptool.py on Windows. Prefer the .exe when present:
 # it bundles a matching Python interpreter and esptool module, whereas

--- a/docs/07-deployment-view/esp-flashing.md
+++ b/docs/07-deployment-view/esp-flashing.md
@@ -313,6 +313,11 @@ bash build.sh
 # Then deploy the updated homepage/public/* artifacts to the host.
 ```
 
+`build.sh` runs unmodified on Linux, macOS, and Windows 11 + Git Bash;
+the script auto-detects `%LOCALAPPDATA%/Arduino15`, `esptool.exe`, and
+the right Python interpreter (rejecting the MS Store stub at
+`python3.exe`) so no env overrides are needed on Windows (#99).
+
 `build.sh` writes both `homepage/public/firmware.bin` (merged, for
 the web installer) and `homepage/public/firmware.app.bin` (app-only,
 for the OTA fetch), plus a `firmware.json` manifest carrying both

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -112,10 +112,17 @@ under tests. The build.sh failures don't reproduce in CI because
 GitHub Actions Ubuntu runners have a `python3` that resolves to a
 real interpreter (no MS Store stub) and an arduino-cli that installs
 under `~/.arduino15` — both trip-wires were latent there. The
-`flashEsp.test.ts` failures didn't reproduce in CI either; the exact
-discriminator between CI and local-Windows isn't pinned down (likely
-Node 22's native `Blob` shadowing jsdom's polyfill differently across
-OS / Node-minor combinations) and the refactor makes the question moot.
+`flashEsp.test.ts` failures don't reproduce in CI either, but CI runs
+the same jsdom 25.0.1 pin on the same Node 22 — so the discriminator
+must be either OS-level (Linux's Node-vs-jsdom Blob class shadowing
+order differs from Windows) or job-shape (the homepage unit job doesn't
+exercise the failing assertions). This was NOT pinned down before
+shipping the refactor; the next contributor who edits these tests
+should `gh run download` the homepage-unit log from an Ubuntu run and
+confirm whether the 6 `assertFirmwareResponse` cases actually ran and
+passed there, or whether they were skipped silently. Logging the gap
+because the refactor sidesteps the question — but the lesson is
+incomplete until somebody answers it.
 
 **Why it happened.** Both gaps are the same anti-pattern: an implicit
 "the dev box looks like the maintainer's box" assumption. The shell

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -156,6 +156,52 @@ assumptions happen to hold.
    enough; treat it as a follow-up, not a bundle into the parity fix
    itself.
 
+### Step 2 wizard validator rejected the only firmware.bin the build produces (PR A / issue #107)
+
+**What happened.** The wizard's pre-flash validator at
+[`flashEsp.ts`'s `assertFirmwareResponse`](../../homepage/src/components/setup/flashEsp.ts)
+gated on `firmware.bin[0] === 0xE9` and rejected every artefact
+produced by [`ESP32-CAM/build.sh`](../../ESP32-CAM/build.sh):
+`esptool merge_bin` emits a blob whose first 0x1000 bytes are 0xFF
+flash-erase padding, with the bootloader (the byte that actually is
+0xE9) at offset 0x1000. The bug was invisible in CI because every
+test fixture in
+[`flashEsp.test.ts`](../../homepage/src/__tests__/flashEsp.test.ts)
+started with 0xE9 by construction; it surfaced on the first
+Windows-host hardware smoke (T7 of PR #106's test plan), where Step
+2 reported "Flashen fehlgeschlagen" against a freshly built
+firmware.bin.
+
+**Why it happened.** The validator was added in PR #104 alongside a
+confidently-worded docstring that asserted "the merged single-blob
+produced by esptool.py merge_bin all begin with 0xE9." Nobody on the
+review chain held the actual bytes against the claim — the reviewer
+trusted the docstring; the docstring trusted the author's mental
+model; the author's mental model came from app-only OTA payloads
+(which DO start with 0xE9) and over-generalised to the merged blob.
+The first real merged-blob bytes touched the validator under
+hardware test, where the false claim broke immediately.
+
+**How to avoid it next time.**
+
+1. **For any byte-gate on a binary artefact, the test fixture must
+   contain bytes from a real build of that artefact at least once.**
+   Synthetic 4-byte fixtures starting with the expected magic only
+   test the validator's logic against itself. If a real-bytes fixture
+   would couple the unit test to the build pipeline (it would here —
+   `firmware.bin` is built by `build.sh`, not by `vitest`), capture a
+   hex dump of the first 0x2000 bytes in the lessons-learned entry or
+   alongside the validator so the next contributor has ground truth.
+2. **When a docstring asserts a layout fact ("X begins with byte Y"),
+   cite the source of the fact.** esptool's `merge_bin` source or
+   `esp_image_format.h` line — uncited layout claims are guesses, and
+   a citation forces the author to verify before writing.
+3. **"CI passes" + "build script succeeds" together do not exercise
+   the producer ↔ validator wire shape** unless the test environment
+   actually feeds the producer's bytes into the validator. The
+   hardware-side T7 smoke is the cheapest moment to catch this gap;
+   it must remain a gate, not optional.
+
 ### `displayName ?? name` lived in seven docs and eight render sites; six review rounds to extinguish (PR 1 / issues #103, #102, #101)
 
 **What happened.** The "operator-visible module label" rule —

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -119,10 +119,11 @@ order differs from Windows) or job-shape (the homepage unit job doesn't
 exercise the failing assertions). This was NOT pinned down before
 shipping the refactor; the next contributor who edits these tests
 should `gh run download` the homepage-unit log from an Ubuntu run and
-confirm whether the 6 `assertFirmwareResponse` cases actually ran and
-passed there, or whether they were skipped silently. Logging the gap
-because the refactor sidesteps the question — but the lesson is
-incomplete until somebody answers it.
+confirm whether the 6 `assertFirmwareResponse` cases (PR #106's count
+— PR A added three more for the merge_bin layout, see the entry just
+below) actually ran and passed there, or whether they were skipped
+silently. Logging the gap because the refactor sidesteps the question
+— but the lesson is incomplete until somebody answers it.
 
 **Why it happened.** Both gaps are the same anti-pattern: an implicit
 "the dev box looks like the maintainer's box" assumption. The shell

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -120,10 +120,13 @@ exercise the failing assertions). This was NOT pinned down before
 shipping the refactor; the next contributor who edits these tests
 should `gh run download` the homepage-unit log from an Ubuntu run and
 confirm whether the 6 `assertFirmwareResponse` cases (PR #106's count
-— PR A added three more for the merge_bin layout, see the entry just
-below) actually ran and passed there, or whether they were skipped
-silently. Logging the gap because the refactor sidesteps the question
-— but the lesson is incomplete until somebody answers it.
+at the time of this incident — PR #106 itself later added a 7th case
+for the `resp.clone()` invariant in `4891e6e`, and PR A added three
+more for the merge_bin layout for a current total of 10; see the
+entry just below) actually ran and passed there, or whether they
+were skipped silently. Logging the gap because the refactor sidesteps
+the question — but the lesson is incomplete until somebody answers
+it.
 
 **Why it happened.** Both gaps are the same anti-pattern: an implicit
 "the dev box looks like the maintainer's box" assumption. The shell
@@ -194,9 +197,13 @@ hardware test, where the false claim broke immediately.
    hex dump of the first 0x2000 bytes in the lessons-learned entry or
    alongside the validator so the next contributor has ground truth.
 2. **When a docstring asserts a layout fact ("X begins with byte Y"),
-   cite the source of the fact.** esptool's `merge_bin` source or
-   `esp_image_format.h` line — uncited layout claims are guesses, and
-   a citation forces the author to verify before writing.
+   cite the file where the `#define` actually lives, not a transitive
+   `#include` consumer.** For ESP-IDF 5.x, `ESP_IMAGE_HEADER_MAGIC` is
+   defined in `components/bootloader_support/include/esp_app_format.h`;
+   `esp_image_format.h` just re-exports it. esptool's `merge_bin`
+   source is the authority for the merged-blob layout itself.
+   Uncited layout claims are guesses, and the citation forces the
+   author to verify before writing.
 3. **"CI passes" + "build script succeeds" together do not exercise
    the producer ↔ validator wire shape** unless the test environment
    actually feeds the producer's bytes into the validator. The

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -168,8 +168,23 @@ gated on `firmware.bin[0] === 0xE9` and rejected every artefact
 produced by [`ESP32-CAM/build.sh`](../../ESP32-CAM/build.sh):
 `esptool merge_bin` emits a blob whose first 0x1000 bytes are 0xFF
 flash-erase padding, with the bootloader (the byte that actually is
-0xE9) at offset 0x1000. The bug was invisible in CI because every
-test fixture in
+0xE9) at offset 0x1000. The byte-level evidence from the failing
+hardware smoke (captured against a freshly built firmware.bin, PR
+#106 T7):
+
+```
+firmware.bin size:            1226832
+firmware.bin[0x0000]:         0xFF   ← flash-erase pad (rejected by old validator)
+firmware.bin[0x1000]:         0xE9   ← bootloader magic (the one the new validator reads)
+firmware.bin[0x8000-0x8001]:  0xAA 0x50   ← partition-table magic
+firmware.bin[0xe000]:         0x01
+firmware.bin[0x10000]:        0xE9   ← app magic
+
+firmware.app.bin size:        1161296
+firmware.app.bin[0x0000]:     0xE9   ← raw app, no padding (the byte-0=0xE9 accept path)
+```
+
+The bug was invisible in CI because every test fixture in
 [`flashEsp.test.ts`](../../homepage/src/__tests__/flashEsp.test.ts)
 started with 0xE9 by construction; it surfaced on the first
 Windows-host hardware smoke (T7 of PR #106's test plan), where Step
@@ -193,9 +208,11 @@ hardware test, where the false claim broke immediately.
    Synthetic 4-byte fixtures starting with the expected magic only
    test the validator's logic against itself. If a real-bytes fixture
    would couple the unit test to the build pipeline (it would here —
-   `firmware.bin` is built by `build.sh`, not by `vitest`), capture a
-   hex dump of the first 0x2000 bytes in the lessons-learned entry or
-   alongside the validator so the next contributor has ground truth.
+   `firmware.bin` is built by `build.sh`, not by `vitest`), capture
+   the wire-shape evidence in the lessons-learned entry alongside the
+   validator — either as a hex dump of the first 0x2000 bytes, or as
+   the annotated key-offset summary used above. The point is "ground
+   truth from a real build", not the specific dump format.
 2. **When a docstring asserts a layout fact ("X begins with byte Y"),
    cite the file where the `#define` actually lives, not a transitive
    `#include` consumer.** For ESP-IDF 5.x, `ESP_IMAGE_HEADER_MAGIC` is

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -102,12 +102,20 @@ nicht gefunden" when invoked). Separately,
 [`homepage/src/__tests__/flashEsp.test.ts`](../../homepage/src/__tests__/flashEsp.test.ts)
 reported `3 failed | 76 passed`: the validator at
 [`flashEsp.ts`'s `assertFirmwareResponse`](../../homepage/src/components/setup/flashEsp.ts)
-called `blob.slice(0, 1).arrayBuffer()`, and jsdom 25.0.1's
-[`Blob-impl.js`](../../node_modules/jsdom/lib/jsdom/living/file-api/Blob-impl.js)
-defines `slice()` but **no `arrayBuffer()` anywhere on the Blob
-prototype**. Vitest's jsdom env shadows `globalThis.Blob`, so the
-entire blob round-trip path throws under tests. CI passed on Linux for
-environmental reasons orthogonal to local.
+called `blob.slice(0, 1).arrayBuffer()`, and jsdom 25.0.1 (pinned via
+[`package-lock.json`](../../package-lock.json)) defines `slice()` on
+its `Blob` polyfill but **no `arrayBuffer()` anywhere on the Blob
+prototype** — `Object.getOwnPropertyNames(Blob.prototype)` returns
+just `['constructor', 'slice', 'size', 'type']`. Vitest's jsdom env
+shadows `globalThis.Blob`, so the entire blob round-trip path throws
+under tests. The build.sh failures don't reproduce in CI because
+GitHub Actions Ubuntu runners have a `python3` that resolves to a
+real interpreter (no MS Store stub) and an arduino-cli that installs
+under `~/.arduino15` — both trip-wires were latent there. The
+`flashEsp.test.ts` failures didn't reproduce in CI either; the exact
+discriminator between CI and local-Windows isn't pinned down (likely
+Node 22's native `Blob` shadowing jsdom's polyfill differently across
+OS / Node-minor combinations) and the refactor makes the question moot.
 
 **Why it happened.** Both gaps are the same anti-pattern: an implicit
 "the dev box looks like the maintainer's box" assumption. The shell
@@ -194,9 +202,10 @@ of truth.
 2. **Use a trip-wire grep to enforce single-source-of-truth.** When
    you promote a rule to a helper, the cost is "every prose copy of
    the old rule is now drift". A one-liner grep
+   <!-- prettier-ignore -->
    (`git grep -nE "display_name \?\?|displayName \?\?" -- docs/
-backend/ duckdb-service/ contracts/ image-service/
-homepage/src/`) finds every survivor; folding that grep into
+   backend/ duckdb-service/ contracts/ image-service/
+   homepage/src/`) finds every survivor; folding that grep into
    `make check-citations` (see `scripts/check-doc-citations.sh`)
    turns the round-N senior-review ritual into a CI check that
    catches the drift at commit time. Done in PR 1 as part of the
@@ -743,8 +752,9 @@ by `MapView`. PR 1 removed the coupling:
    pagination or a separate "needs attention" surface, not re-coupling
    to viewport (which is what PR 1 explicitly walked away from).
 3. **The integration test pins the full ordering invariant.**
+   <!-- prettier-ignore -->
    [`DashboardPage.test.tsx`'s `DashboardPage Location-pending
-side-list` block](../../homepage/src/__tests__/DashboardPage.test.tsx)
+   side-list` block](../../homepage/src/__tests__/DashboardPage.test.tsx)
    uses a three-module fixture (`pending-null-island`, `real-bodensee`,
    `alpha-foo`) deliberately ordered to distinguish three regression
    shapes: a no-op sort, a pending-last-only sort, and the current

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -86,6 +86,61 @@ write the lesson here so the next contributor doesn't repeat it.
 Format: short title + **What happened** + **Why it happened** +
 **How to avoid it next time**.
 
+### Windows host parity: build.sh tripped on three path assumptions and a unit test depended on a jsdom polyfill that doesn't exist (PR 2 / issues #99, #100)
+
+**What happened.** A contributor on Windows 11 + Git Bash + Node 22 +
+arduino-cli 1.x hit two unrelated parity gaps in the same week.
+[`ESP32-CAM/build.sh`](../../ESP32-CAM/build.sh) failed three different
+ways before producing artifacts: the hardcoded `$HOME/.arduino15`
+arduino-cli data dir was wrong (Windows uses `%LOCALAPPDATA%/Arduino15`),
+the hardcoded `esptool.py` invocation was wrong (Windows arduino-cli
+prefers `esptool.exe` because the shipped `esptool.py` crashes against
+a newer pip-installed `esptool` module), and `python3` was wrong
+(Windows ships an MS Store stub at `python3.exe` that is on PATH so
+`command -v python3` finds it, but it exits non-zero with "Python wurde
+nicht gefunden" when invoked). Separately,
+[`homepage/src/__tests__/flashEsp.test.ts`](../../homepage/src/__tests__/flashEsp.test.ts)
+reported `3 failed | 76 passed`: the validator at
+[`flashEsp.ts`'s `assertFirmwareResponse`](../../homepage/src/components/setup/flashEsp.ts)
+called `blob.slice(0, 1).arrayBuffer()`, and jsdom 25.0.1's
+[`Blob-impl.js`](../../node_modules/jsdom/lib/jsdom/living/file-api/Blob-impl.js)
+defines `slice()` but **no `arrayBuffer()` anywhere on the Blob
+prototype**. Vitest's jsdom env shadows `globalThis.Blob`, so the
+entire blob round-trip path throws under tests. CI passed on Linux for
+environmental reasons orthogonal to local.
+
+**Why it happened.** Both gaps are the same anti-pattern: an implicit
+"the dev box looks like the maintainer's box" assumption. The shell
+script assumed a POSIX-shaped install layout because that's what the
+author ran. The unit test reached for a Web API (`Blob.arrayBuffer`)
+that's documented in MDN, looked plausible in the test runner, and was
+silently absent from the polyfill the runner actually uses. Neither
+gap was caught by CI because CI runs on Linux only, where both
+assumptions happen to hold.
+
+**How to avoid it next time.**
+
+1. **Probe, don't assume.** Whenever a shell script reaches outside
+   the repo (env vars, system paths, executables), probe with
+   `command -v` and `${VAR:-}` and `for candidate in …`. The cost of
+   one extra branch beats one extra hour of a contributor unwinding
+   inline workarounds — and the workarounds always rot back. Validate
+   probed executables by actually invoking them (`--version`) before
+   committing; PATH-presence is not interpreter-existence on Windows.
+2. **When a unit test depends on a Web API method, inspect the
+   polyfill's prototype, not MDN.** `Object.getOwnPropertyNames(SomeClass.prototype)`
+   tells the truth about what jsdom actually implements; MDN tells
+   the truth about what browsers implement. The two diverge silently.
+   Prefer reading the response body via `Response.arrayBuffer()` (Node
+   native, unaffected by jsdom polyfills) over the `Blob` round-trip
+   when feasible.
+3. **"CI passes on Linux" does not entail "this works on Windows + Git Bash".**
+   The mandatory senior-reviewer subagent gate is where the "what
+   platforms has this been exercised on?" question lands. Add a
+   Windows runner to CI if the cost of running parity locally is high
+   enough; treat it as a follow-up, not a bundle into the parity fix
+   itself.
+
 ### `displayName ?? name` lived in seven docs and eight render sites; six review rounds to extinguish (PR 1 / issues #103, #102, #101)
 
 **What happened.** The "operator-visible module label" rule —
@@ -127,6 +182,7 @@ point at, so every doc and every render site became its own source
 of truth.
 
 **How to avoid it next time.**
+
 1. **Make the rule a callable, then point at it.** The structural
    fix that closed this PR was `homepage/src/lib/displayLabel.ts`
    with `Pick<Module, 'name' | 'displayName'>` as its parameter type
@@ -139,8 +195,8 @@ of truth.
    you promote a rule to a helper, the cost is "every prose copy of
    the old rule is now drift". A one-liner grep
    (`git grep -nE "display_name \?\?|displayName \?\?" -- docs/
-   backend/ duckdb-service/ contracts/ image-service/
-   homepage/src/`) finds every survivor; folding that grep into
+backend/ duckdb-service/ contracts/ image-service/
+homepage/src/`) finds every survivor; folding that grep into
    `make check-citations` (see `scripts/check-doc-citations.sh`)
    turns the round-N senior-review ritual into a CI check that
    catches the drift at commit time. Done in PR 1 as part of the
@@ -688,7 +744,7 @@ by `MapView`. PR 1 removed the coupling:
    to viewport (which is what PR 1 explicitly walked away from).
 3. **The integration test pins the full ordering invariant.**
    [`DashboardPage.test.tsx`'s `DashboardPage Location-pending
-   side-list` block](../../homepage/src/__tests__/DashboardPage.test.tsx)
+side-list` block](../../homepage/src/__tests__/DashboardPage.test.tsx)
    uses a three-module fixture (`pending-null-island`, `real-bodensee`,
    `alpha-foo`) deliberately ordered to distinguish three regression
    shapes: a no-op sort, a pending-last-only sort, and the current

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,21 +3,7 @@
 Active and planned work is tracked via GitHub Issues and Milestones on
 [schutera/highfive](https://github.com/schutera/highfive/issues).
 
-## In-flight multi-PR series
-
-A 3-PR series to clear cofade's open issues. Auto-close keywords
-(`closes`, `fixes`, `resolves`) are intentionally avoided in this file —
-GitHub matches them anywhere in a merging PR's body, which would
-prematurely close the future-PR tickets when _any_ PR in the series
-merges. Update the bullets as PRs land; delete this section when all
-three are merged.
-
-- **PR 1 — Dashboard side-list rework** (addresses #103, #102, #101):
-  on `claude/analyze-github-issues-wiqYS` (the bullet's own closeout
-  ships in PR 1's final commit)
-- **PR 2 — Windows host parity** (addresses #100, #99): in review
-- **PR 3 — `module_configs.updated_at` semantic split** (addresses
-  #97): not started
-
-Out of repo: #80 (nginx HSTS on production — server config, not a code
-change here).
+In-flight multi-PR series tracking lives in [`CLAUDE.md`](../CLAUDE.md)
+under "In-flight multi-PR series" — moved there so every agent session
+picks up the current grouping automatically without having to be told
+to read this file.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,7 +15,7 @@ three are merged.
 - **PR 1 — Dashboard side-list rework** (addresses #103, #102, #101):
   on `claude/analyze-github-issues-wiqYS` (the bullet's own closeout
   ships in PR 1's final commit)
-- **PR 2 — Windows host parity** (addresses #100, #99): not started
+- **PR 2 — Windows host parity** (addresses #100, #99): in review
 - **PR 3 — `module_configs.updated_at` semantic split** (addresses
   #97): not started
 

--- a/homepage/src/__tests__/flashEsp.test.ts
+++ b/homepage/src/__tests__/flashEsp.test.ts
@@ -76,4 +76,48 @@ describe('assertFirmwareResponse', () => {
     const blob = await resp.blob();
     expect(blob.size).toBe(4);
   });
+
+  it('accepts the esptool merge_bin layout (0xFF pad at byte 0, 0xE9 bootloader at 0x1000)', async () => {
+    // Production wire shape: build.sh's `esptool merge_bin` invocation
+    // places the bootloader at 0x1000 and pads bytes [0, 0x1000) with
+    // 0xFF (flash-erase pattern). The pre-#107 validator rejected this
+    // because it only inspected byte 0; the new validator reaches the
+    // bootloader byte and accepts. Issue #107.
+    const bytes = new Uint8Array(0x1001).fill(0xff);
+    bytes[0x1000] = ESP_IMAGE_MAGIC;
+    const resp = new Response(bytes, {
+      status: 200,
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+    await expect(assertFirmwareResponse(resp, '/firmware.bin')).resolves.toBeUndefined();
+  });
+
+  it('rejects a merge_bin-shaped body truncated before the bootloader offset', async () => {
+    // A short body whose byte 0 looks like the merge_bin pad (0xFF) but
+    // doesn't reach offset 0x1000 must be rejected — otherwise the
+    // bootloader byte read would index past the buffer.
+    const bytes = new Uint8Array(0x800).fill(0xff);
+    const resp = new Response(bytes, {
+      status: 200,
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+    await expect(assertFirmwareResponse(resp, '/firmware.bin')).rejects.toThrow(
+      /truncated.*2048 bytes/,
+    );
+  });
+
+  it('rejects 0xFF pad with wrong bootloader magic at 0x1000', async () => {
+    // A mis-merged blob (e.g., partition-table magic 0xAA where the
+    // bootloader should be) is the realistic failure mode if merge_bin's
+    // offset args got reordered. The validator catches it.
+    const bytes = new Uint8Array(0x1001).fill(0xff);
+    bytes[0x1000] = 0xaa;
+    const resp = new Response(bytes, {
+      status: 200,
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+    await expect(assertFirmwareResponse(resp, '/firmware.bin')).rejects.toThrow(
+      /byte 0x1000 is 0xAA.*expected 0xE9/,
+    );
+  });
 });

--- a/homepage/src/__tests__/flashEsp.test.ts
+++ b/homepage/src/__tests__/flashEsp.test.ts
@@ -21,18 +21,14 @@ describe('assertFirmwareResponse', () => {
 
   it('rejects an HTML response (Vite SPA fallback)', async () => {
     const resp = html('<!doctype html><html><body>vite</body></html>');
-    const blob = await resp.clone().blob();
-    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).rejects.toThrow(
+    await expect(assertFirmwareResponse(resp, '/firmware.bin')).rejects.toThrow(
       /Firmware not found at \/firmware\.bin/,
     );
   });
 
   it('rejects an HTML response even when content-type uses charset suffix', async () => {
     const resp = html('<!doctype html>', { 'content-type': 'text/html; charset=utf-8' });
-    const blob = await resp.clone().blob();
-    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).rejects.toThrow(
-      /not found.*HTML/,
-    );
+    await expect(assertFirmwareResponse(resp, '/firmware.bin')).rejects.toThrow(/not found.*HTML/);
   });
 
   it('rejects a non-0xE9 first byte even with octet-stream content-type', async () => {
@@ -40,24 +36,21 @@ describe('assertFirmwareResponse', () => {
     // fallback as application/octet-stream would slip past the
     // content-type check; magic-byte check catches it.
     const resp = bin([0x3c, 0x21, 0x64, 0x6f], { 'content-type': 'application/octet-stream' });
-    const blob = await resp.clone().blob();
-    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).rejects.toThrow(
+    await expect(assertFirmwareResponse(resp, '/firmware.bin')).rejects.toThrow(
       /not a valid ESP32 image.*0x3C.*expected 0xE9/,
     );
   });
 
   it('rejects an empty body', async () => {
     const resp = bin([], { 'content-type': 'application/octet-stream' });
-    const blob = await resp.clone().blob();
-    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).rejects.toThrow(/empty/);
+    await expect(assertFirmwareResponse(resp, '/firmware.bin')).rejects.toThrow(/empty/);
   });
 
   it('accepts a binary starting with the ESP32 image magic byte', async () => {
     const resp = bin([ESP_IMAGE_MAGIC, 0x00, 0x10, 0x20], {
       'content-type': 'application/octet-stream',
     });
-    const blob = await resp.clone().blob();
-    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).resolves.toBeUndefined();
+    await expect(assertFirmwareResponse(resp, '/firmware.bin')).resolves.toBeUndefined();
   });
 
   it('accepts the magic byte even when content-type is missing', async () => {
@@ -65,7 +58,6 @@ describe('assertFirmwareResponse', () => {
     // always carry an explicit content-type. The magic byte is the
     // authoritative check.
     const resp = bin([ESP_IMAGE_MAGIC, 0x01]);
-    const blob = await resp.clone().blob();
-    await expect(assertFirmwareResponse(resp, blob, '/firmware.bin')).resolves.toBeUndefined();
+    await expect(assertFirmwareResponse(resp, '/firmware.bin')).resolves.toBeUndefined();
   });
 });

--- a/homepage/src/__tests__/flashEsp.test.ts
+++ b/homepage/src/__tests__/flashEsp.test.ts
@@ -60,4 +60,20 @@ describe('assertFirmwareResponse', () => {
     const resp = bin([ESP_IMAGE_MAGIC, 0x01]);
     await expect(assertFirmwareResponse(resp, '/firmware.bin')).resolves.toBeUndefined();
   });
+
+  it('leaves the original Response body readable after validation (pins resp.clone() invariant)', async () => {
+    // Pins the production sequence at flashEsp.ts's flashEsp():
+    //   await assertFirmwareResponse(firmwareResp, part.path);
+    //   const blob = await firmwareResp.blob();
+    // A future refactor that drops `resp.clone()` from the validator
+    // would still pass the 6 cases above (they discard the response)
+    // but would break this round-trip because Response bodies can only
+    // be consumed once. Issue #100.
+    const resp = bin([ESP_IMAGE_MAGIC, 0x00, 0x10, 0x20], {
+      'content-type': 'application/octet-stream',
+    });
+    await assertFirmwareResponse(resp, '/firmware.bin');
+    const blob = await resp.blob();
+    expect(blob.size).toBe(4);
+  });
 });

--- a/homepage/src/components/setup/flashEsp.ts
+++ b/homepage/src/components/setup/flashEsp.ts
@@ -150,14 +150,16 @@ export async function flashEsp(
 
 /**
  * ESP32 application image header magic byte (esp_image_format.h
- * `ESP_IMAGE_HEADER_MAGIC`). The bootloader, every app slot, and
- * the merged single-blob produced by `esptool.py merge_bin` all
- * begin with 0xE9. Other artefacts in a multi-part flash layout
- * have different magics — partition tables start with 0xAA 0x50.
- * The current Step2Flash manifest is a single merged part at
- * offset 0, so 0xE9 is the right gate; if anyone splits the
- * manifest into bootloader + partitions + app, this validator
- * needs to learn the per-offset allow-list.
+ * `ESP_IMAGE_HEADER_MAGIC`). The bootloader and every app slot
+ * begin with 0xE9. Partition tables have a different magic
+ * (0xAA 0x50 — `ESP_PARTITION_MAGIC`).
+ *
+ * Important: the merged single-blob produced by `esptool merge_bin`
+ * does NOT begin with 0xE9. Its first 0x1000 bytes are 0xFF —
+ * flash-erase padding placed before the bootloader, which lives at
+ * 0x1000 in the merged layout. `assertFirmwareResponse` therefore
+ * accepts two byte-0 patterns; see issue #107 and chapter 11
+ * "Lessons learned" for the wire-shape evidence.
  */
 export const ESP_IMAGE_MAGIC = 0xe9;
 
@@ -199,13 +201,37 @@ export async function assertFirmwareResponse(resp: Response, path: string): Prom
     throw new Error(`Firmware at ${path} is empty.`);
   }
 
-  const head = new Uint8Array(buf, 0, 1)[0];
-  if (head !== ESP_IMAGE_MAGIC) {
-    const hex = head.toString(16).padStart(2, '0').toUpperCase();
+  const bytes = new Uint8Array(buf);
+  const head = bytes[0];
+
+  // Two valid layouts (see issue #107 and chapter 11 "Lessons learned"):
+  //   1. byte 0 == 0xE9 — a raw ESP image (app-only, or a future manifest
+  //      that points at the bootloader offset directly).
+  //   2. byte 0 == 0xFF AND byte 0x1000 == 0xE9 — an esptool merge_bin
+  //      output. The bytes [0, 0x1000) are flash-erase padding placed
+  //      BEFORE the bootloader. This is what build.sh produces today and
+  //      what the wizard's in-app manifest fetches at offset 0.
+  if (head === ESP_IMAGE_MAGIC) {
+    return;
+  }
+  if (head === 0xff) {
+    if (bytes.length <= 0x1000) {
+      throw new Error(
+        `Firmware at ${path} looks like an esptool merge_bin output but is truncated (${bytes.length} bytes, need at least 4097 to reach the bootloader at 0x1000). Rebuild with "make firmware".`,
+      );
+    }
+    if (bytes[0x1000] === ESP_IMAGE_MAGIC) {
+      return;
+    }
+    const bootHex = bytes[0x1000].toString(16).padStart(2, '0').toUpperCase();
     throw new Error(
-      `Firmware at ${path} is not a valid ESP32 image (first byte 0x${hex}, expected 0xE9). Rebuild with "make firmware".`,
+      `Firmware at ${path} starts with the merge_bin pad (0xFF) but byte 0x1000 is 0x${bootHex} (expected 0xE9 for the ESP32 bootloader). Rebuild with "make firmware".`,
     );
   }
+  const hex = head.toString(16).padStart(2, '0').toUpperCase();
+  throw new Error(
+    `Firmware at ${path} is not a valid ESP32 image (first byte 0x${hex}, expected 0xE9 for a raw image or 0xFF for an esptool merge_bin output with bootloader at 0x1000). Rebuild with "make firmware".`,
+  );
 }
 
 /** Convert a Blob to a binary string (each char = one byte). */

--- a/homepage/src/components/setup/flashEsp.ts
+++ b/homepage/src/components/setup/flashEsp.ts
@@ -149,10 +149,12 @@ export async function flashEsp(
 }
 
 /**
- * ESP32 application image header magic byte (esp_image_format.h
- * `ESP_IMAGE_HEADER_MAGIC`). The bootloader and every app slot
- * begin with 0xE9. Partition tables have a different magic
- * (0xAA 0x50 — `ESP_PARTITION_MAGIC`).
+ * ESP32 application image header magic byte (esp-idf 5.x
+ * `components/bootloader_support/include/esp_app_format.h`'s
+ * `ESP_IMAGE_HEADER_MAGIC`; the legacy `esp_image_format.h` simply
+ * re-exports it). The bootloader and every app slot begin with
+ * 0xE9. Partition tables have a different magic (0xAA 0x50 —
+ * `ESP_PARTITION_MAGIC`).
  *
  * Important: the merged single-blob produced by `esptool merge_bin`
  * does NOT begin with 0xE9. Its first 0x1000 bytes are 0xFF —
@@ -205,8 +207,11 @@ export async function assertFirmwareResponse(resp: Response, path: string): Prom
   const head = bytes[0];
 
   // Two valid layouts (see issue #107 and chapter 11 "Lessons learned"):
-  //   1. byte 0 == 0xE9 — a raw ESP image (app-only, or a future manifest
-  //      that points at the bootloader offset directly).
+  //   1. byte 0 == 0xE9 — a raw ESP image. This is the layout of
+  //      firmware.app.bin (consumed by the ESP's OTA path today), or
+  //      any manifest that points the wizard at the bootloader offset
+  //      directly. The wizard's current manifest does NOT use this
+  //      path, but the validator accepts it for forward-compat.
   //   2. byte 0 == 0xFF AND byte 0x1000 == 0xE9 — an esptool merge_bin
   //      output. The bytes [0, 0x1000) are flash-erase padding placed
   //      BEFORE the bootloader. This is what build.sh produces today and

--- a/homepage/src/components/setup/flashEsp.ts
+++ b/homepage/src/components/setup/flashEsp.ts
@@ -82,8 +82,8 @@ export async function flashEsp(
     for (const part of build.parts) {
       const firmwareResp = await fetch(part.path);
       if (!firmwareResp.ok) throw new Error(`Failed to fetch firmware: ${part.path}`);
+      await assertFirmwareResponse(firmwareResp, part.path);
       const blob = await firmwareResp.blob();
-      await assertFirmwareResponse(firmwareResp, blob, part.path);
       const data = await blobToBinaryString(blob);
       fileArray.push({ data, address: part.offset });
     }
@@ -180,11 +180,7 @@ export const ESP_IMAGE_MAGIC = 0xe9;
  *
  * See issue #43.
  */
-export async function assertFirmwareResponse(
-  resp: Response,
-  blob: Blob,
-  path: string,
-): Promise<void> {
+export async function assertFirmwareResponse(resp: Response, path: string): Promise<void> {
   const ctype = resp.headers.get('content-type') || '';
   if (/text\/html/i.test(ctype)) {
     throw new Error(
@@ -192,12 +188,18 @@ export async function assertFirmwareResponse(
     );
   }
 
-  if (blob.size === 0) {
+  // resp.clone() is required because the caller consumes the original body
+  // via firmwareResp.blob() right after this returns. We read via Response
+  // (not Blob) because jsdom 25's Blob prototype is missing arrayBuffer()
+  // entirely — vitest's jsdom env then shadows globalThis.Blob, so any
+  // blob.slice().arrayBuffer() or blob.arrayBuffer() path throws TypeError
+  // under tests (issue #100). Native Response.arrayBuffer() is unaffected.
+  const buf = await resp.clone().arrayBuffer();
+  if (buf.byteLength === 0) {
     throw new Error(`Firmware at ${path} is empty.`);
   }
 
-  const headBuf = await blob.slice(0, 1).arrayBuffer();
-  const head = new Uint8Array(headBuf)[0];
+  const head = new Uint8Array(buf, 0, 1)[0];
   if (head !== ESP_IMAGE_MAGIC) {
     const hex = head.toString(16).padStart(2, '0').toUpperCase();
     throw new Error(


### PR DESCRIPTION
## Summary

Step 2 of the setup wizard now works end-to-end on Windows. Three related issues addressed:

- **#99** — [`ESP32-CAM/build.sh`](ESP32-CAM/build.sh) auto-detects the Windows arduino-cli data dir (`%LOCALAPPDATA%/Arduino15` vs `~/.arduino15`), `esptool.exe` (vs `.py`), and `python` (vs `python3`, which is the MS Store stub on Windows that exits with "Python wurde nicht gefunden").
- **#100** — [`flashEsp.ts`'s `assertFirmwareResponse`](homepage/src/components/setup/flashEsp.ts) reads the firmware-bin head via `Response.clone().arrayBuffer()` instead of `Blob.arrayBuffer()`. Root cause: jsdom 25.0.1's Blob polyfill prototype has no `arrayBuffer()` method at all (verified with `Object.getOwnPropertyNames(Blob.prototype)`); vitest's jsdom env shadows `globalThis.Blob`, so the original path threw under tests on Windows + Node 22.
- **#107** — The same validator now accepts the `esptool merge_bin` output layout: byte 0 = 0xFF (flash-erase pad placed before the bootloader) AND byte 0x1000 = 0xE9 (bootloader magic). The pre-#107 validator only accepted byte 0 = 0xE9 and rejected every artefact `build.sh` produces. Three new tests pin the merge_bin layout (accept + truncation reject + wrong-bootloader-magic reject). The byte-level evidence from the failing PR #106 T7 smoke is captured in chapter 11 "Lessons learned".

This is the revival of the closed PR #106 branch (which addressed #99 + #100 but failed its T7 hardware smoke on #107) plus the #107 validator change on top. PR #106's history was rebased to scrub one commit body that quoted an auto-close-keyword antipattern verbatim — the same antipattern the commit itself documented and that the rule it introduces would catch. Subsequent commits address senior-reviewer feedback across four review rounds.

## Test plan

- [x] `cd homepage; npm test` — 102/102 green (was 99 pre-PR; +3 new `assertFirmwareResponse` cases)
- [x] `bash scripts/check-doc-citations.sh` — 7 OK, 0 problem
- [x] `bash scripts/check-stale-display-name-rule.sh` — clean
- [x] `bash scripts/check-no-hardcoded-api-keys.sh` — OK
- [x] `bash scripts/check-stale-reset-prose.sh` — OK
- [x] Auto-close keyword sweep on commit bodies (`git log b2e040d..HEAD --pretty=full | grep -iE "(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+#"`) — three hits, all on subject lines of the three fix commits, no body leaks
- [x] Senior-reviewer subagent gate cleared in four rounds
- [ ] **T7 hardware smoke** — operator-side: `bash ESP32-CAM/build.sh`, `docker compose up --build -d`, flash a real ESP32-CAM-MB via Step 2 in Chrome, confirm boot via serial. This is the acceptance gate for #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
