### PR TITLE
fix: module_configs write-path semantics (closes #97, closes #105)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,11 +179,3 @@ See [`scripts/README.md`](scripts/README.md) for the full list and prerequisites
 ## Branch model
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Quick form: branch off `main` with typed prefix (`feat/`, `fix/`, `docs/`, `refactor/`, `chore/`, `test/`, `ci/`); first commit line `<type>: <imperative summary>` ≤ ~72 chars; PRs require all CI green.
-
-## In-flight multi-PR series
-
-One PR remaining to clear cofade's open issues; when PR B lands, this whole section goes too. Auto-close keywords (`closes` / `fixes` / `resolves`) are intentionally avoided in this section — see the "Critical rules" entry above on auto-close-keyword leakage.
-
-- **PR B — `module_configs` write-path semantics** (addresses #97, #105): not started. Two commits, one PR. Commit 1 splits `updated_at`'s overloaded semantics (#97 — row-metadata vs liveness signal; today every metadata UPDATE silently bumps `lastSeenAt` in [`backend/src/database.ts`'s `fetchAndAssemble`](backend/src/database.ts)). Commit 2 fixes [`duckdb-service/routes/modules.py`'s `set_display_name`](duckdb-service/routes/modules.py) so it works on modules with `nest_data` rows (#105 — DuckDB FK quirk surfaced through a Flask stacked-rollback bug). Regression tests pin both shapes. _This bullet ships removed in PR B's final commit._
-
-Out of repo: #80 (nginx HSTS on production — server config, not a code change here).

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -38,6 +38,12 @@ interface ApiModule {
   last_image_at: string | null;
   email: string | null;
   updated_at: string | null;
+  // Device-liveness signal — bumped only on `add_module` per-boot
+  // registration in duckdb-service (issue #97 / PR B split).
+  // `fetchAndAssemble` reads this for the 2 h status window via the
+  // `lastSeenAt` derivation; the older `updated_at` is row-metadata
+  // only post-split.
+  last_seen_at: string | null;
 }
 
 interface ApiNestResponse {
@@ -213,10 +219,14 @@ export class ModuleReadModel {
           }
         : null;
 
-      // lastSeenAt = freshest of: image upload, registration, heartbeat
+      // lastSeenAt = freshest of: image upload, registration, heartbeat.
+      // Reads `m.last_seen_at` (bumped only on `add_module`'s per-boot
+      // registration UPSERT). Pre-#97 split this read `m.updated_at`,
+      // but that column is now row-metadata only — see chapter 11
+      // "updated_at semantic overload" for why the rename matters.
       const candidates: number[] = [];
       if (m.last_image_at) candidates.push(new Date(m.last_image_at).getTime());
-      if (m.updated_at) candidates.push(new Date(m.updated_at).getTime());
+      if (m.last_seen_at) candidates.push(new Date(m.last_seen_at).getTime());
       if (latestHeartbeat?.receivedAt)
         candidates.push(new Date(latestHeartbeat.receivedAt).getTime());
       const lastSeenAt =
@@ -235,17 +245,19 @@ export class ModuleReadModel {
       // — we just couldn't ask. Surface 'unknown' (gray) rather than
       // misleading the user with red 'offline'.
       //
-      // Note: an earlier draft gated this on `!m.updated_at`, but
-      // `updated_at` refreshes on every module-registration call via
-      // the `ON CONFLICT (id) DO UPDATE SET ... updated_at = NOW()`
+      // Note: an earlier draft gated this on `!m.last_seen_at`, but
+      // `last_seen_at` refreshes on every module-registration call via
+      // the `ON CONFLICT (id) DO UPDATE SET ... last_seen_at = NOW()`
       // branch in `duckdb-service/routes/modules.py`'s `add_module`,
       // which firmware fires unconditionally in setup() on every
-      // boot. So a `!m.updated_at` guard was unreachable for the
+      // boot. So a `!m.last_seen_at` guard was unreachable for the
       // exact population the fix was for. Switched to gating on the
       // would-be-offline outcome itself. (The first draft of this
       // comment said `updated_at` "never refreshes" — corrected by
-      // the #15 fix's senior-review against the DDL. See chapter-11
-      // "Post-reflash dashboard latency" for the full incident.)
+      // the #15 fix's senior-review against the DDL; the column was
+      // later renamed to `last_seen_at` in PR B / issue #97. See
+      // chapter-11 "Post-reflash dashboard latency" and "updated_at
+      // semantic overload" for full incident context.)
       let status: 'online' | 'offline' | 'unknown';
       if (isOnline) {
         status = 'online';

--- a/backend/tests/heartbeats-partial-failure.test.ts
+++ b/backend/tests/heartbeats-partial-failure.test.ts
@@ -31,6 +31,7 @@ interface UpstreamModule {
   last_image_at: string | null;
   email: string | null;
   updated_at: string | null;
+  last_seen_at: string | null;
 }
 
 function fakeModule(overrides: Partial<UpstreamModule> = {}): UpstreamModule {
@@ -47,6 +48,7 @@ function fakeModule(overrides: Partial<UpstreamModule> = {}): UpstreamModule {
     last_image_at: null,
     email: null,
     updated_at: null,
+    last_seen_at: null,
     ...overrides,
   };
 }
@@ -119,13 +121,13 @@ describe('ModuleReadModel — heartbeats fetch failure (#31)', () => {
     expect(warnSpy).toHaveBeenCalledWith('⚠️ Failed to fetch heartbeats:', expect.any(Error));
   });
 
-  it("classifies a module with no last_image_at and no updated_at as 'unknown' on heartbeat failure", async () => {
+  it("classifies a module with no last_image_at and no last_seen_at as 'unknown' on heartbeat failure", async () => {
     mockFetch({
       modules: [
         fakeModule({
           id: 'aabbccddeeff',
           last_image_at: null,
-          updated_at: null,
+          last_seen_at: null,
         }),
       ],
       heartbeats: 'reject',
@@ -155,20 +157,22 @@ describe('ModuleReadModel — heartbeats fetch failure (#31)', () => {
     expect(modules[0].status).toBe('online');
   });
 
-  it("classifies a module with stale image and stale updatedAt as 'unknown' on heartbeat failure (the production case)", async () => {
-    // The case the fix exists for. `updated_at` is set permanently at
+  it("classifies a module with stale image and stale last_seen_at as 'unknown' on heartbeat failure (the production case)", async () => {
+    // The case the fix exists for. `last_seen_at` is bumped on every
     // registration and is days-to-months stale on every healthy module
-    // — gating 'unknown' on `!m.updated_at` (an earlier draft) made the
-    // 'unknown' branch unreachable for the exact population #31 was for.
-    // The right rule: "would-be-offline AND heartbeats failed →
-    // unknown" — we can't rule out the heartbeat from a minute ago that
-    // would have flipped this to online.
+    // — gating 'unknown' on `!m.last_seen_at` (an earlier draft) made
+    // the 'unknown' branch unreachable for the exact population #31
+    // was for. The right rule: "would-be-offline AND heartbeats failed
+    // → unknown" — we can't rule out the heartbeat from a minute ago
+    // that would have flipped this to online. (Pre-#97 split this used
+    // `updated_at` for the same role; the field was renamed to
+    // `last_seen_at` when the row-metadata role was split out.)
     mockFetch({
       modules: [
         fakeModule({
           id: 'aabbccddeeff',
           last_image_at: FRESH(3 * TWO_HOURS_MS),
-          updated_at: FRESH(2 * TWO_HOURS_MS),
+          last_seen_at: FRESH(2 * TWO_HOURS_MS),
         }),
       ],
       heartbeats: 'reject',
@@ -190,7 +194,7 @@ describe('ModuleReadModel — heartbeats fetch failure (#31)', () => {
         fakeModule({
           id: 'aabbccddeeff',
           last_image_at: null,
-          updated_at: null,
+          last_seen_at: null,
         }),
       ],
       heartbeats: { summary: {} },

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -80,9 +80,17 @@ export interface Module {
   totalHatches: number; // Sum of all hatches across all nests
   imageCount: number; // Total images uploaded by this module
   email: string | null;
-  updatedAt?: string; // ISO timestamp — set on every registration/UPSERT
-  // Liveness — derived from max(updatedAt, lastApiCall, latestHeartbeat.receivedAt).
-  // If null, the module has never phoned home.
+  // ISO timestamp — row-metadata; bumped on every UPDATE to
+  // `module_configs` (registration, display-name rename, legacy
+  // heartbeat row-update, heartbeat-side geo-patch). Use `lastSeenAt`
+  // for device-liveness, NOT this — the split shipped in PR B / issue
+  // #97. See chapter 11 "updated_at semantic overload" for why.
+  updatedAt?: string;
+  // Liveness — derived from max(last_seen_at, lastApiCall,
+  // latestHeartbeat.receivedAt). `last_seen_at` is bumped only on
+  // per-boot registration in duckdb-service `add_module`; metadata
+  // writes (rename, geo-patch, legacy heartbeat) do NOT corrupt it
+  // (post-#97 split). If null, the module has never phoned home.
   lastSeenAt: string | null;
   latestHeartbeat: HeartbeatSnapshot | null;
 }

--- a/docs/05-building-block-view/duckdb-service.md
+++ b/docs/05-building-block-view/duckdb-service.md
@@ -214,12 +214,18 @@ iff the optional lat/lng/accuracy fields parsed plausible (matching
 the `_is_plausible_fix` rule — same shape as `hf::isPlausibleFix`
 on the firmware side) AND the existing `module_configs` row sits at
 the `(0,0)` sentinel. The "only patch from (0,0)" rule means a
-deliberately-placed module is never clobbered. The handler does
-**not** touch `module_configs.updated_at` — that column has dual
-semantics (issue #97). Liveness derivation in the backend reads
-`module_configs.updated_at`, the latest `module_heartbeats.received_at`,
+deliberately-placed module is never clobbered. The handler bumps
+`module_configs.updated_at` (row-metadata: the row was touched) but
+NOT `module_configs.last_seen_at` — the heartbeat is already recorded
+in `module_heartbeats` (where the backend folds it into liveness
+separately), so bumping `last_seen_at` here would double-count the
+same event. Liveness derivation in the backend reads
+`module_configs.last_seen_at`, the latest `module_heartbeats.received_at`,
 and the latest `image_uploads.uploaded_at` separately and takes the
-freshest (`backend/src/database.ts`'s `fetchAndAssemble`). The most
+freshest (`backend/src/database.ts`'s `fetchAndAssemble`). Prior to
+PR B (issue #97), `module_configs.updated_at` carried both the
+row-metadata role AND the liveness signal; chapter 11 has the
+split rationale. The most
 recent `module_heartbeats` row is materialised on the wire as
 `Module.latestHeartbeat`
 (shape: [`HeartbeatSnapshot`](../08-crosscutting-concepts/api-contracts.md))

--- a/docs/08-crosscutting-concepts/api-contracts.md
+++ b/docs/08-crosscutting-concepts/api-contracts.md
@@ -105,7 +105,7 @@ wire fields off the duckdb response and takes the freshest:
 ```ts
 // pseudocode of backend/src/database.ts's fetchAndAssemble per-module loop
 const candidates = [
-  m.updated_at, // module_configs.updated_at
+  m.last_seen_at, // module_configs.last_seen_at (registration UPSERT only — issue #97 split; pre-split this was module_configs.updated_at)
   m.last_image_at, // SELECT MAX(uploaded_at) FROM image_uploads ...
   m.latestHeartbeat?.receivedAt, // SELECT MAX(received_at) FROM module_heartbeats ...
 ].filter(Boolean);

--- a/docs/09-architecture-decisions/README.md
+++ b/docs/09-architecture-decisions/README.md
@@ -7,20 +7,21 @@ and link backwards.
 
 ## Index
 
-| ADR                                                        | Title                                                                           | Status   |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------- | -------- |
-| [001](adr-001-duckdb-as-sole-writer.md)                    | DuckDB-service is the sole writer of `app.duckdb`                               | Accepted |
-| [002](adr-002-esp-host-testable-lib.md)                    | Pure C++ helpers under `ESP32-CAM/lib/` for host testability                    | Accepted |
-| [003](adr-003-shared-api-key-for-admin.md)                 | `HIGHFIVE_API_KEY` reused for both API key and admin key                        | Accepted |
-| [004](adr-004-heartbeat-snapshot-in-contracts.md)          | `HeartbeatSnapshot` lives in `@highfive/contracts`                              | Accepted |
-| [005](adr-005-silence-watcher-in-duckdb-service.md)        | Discord silence watcher lives in `duckdb-service`                               | Accepted |
-| [006](adr-006-bee-name-firmware-versioning.md)             | ESP firmware uses bee-species names as version identifiers                      | Accepted |
-| [007](adr-007-esp-reliability-breaker-and-daily-reboot.md) | ESP reliability — circuit breaker + daily reboot + camera PWDN recovery         | Accepted |
-| [008](adr-008-firmware-ota-partition-and-rollback.md)      | Firmware OTA — partition layout, two-slot rollback, dual-binary publish         | Accepted |
-| [009](adr-009-node-22-baseline.md)                         | Node 22.12+ baseline for `backend` and `homepage`, enforced via `engine-strict` | Accepted |
-| [010](adr-010-esp-firmware-tls-trust-model.md)             | ESP firmware TLS — CA-pinned trust anchors for highfive.schutera.com            | Accepted |
-| [011](adr-011-module-display-name-override.md)             | Two-column module naming — firmware `name` + admin-settable `display_name`      | Accepted |
-| [012](adr-012-dashboard-ip-geo-hint.md)                    | Dashboard map IP-geo hint via backend proxy (not `GEO_API_KEY`)                 | Accepted |
+| ADR                                                         | Title                                                                           | Status   |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------- | -------- |
+| [001](adr-001-duckdb-as-sole-writer.md)                     | DuckDB-service is the sole writer of `app.duckdb`                               | Accepted |
+| [002](adr-002-esp-host-testable-lib.md)                     | Pure C++ helpers under `ESP32-CAM/lib/` for host testability                    | Accepted |
+| [003](adr-003-shared-api-key-for-admin.md)                  | `HIGHFIVE_API_KEY` reused for both API key and admin key                        | Accepted |
+| [004](adr-004-heartbeat-snapshot-in-contracts.md)           | `HeartbeatSnapshot` lives in `@highfive/contracts`                              | Accepted |
+| [005](adr-005-silence-watcher-in-duckdb-service.md)         | Discord silence watcher lives in `duckdb-service`                               | Accepted |
+| [006](adr-006-bee-name-firmware-versioning.md)              | ESP firmware uses bee-species names as version identifiers                      | Accepted |
+| [007](adr-007-esp-reliability-breaker-and-daily-reboot.md)  | ESP reliability — circuit breaker + daily reboot + camera PWDN recovery         | Accepted |
+| [008](adr-008-firmware-ota-partition-and-rollback.md)       | Firmware OTA — partition layout, two-slot rollback, dual-binary publish         | Accepted |
+| [009](adr-009-node-22-baseline.md)                          | Node 22.12+ baseline for `backend` and `homepage`, enforced via `engine-strict` | Accepted |
+| [010](adr-010-esp-firmware-tls-trust-model.md)              | ESP firmware TLS — CA-pinned trust anchors for highfive.schutera.com            | Accepted |
+| [011](adr-011-module-display-name-override.md)              | Two-column module naming — firmware `name` + admin-settable `display_name`      | Accepted |
+| [012](adr-012-dashboard-ip-geo-hint.md)                     | Dashboard map IP-geo hint via backend proxy (not `GEO_API_KEY`)                 | Accepted |
+| [013](adr-013-compensating-restore-for-duckdb-fk-update.md) | Bespoke autocommit + compensating-restore for DuckDB FK over-enforced UPDATEs   | Accepted |
 
 ## When to create an ADR
 

--- a/docs/09-architecture-decisions/adr-005-silence-watcher-in-duckdb-service.md
+++ b/docs/09-architecture-decisions/adr-005-silence-watcher-in-duckdb-service.md
@@ -16,10 +16,13 @@ message when the module phones home again
 The watcher needs three things:
 
 1. **Liveness state for every module.** It computes the freshest of
-   `module_configs.updated_at`, the latest `image_uploads.uploaded_at`
+   `module_configs.last_seen_at`, the latest `image_uploads.uploaded_at`
    per module, and the latest `module_heartbeats.received_at` per
    module. The `SELECT` block is at `silence_watcher.py:38-52`; the
-   per-row liveness max is at `silence_watcher.py:60-65`.
+   per-row liveness max is at `silence_watcher.py:60-65`. Pre-PR-B
+   (issue #97), `module_configs.updated_at` did double duty as both
+   row-metadata and liveness signal; the watcher now reads the
+   dedicated `last_seen_at` column.
 2. **A place to record "we already alerted on this silence so don't
    re-fire for `REALERT_INTERVAL_S` seconds"** — done with a single
    nullable `last_silence_alert_at TIMESTAMP` column on

--- a/docs/09-architecture-decisions/adr-013-compensating-restore-for-duckdb-fk-update.md
+++ b/docs/09-architecture-decisions/adr-013-compensating-restore-for-duckdb-fk-update.md
@@ -1,0 +1,193 @@
+# ADR-013: Bespoke autocommit + compensating-restore for UPDATEs that DuckDB FK enforcement blocks
+
+## Status
+
+Accepted
+
+## Context
+
+DuckDB 1.4.4 (and 1.5.2, verified during PR B) over-enforces foreign-key
+constraints: any UPDATE on a row whose primary key is referenced by a
+child table fails with
+`ConstraintException: Violates foreign key constraint because key
+"module_id: ..." is still referenced by a foreign key in a different
+table` — even when the UPDATE doesn't touch the FK column. The
+documented limitation says "updates that affect referenced rows must
+be propagated using DELETE-then-INSERT"; the implementation interprets
+"affect" as "the row exists and is referenced". The effect is observed
+most sharply when the UPDATE touches a UNIQUE-constrained column
+(`module_configs.display_name` was the trigger case).
+
+The project has an atomicity primitive,
+[`duckdb-service/db/repository.py`](../../duckdb-service/db/repository.py)'s
+`write_transaction`, which acquires the global write lock, issues an
+explicit `BEGIN`, yields the connection, and `COMMIT`s on clean exit
+or `ROLLBACK`s on exception. The vast majority of multi-statement
+writers in `duckdb-service` use it. But: **inside an explicit
+transaction, DuckDB's FK enforcement uses the transaction-snapshot
+view of the data, not the row's current state inside the
+transaction.** So the standard "temp-table dance" workaround for the
+FK over-enforcement — snapshot child rows, DELETE them in reverse-FK
+order, run the UPDATE on the now-unreferenced parent, re-insert the
+children — fails inside `write_transaction()`: the UPDATE still sees
+the pre-DELETE snapshot of `nest_data` references and trips the same
+FK exception that motivated the workaround.
+
+This created a forced trade-off: full transactional atomicity vs.
+admit-the-UPDATE-on-FK-referenced-rows.
+
+The alternatives the issue's reporter suggested all turned out to be
+inapplicable in DuckDB (empirical results captured at PR B execution,
+duckdb-python==1.4.4):
+
+- **`PRAGMA foreign_keys = OFF`** — SQLite pragma, not DuckDB. DuckDB
+  returns `Catalog Error: unrecognized configuration parameter
+"foreign_keys"`.
+- **`ALTER TABLE nest_data DROP CONSTRAINT ...`** — raises
+  `NotImplementedException: No support for that ALTER TABLE option
+yet`. DuckDB 1.4.4 does not implement that ALTER form.
+- **`INSERT ... ON CONFLICT (id) DO UPDATE`** — same FK
+  over-enforcement when the SET clause touches a UNIQUE-constrained
+  column. The UPSERT branch is treated as a regular UPDATE for FK
+  purposes.
+- **DuckDB version bump (1.4.4 → 1.5.2)** — 1.5.2 still has the bug.
+  Verified by re-running the regression test against 1.5.2; same
+  exception.
+
+## Decision
+
+`set_display_name` opts out of `write_transaction()` and runs its
+dance in autocommit mode (each `con.execute` commits individually).
+The atomicity guarantee is provided at the Python layer:
+
+1. **Snapshot phase.** Read `daily_progress` rows for this module
+   (JOINed via `nest_data`) and `nest_data` rows for this module
+   into in-memory tuples.
+2. **Mutation phase.** DELETE `daily_progress` rows (grandchild),
+   DELETE `nest_data` rows (child), UPDATE `module_configs` (parent
+   now FK-unreferenced), INSERT `nest_data` rows back, INSERT
+   `daily_progress` rows back.
+3. **Compensating-restore on exception.** If any mutation raises, an
+   inner exception handler calls a `_restore_children()` closure that
+   DELETEs any partial inserts then re-INSERTs the full snapshot.
+   The handler converges from any intermediate state — DELETE-phase
+   partial failures, UPDATE failures, INSERT-phase partial failures.
+4. **Restore-failure surface.** If `_restore_children()` itself
+   raises, the 500 response body carries
+   `{"restore_failed": true, "module_id": <mac>, "message": "...
+restore from backup before retrying"}` so the backend can
+   distinguish "retry-safe rename failure" from "data lost".
+
+The global `lock` in
+[`duckdb-service/db/connection.py`](../../duckdb-service/db/connection.py)
+is held for the whole dance, so no concurrent reader or writer
+observes the half-deleted state. This is load-bearing: every
+duckdb-service read goes through the same lock
+([`db/repository.py`](../../duckdb-service/db/repository.py)'s
+`query_all` / `query_one` / `query_scalar`).
+
+## When to use this pattern
+
+This pattern is the **opt-out from `write_transaction()`**, not the
+default. Reach for it when ALL of the following hold:
+
+1. You need to UPDATE a row whose primary key is referenced by a
+   child table, AND
+2. The UPDATE touches a UNIQUE-constrained column (DuckDB
+   over-enforces FK on these specifically — observed empirically), AND
+3. The standard `write_transaction()` helper would trip the FK
+   exception via its `BEGIN` (verifiable by trying it and seeing
+   `ConstraintException: ... still referenced` come back).
+
+If condition 2 doesn't hold, the UPDATE inside `write_transaction()`
+works fine. If condition 1 doesn't hold (no child references), the
+FK over-enforcement doesn't fire at all. Both `add_module`'s UPSERT
+and the legacy `/modules/<id>/heartbeat` route are in this safer
+zone — they stay on `write_transaction()`.
+
+The pattern must be paired with a fault-injection test
+(`test_set_display_name_restores_children_on_mid_dance_failure` is
+the prior art) that pins the compensating-restore contract — without
+the test, a refactor that drops the restore handler would pass the
+happy-path test and silently regress.
+
+## Consequences
+
+**Positive:**
+
+- The user-visible bug (#105 — operators couldn't rename seeded
+  modules) is fixed without giving up `write_transaction()`'s
+  atomicity for other callers. The four routes that don't have the
+  FK over-enforcement constraint (`add_module`, `record_image`,
+  `add_progress_for_module`, legacy `heartbeat`) keep their real
+  transactional semantics — PR B's senior-review caught that
+  `write_transaction` was missing its `BEGIN` and the fix benefits
+  all four uniformly.
+- The compensating-restore semantics are observable: success returns
+  200, retry-safe failures return 500 with the original error, and
+  the rare "restore-itself-failed" mode returns 500 with the
+  `restore_failed: true` marker so the backend can surface "restore
+  from backup" rather than "retry".
+
+**Negative:**
+
+- Two paths now exist for multi-statement atomicity in
+  `duckdb-service`: `write_transaction()` for the standard case,
+  bespoke autocommit + compensating-restore for the DuckDB-FK-over-
+  enforcement case. Future contributors writing a new UPDATE need to
+  pick the right one. The chapter 11 entry for #105 documents the
+  decision tree, and this ADR is the long-form reference.
+- The dance's atomicity is best-effort, not transactional. If the
+  Python process dies mid-dance (between `DELETE` and re-`INSERT`),
+  the database is left in the half-deleted state. The probability is
+  low (one route, lock held, container restart would replay the
+  request from the operator's side), but it's strictly weaker than
+  the transactional guarantee.
+- The compensating-restore handler duplicates the DELETE+INSERT logic
+  from the happy path. A future column add to `nest_data` or
+  `daily_progress` has to land in both places. Mitigation: the inner
+  `_restore_children` closure is a single function, called from the
+  one exception path; the duplication is bounded to that one route.
+
+## Alternatives considered
+
+- **DuckDB version bump alone (1.4.4 → 1.5.2).** Tried first per PR
+  B's plan. The FK over-enforcement persists in 1.5.2; reverted.
+  Worth revisiting if DuckDB ever relaxes the constraint upstream.
+- **Drop the `nest_data.module_id` FK constraint entirely.** Loses
+  the structural guarantee that every nest row points at a real
+  module. The schema's whole point is that the FK enforces "no orphan
+  nests"; dropping it transfers the invariant from SQL to
+  application code, which the project has historically avoided
+  (ADR-001 makes `duckdb-service` the sole writer specifically so
+  these invariants can stay in SQL).
+- **Switch the column type to remove the UNIQUE constraint.** The
+  UNIQUE invariant on `display_name` is load-bearing — two modules
+  on the same dashboard with the same label leave the operator
+  unable to tell them apart (ADR-011 has the full rationale). Not
+  negotiable.
+- **A DEFERRED-FK transaction.** DuckDB 1.4.4/1.5.2 has limited
+  support for deferred constraints; the FK over-enforcement we hit
+  fires at statement time regardless of deferral. Same effect.
+- **`write_transaction()` with explicit `BEGIN/COMMIT` and the dance
+  inside.** The combination this ADR rules out. The DuckDB
+  transaction-snapshot view re-trips the FK exception even after the
+  in-transaction DELETE of the children. Verified empirically; would
+  require a DuckDB upstream fix.
+
+## References
+
+- [Issue #105](https://github.com/schutera/highfive/issues/105) —
+  the operator-side symptom (admin rename failed for all seeded
+  modules) and the stacked DuckDB FK + Flask rollback bug.
+- [Issue #97](https://github.com/schutera/highfive/issues/97) — the
+  column split that surfaced this; pre-#97, `set_display_name` ran a
+  plain UPDATE on `display_name` and that already hit the FK
+  enforcement (the stacked-rollback bug at the route level just
+  masked it).
+- [Chapter 11 — "Admin rename failed silently on seeded modules"](../11-risks-and-technical-debt/README.md)
+  — the incident write-up, including the workaround discovery path
+  (PRAGMA / ALTER / UPSERT all inapplicable).
+- [ADR-001](adr-001-duckdb-as-sole-writer.md) — why `duckdb-service`
+  is the sole writer (and therefore the only place this pattern
+  needs to live).

--- a/docs/09-architecture-decisions/adr-013-compensating-restore-for-duckdb-fk-update.md
+++ b/docs/09-architecture-decisions/adr-013-compensating-restore-for-duckdb-fk-update.md
@@ -166,9 +166,13 @@ happy-path test and silently regress.
   on the same dashboard with the same label leave the operator
   unable to tell them apart (ADR-011 has the full rationale). Not
   negotiable.
-- **A DEFERRED-FK transaction.** DuckDB 1.4.4/1.5.2 has limited
-  support for deferred constraints; the FK over-enforcement we hit
-  fires at statement time regardless of deferral. Same effect.
+- **A DEFERRED-FK transaction.** DuckDB documents deferred
+  constraints as unsupported in the FK enforcement path (the
+  `INITIALLY DEFERRED` clause is parsed but has no behavioural
+  effect on UPDATEs against referenced rows). This alternative was
+  ruled out from the docs rather than via a separate repro; the
+  empirical work focused on the other three alternatives where
+  uncertainty actually existed.
 - **`write_transaction()` with explicit `BEGIN/COMMIT` and the dance
   inside.** The combination this ADR rules out. The DuckDB
   transaction-snapshot view re-trips the FK exception even after the

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -360,7 +360,102 @@ half of the contract.
   review cycle on any PR that adds a write to a column whose name
   doesn't fully describe its read-path semantics.
 
-**Resolved in PR B (closes #97).** The split shipped: `module_configs`
+### Admin rename failed silently on seeded modules — DuckDB FK over-enforcement + stacked rollback (PR B / issue #105)
+
+**What happened.** Operators trying to rename one of the five seeded
+modules (`Garten 12` and friends) via the admin UI got "Save failed.
+Please try again." Backend logs showed a JSON parse error (`Unexpected
+token '<'`) — duckdb-service was returning Flask's HTML 500 page.
+Beneath the HTML body, duckdb-service had logged two stacked
+exceptions: a `ConstraintException: Violates foreign key constraint
+because key "module_id: 000000000002" is still referenced by a foreign
+key in a different table`, immediately followed by a
+`TransactionException: cannot rollback - no transaction is active`.
+Both bugs were live simultaneously; the second masked the first.
+
+**Why it happened.**
+
+1. **DuckDB FK over-enforcement** (the primary bug). DuckDB 1.4.4 (and
+   1.5.2, verified during the fix) rejects `UPDATE module_configs SET
+display_name = ?` whenever the targeted row's `id` is referenced
+   by `nest_data.module_id`, _even though_ the UPDATE doesn't touch
+   `id` and would not break referential integrity. The behaviour is a
+   conservative reading of the SQL standard's "updates that affect
+   referenced rows must be propagated" rule. Seeded modules all carry
+   `nest_data` rows so all five were unrenamable out of the box; an
+   ESP that registered post-seed with no nests yet would have renamed
+   fine — the test suite seeded the latter and missed the former.
+2. **Stacked rollback** (the secondary bug). The route used manual
+   `con = get_conn() / con.commit() / con.rollback()` instead of the
+   project's `write_transaction()` helper. DuckDB defaults to
+   autocommit; `con.rollback()` in the exception handler — with no
+   active transaction — raised a `TransactionException` whose
+   traceback escaped the route's wrapper, so Flask served its
+   default HTML 500 page instead of the JSON the backend's parser
+   expected.
+
+**The workaround.** The fixes the issue's reporter listed
+(`PRAGMA foreign_keys = OFF`, `ALTER TABLE DROP CONSTRAINT`,
+INSERT ... ON CONFLICT DO UPDATE) all turned out to be inapplicable
+in DuckDB:
+
+- `PRAGMA foreign_keys` is a SQLite pragma. DuckDB returns
+  `Catalog Error: unrecognized configuration parameter
+"foreign_keys"`.
+- `ALTER TABLE nest_data DROP CONSTRAINT ...` raises
+  `NotImplementedException: No support for that ALTER TABLE option
+yet`.
+- `INSERT INTO module_configs ... ON CONFLICT (id) DO UPDATE` hits
+  the same FK over-enforcement — DuckDB treats the UPSERT branch as
+  a regular UPDATE for FK purposes (even though `add_module`'s
+  fresh-row UPSERT works because no `nest_data` rows reference a
+  not-yet-inserted module).
+
+The only path through DuckDB's FK over-enforcement is to temporarily
+move the referencing child rows out of the way: snapshot
+`daily_progress` + `nest_data` rows for this module, delete them in
+reverse-FK order, run the UPDATE on the now-unreferenced parent, then
+re-insert the children. The full sequence runs inside
+`write_transaction()` so it's atomic — any failure rolls back to the
+original state and the FK invariant is preserved end-to-end. Bounded
+blast radius: only the renamed module's children move (the `WHERE
+module_id = ?` filter pins it).
+
+**How to avoid it next time.**
+
+- **Use `write_transaction()` for every duckdb-service route that
+  mutates state.** The helper at
+  [`duckdb-service/db/repository.py`](../../duckdb-service/db/repository.py)'s
+  `write_transaction` handles the autocommit-rollback case
+  gracefully (`try: con.rollback() except: pass` for the
+  no-active-transaction path). Manual `con.commit() / con.rollback()`
+  lifecycles are a smell — they bypass the helper's safety net and
+  recreate the bug.
+- **Test fixtures must seed the realistic precondition for the route
+  under test, not the minimum that lets the happy path pass.** The
+  five seeded modules all carry `nest_data`; any `set_display_name`
+  test that doesn't reproduce that shape is exercising a fictional
+  schema. The new regression test
+  (`test_set_display_name_works_on_module_with_nest_data`) seeds the
+  FK reference explicitly. Same lesson the
+  `assertFirmwareResponse` byte-0 incident (#107) taught: a
+  validator's test fixture must contain bytes / rows from a
+  realistic source at least once.
+- **When a backend response surfaces "Unexpected token '<' ... is
+  not valid JSON", the upstream almost certainly fell back to Flask's
+  default HTML 500 page.** That means an exception escaped the
+  route's wrapper. Logging the upstream body (not just status) in
+  backend error paths makes this grep-able.
+- **DuckDB's FK enforcement is conservative.** Any UPDATE on a row
+  whose PK is FK-referenced will trip the over-enforcement,
+  regardless of whether the UPDATE touches the FK column. Plan
+  for it on any rename / metadata-edit route, not just `display_name`.
+  The DELETE-children-and-restore dance is the supported workaround
+  until DuckDB relaxes the constraint (which 1.5.2 did NOT — checked).
+
+### Resolved — `updated_at` semantic overload split into two columns (PR B / issue #97)
+
+The split shipped: `module_configs`
 now carries `updated_at` (row-metadata, bumped on every UPDATE) and
 `last_seen_at` (device-liveness, bumped only on `add_module`'s per-boot
 registration UPSERT). The backend's `fetchAndAssemble` reads

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -360,6 +360,23 @@ half of the contract.
   review cycle on any PR that adds a write to a column whose name
   doesn't fully describe its read-path semantics.
 
+**Resolved in PR B (closes #97).** The split shipped: `module_configs`
+now carries `updated_at` (row-metadata, bumped on every UPDATE) and
+`last_seen_at` (device-liveness, bumped only on `add_module`'s per-boot
+registration UPSERT). The backend's `fetchAndAssemble` reads
+`last_seen_at` for the 2 h status window; every other write site
+(display-name rename, heartbeat-side geo-patch, legacy heartbeat
+row-update) bumps only `updated_at`. The existing regression test was
+inverted (renamed `test_patch_display_name_bumps_updated_at_not_last_seen_at`)
+and two companion tests pin the new contract end-to-end. What this
+changes for future writers: any new UPDATE on `module_configs` should
+set `updated_at = NOW()` in the SET clause; NEVER write
+`last_seen_at = NOW()` outside `add_module` — that column is the
+contract for "ESP32 just announced itself", and `Module.status`
+depends on it. The setup wizard's verification poll was also switched
+from `m.updatedAt` to `m.lastSeenAt` — the old field is now polluted
+by metadata writes that pre-split couldn't reach it.
+
 ### Same-batch ESP firmwares collided on the auto-generated module name (issues #91, #92, #93, #94)
 
 **What happened.** Two distinct modules with MACs `b0:69:6e:f2:3a:08`

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -415,22 +415,55 @@ The only path through DuckDB's FK over-enforcement is to temporarily
 move the referencing child rows out of the way: snapshot
 `daily_progress` + `nest_data` rows for this module, delete them in
 reverse-FK order, run the UPDATE on the now-unreferenced parent, then
-re-insert the children. The full sequence runs inside
-`write_transaction()` so it's atomic — any failure rolls back to the
-original state and the FK invariant is preserved end-to-end. Bounded
-blast radius: only the renamed module's children move (the `WHERE
-module_id = ?` filter pins it).
+re-insert the children. Bounded blast radius: only the renamed
+module's children move (the `WHERE module_id = ?` filter pins it).
+
+**Atomicity caveat (senior-review round 1 finding).** The dance
+CANNOT run inside `write_transaction()`'s explicit `BEGIN/COMMIT`.
+DuckDB's FK enforcement uses a transaction-snapshot view: even after
+DELETing the children in the same transaction, the UPDATE on the
+UNIQUE-constrained `display_name` column sees the snapshotted
+references and trips the same FK exception that motivated the dance.
+The dance therefore runs in autocommit (each DELETE / UPDATE /
+INSERT commits individually) and atomicity is provided at the
+Python layer via a **compensating-restore** handler in the
+exception path: if any phase raises, the handler re-inserts the
+snapshotted children before the 500 surfaces. The global `lock` is
+held for the whole dance so no concurrent writer races with the
+half-deleted state. Pinned by `set_display_name`'s
+fault-injection test (`test_set_display_name_restores_children_on_mid_dance_failure`)
+and the FK-chain preservation test
+(`test_set_display_name_preserves_full_fk_chain_nest_and_progress`).
+
+The PR-B-side correction that surfaced this: `write_transaction`
+itself was missing its `BEGIN`, so multi-statement callers got
+silent partial-write semantics ("rollback on exception" was a
+no-op because DuckDB autocommit had already committed each
+statement). The senior-reviewer caught it; the fix adds explicit
+`BEGIN/COMMIT` for that helper's 4 OTHER callers (add_module,
+record_image, the legacy heartbeat route, add_progress_for_module),
+all of which benefit from real atomicity. set_display_name's dance
+is the one route that opts out of the helper because of the
+DuckDB-snapshot incompatibility. Pinned by
+`tests/test_repository.py`'s `test_write_transaction_rolls_back_partial_writes`.
 
 **How to avoid it next time.**
 
 - **Use `write_transaction()` for every duckdb-service route that
   mutates state.** The helper at
   [`duckdb-service/db/repository.py`](../../duckdb-service/db/repository.py)'s
-  `write_transaction` handles the autocommit-rollback case
-  gracefully (`try: con.rollback() except: pass` for the
-  no-active-transaction path). Manual `con.commit() / con.rollback()`
-  lifecycles are a smell — they bypass the helper's safety net and
-  recreate the bug.
+  `write_transaction` now issues an explicit `BEGIN` so multi-
+  statement callers get real atomicity. Manual `con.commit() /
+con.rollback()` lifecycles are a smell — they bypass the helper's
+  safety net and recreate both bugs.
+- **The one exception is when an UPDATE on a row with FK references
+  has to bypass DuckDB's snapshot-based FK enforcement** (the
+  `display_name` rename being the only known case today). Such
+  routes use a bespoke autocommit + compensating-restore pattern;
+  document it explicitly in the route comment and pin it with a
+  fault-injection test, otherwise a future refactor that switches
+  back to `write_transaction()` reintroduces the FK-over-enforcement
+  symptom.
 - **Test fixtures must seed the realistic precondition for the route
   under test, not the minimum that lets the happy path pass.** The
   five seeded modules all carry `nest_data`; any `set_display_name`

--- a/duckdb-service/db/repository.py
+++ b/duckdb-service/db/repository.py
@@ -68,15 +68,31 @@ def query_scalar(sql: str, params: tuple = ()) -> Any:
 
 @contextmanager
 def write_transaction() -> Iterator[Any]:
-    """Acquire lock, open conn, yield it, commit on success / rollback on exception, close.
+    """Acquire lock, open conn, BEGIN explicit transaction, yield it,
+    commit on success / rollback on exception, close.
 
-    Yields the live DuckDB connection so callers can run multiple statements
-    in the same transaction (e.g. ``add_progress_for_module`` which inserts
-    nests and progress rows together).
+    Yields the live DuckDB connection so callers can run multiple
+    statements in the same transaction (e.g. ``add_progress_for_module``
+    which inserts nests and progress rows together, or
+    ``set_display_name``'s temp-table-dance which snapshots child rows
+    and restores them around the parent UPDATE).
+
+    The explicit ``BEGIN`` is load-bearing for multi-statement atomicity.
+    DuckDB defaults to autocommit, so every ``con.execute`` outside an
+    explicit transaction commits individually — without ``BEGIN``, a
+    multi-statement caller that raises midway leaves the earlier
+    statements committed AND the ``con.rollback()`` below raises a
+    secondary ``TransactionException: cannot rollback - no transaction
+    is active``. Pre-#105 the helper had no ``BEGIN`` and the rollback
+    was a no-op; the senior-reviewer caught this during PR B and the
+    fix is part of #105's safety contract for the rename-dance.
+    Pinned by ``test_write_transaction_rolls_back_partial_writes`` in
+    ``tests/test_repository.py``.
     """
     c = _conn_module()
     with c.lock:
         con = c.get_conn()
+        con.execute("BEGIN")
         try:
             yield con
             con.commit()
@@ -84,7 +100,9 @@ def write_transaction() -> Iterator[Any]:
             try:
                 con.rollback()
             except Exception:
-                # No active transaction (e.g. DDL auto-committed) — nothing to roll back.
+                # If rollback itself fails the transaction state is
+                # already torn down; surfacing the original exception
+                # is more useful than masking it with a rollback error.
                 pass
             raise
         finally:

--- a/duckdb-service/db/repository.py
+++ b/duckdb-service/db/repository.py
@@ -83,11 +83,18 @@ def write_transaction() -> Iterator[Any]:
     multi-statement caller that raises midway leaves the earlier
     statements committed AND the ``con.rollback()`` below raises a
     secondary ``TransactionException: cannot rollback - no transaction
-    is active``. Pre-#105 the helper had no ``BEGIN`` and the rollback
-    was a no-op; the senior-reviewer caught this during PR B and the
-    fix is part of #105's safety contract for the rename-dance.
-    Pinned by ``test_write_transaction_rolls_back_partial_writes`` in
+    is active``. The senior-reviewer caught this during PR B; the
+    helper has issued ``BEGIN`` since then. Pinned by
+    ``test_write_transaction_rolls_back_partial_writes`` in
     ``tests/test_repository.py``.
+
+    Note: ``set_display_name`` in ``routes/modules.py`` deliberately
+    BYPASSES this helper — DuckDB's transaction-snapshot view of FK
+    references blocks the temp-table-dance workaround for #105's FK
+    over-enforcement bug. That route uses bespoke autocommit +
+    compensating-restore instead; see
+    [ADR-013](../docs/09-architecture-decisions/adr-013-compensating-restore-for-duckdb-fk-update.md)
+    for when to follow which pattern.
     """
     c = _conn_module()
     with c.lock:

--- a/duckdb-service/db/schema.py
+++ b/duckdb-service/db/schema.py
@@ -11,6 +11,24 @@ from db.connection import lock, get_conn
 # would silently break the other deploy path. Column lists in
 # `_MODULE_CONFIGS_COLUMNS` are also referenced from the migration's
 # explicit `INSERT ... SELECT ...` so ordinal drift can't corrupt data.
+#
+# `updated_at` vs `last_seen_at` — issue #97 / PR B split.
+#
+# - `updated_at` is the row-metadata timestamp — bumped on every UPDATE
+#   to `module_configs`, DEFAULT CURRENT_TIMESTAMP fires on INSERT.
+#   Useful for ETag-style freshness; do not derive device-liveness from
+#   it.
+# - `last_seen_at` is the device-liveness signal — bumped only on
+#   `add_module` (the firmware's per-boot registration). Backend's
+#   `fetchAndAssemble` folds it into `lastSeenAt = max(last_image_at,
+#   last_seen_at, latestHeartbeat.receivedAt)` and derives
+#   `Module.status` from a 2 h window on that value. Metadata writes
+#   (display_name, heartbeat row-update, geo-patch) must NOT bump it;
+#   only "device was heard from" events should. Prior to the PR B
+#   split, `updated_at` did double duty for both roles, which let a
+#   metadata UPDATE silently flip an offline module to 'online' for
+#   two hours. See chapter 11 "updated_at semantic overload" for the
+#   incident and `issue #97` for the rationale.
 _MODULE_CONFIGS_DDL = """
     CREATE TABLE module_configs (
         id VARCHAR(20) PRIMARY KEY,
@@ -23,6 +41,7 @@ _MODULE_CONFIGS_DDL = """
         image_count INTEGER NOT NULL DEFAULT 0,
         email VARCHAR(255),
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         last_silence_alert_at TIMESTAMP
     )
 """
@@ -36,7 +55,7 @@ _MODULE_CONFIGS_DDL = """
 # `name` on null/empty/whitespace-only). See ADR-011 and #93.
 _MODULE_CONFIGS_COLUMNS = (
     "id, name, display_name, lat, lng, first_online, battery_level, "
-    "image_count, email, updated_at, last_silence_alert_at"
+    "image_count, email, updated_at, last_seen_at, last_silence_alert_at"
 )
 
 _NEST_DATA_DDL = """
@@ -123,6 +142,31 @@ def init_db():
                 "ALTER TABLE module_configs ADD COLUMN updated_at TIMESTAMP "
                 "DEFAULT CURRENT_TIMESTAMP"
             )
+        # Issue #97 / PR B — split `updated_at`'s overloaded semantics.
+        # Pre-split, `updated_at` carried both row-metadata AND device-
+        # liveness signals; only the registration UPSERT in `add_module`
+        # bumped it. After the split, `last_seen_at` owns the liveness
+        # role, and `updated_at` is freely bumped by every UPDATE.
+        #
+        # Backfill from `updated_at` so operator volumes carrying the
+        # pre-split value preserve their "module last seen" timestamp
+        # across the rename — otherwise every offline module would
+        # snap to NOW() on the first boot after the migration and the
+        # 2 h status window would lie.
+        #
+        # The UPDATE is unconditional (no `WHERE last_seen_at IS NULL`)
+        # because DuckDB's `ALTER TABLE ADD COLUMN ... DEFAULT
+        # CURRENT_TIMESTAMP` pre-populates the new column with NOW()
+        # for every existing row — by the time we reach the UPDATE,
+        # `last_seen_at IS NULL` is empty. The block-level
+        # `"last_seen_at" not in existing_cols` gate already makes the
+        # whole migration a one-shot, so the UPDATE never runs twice.
+        if "last_seen_at" not in existing_cols:
+            con.execute(
+                "ALTER TABLE module_configs ADD COLUMN last_seen_at TIMESTAMP "
+                "DEFAULT CURRENT_TIMESTAMP"
+            )
+            con.execute("UPDATE module_configs SET last_seen_at = updated_at")
         # Track Discord-silence-alert state so we don't spam the channel.
         # Set to NOW() when a silence alert fires, cleared on recovery alert.
         if "last_silence_alert_at" not in existing_cols:

--- a/duckdb-service/routes/heartbeats.py
+++ b/duckdb-service/routes/heartbeats.py
@@ -129,16 +129,18 @@ def post_heartbeat():
         #     gates this; the server re-checks for safety),
         #  2) an existing module_configs row sits at the (0,0)
         #     sentinel — we never overwrite a placed module.
-        # Tested via `tests/test_heartbeats_endpoint.py`. Note that we
-        # deliberately do NOT touch `module_configs.updated_at` —
-        # that column has dual semantics (row metadata vs liveness),
-        # see chapter-11 "updated_at semantic overload" / issue #97.
+        # Tested via `tests/test_heartbeats_endpoint.py`. Post-#97 split:
+        # we bump `updated_at` (row-metadata: the row was touched) but
+        # NOT `last_seen_at` — the heartbeat itself is already recorded
+        # in the dedicated `module_heartbeats` table (line 117-124
+        # above), which the backend folds into `Module.lastSeenAt`
+        # separately. Bumping `last_seen_at` here would double-count
+        # the same liveness event.
         if _is_plausible_fix(lat, lng, acc):
             # Column names in `module_configs` are `lat`/`lng` (not
             # `latitude`/`longitude`); the contracts-layer rename to
             # `location.lat/lng` happens in the dto in
-            # `backend/src/database.ts`, not in the DB. Don't touch
-            # `updated_at` here — it's a liveness signal (issue #97).
+            # `backend/src/database.ts`, not in the DB.
             row = con.execute(
                 "SELECT lat, lng FROM module_configs WHERE id = ?",
                 [mac],
@@ -148,7 +150,8 @@ def post_heartbeat():
                 existing_lng = float(row[1]) if row[1] is not None else 0.0
                 if existing_lat == 0.0 and existing_lng == 0.0:
                     con.execute(
-                        "UPDATE module_configs SET lat = ?, lng = ? WHERE id = ?",
+                        "UPDATE module_configs SET lat = ?, lng = ?, "
+                        "updated_at = NOW() WHERE id = ?",
                         [lat, lng, mac],
                     )
                     print(

--- a/duckdb-service/routes/modules.py
+++ b/duckdb-service/routes/modules.py
@@ -242,9 +242,19 @@ def set_display_name(module_id):
             400,
         )
 
-    with lock:
-        con = get_conn()
-        try:
+    # Switched from manual `con = get_conn() / con.commit() /
+    # con.rollback()` to the project's `write_transaction()` helper as
+    # part of #105's fix. DuckDB defaults to autocommit; calling
+    # `con.rollback()` in an exception handler with no active
+    # transaction raises a secondary `TransactionException` which
+    # Flask surfaces as its HTML 500 page — backend's JSON parser then
+    # chokes on the `<!doctype ...` prefix and the operator sees
+    # "Unexpected token '<'" instead of the actual error.
+    # `write_transaction` (db/repository.py) swallows the
+    # "no active transaction" rollback gracefully, so the route's
+    # exception path is now clean.
+    try:
+        with write_transaction() as con:
             existing = con.execute(
                 "SELECT id FROM module_configs WHERE id = ?", (canonical,)
             ).fetchone()
@@ -263,6 +273,9 @@ def set_display_name(module_id):
                     (new_value, canonical),
                 ).fetchone()
                 if clash is not None:
+                    # Returning a non-200 inside the with-block is fine
+                    # — write_transaction commits the empty (no
+                    # mutation) transaction and closes cleanly.
                     return (
                         jsonify(
                             {
@@ -284,12 +297,100 @@ def set_display_name(module_id):
             # module to "online" for two hours regardless of telemetry.
             # See chapter 11 "updated_at semantic overload" and issue #97
             # for the split rationale; PR B carries the fix.
+            #
+            # FK-enforcement workaround for #105: DuckDB 1.4.4 (and 1.5.2,
+            # verified at PR B execution) rejects this UPDATE on any
+            # `module_configs` row whose `id` is referenced by a child
+            # table, even though `display_name` is neither the PK nor an
+            # FK column. The error surfaces as
+            # `ConstraintException: Violates foreign key constraint
+            # because key "module_id: ..." is still referenced`.
+            #
+            # The DuckDB workarounds the issue's reporter suggested don't
+            # exist in DuckDB:
+            #   - `PRAGMA foreign_keys = OFF` is a SQLite pragma, not a
+            #     DuckDB one (DuckDB returns "Catalog Error: unrecognized
+            #     configuration parameter").
+            #   - `ALTER TABLE nest_data DROP CONSTRAINT ...` raises
+            #     `NotImplementedException: No support for that ALTER
+            #     TABLE option yet`.
+            #   - `INSERT INTO module_configs ... ON CONFLICT (id) DO
+            #     UPDATE` hits the SAME FK over-enforcement (DuckDB
+            #     treats the UPSERT branch as a regular UPDATE for FK
+            #     purposes).
+            #
+            # The only workaround DuckDB accepts is to temporarily move
+            # the referencing child rows out of the way: snapshot
+            # `nest_data` + `daily_progress` rows for this module,
+            # delete them in reverse-FK order, run the UPDATE on the
+            # now-unreferenced parent, then re-insert the children. The
+            # full sequence runs inside `write_transaction` so it's
+            # atomic — any failure rolls back to the original state and
+            # the FK invariant is preserved end-to-end.
+            #
+            # Safe because:
+            #   - `display_name` is a non-FK, non-PK column. The end
+            #     state preserves every `nest_data.module_id →
+            #     module_configs.id` reference (children re-inserted
+            #     with identical `module_id`).
+            #   - duckdb-service uses a single shared connection guarded
+            #     by a global `lock` (db/connection.py); write_transaction
+            #     holds the lock for the with-block, so no concurrent
+            #     reader sees the half-deleted state.
+            #   - Bounded blast radius: only this module's children
+            #     move (the `WHERE module_id = ?` filter pins it).
+            #     Typical modules carry <20 nests and <200 progress
+            #     rows over their lifetime.
+            #
+            # See chapter 11 "Admin rename failed silently on seeded
+            # modules" for the incident and the workaround discovery
+            # path.
+            #
+            # Snapshot daily_progress for this module's nests (the
+            # grandchild FK chain).
+            progress_rows = con.execute(
+                """
+                SELECT dp.progress_id, dp.nest_id, dp.date,
+                       dp.empty, dp.sealed, dp.hatched
+                  FROM daily_progress dp
+                  JOIN nest_data n ON n.nest_id = dp.nest_id
+                 WHERE n.module_id = ?
+                """,
+                (canonical,),
+            ).fetchall()
+            nest_rows = con.execute(
+                "SELECT nest_id, module_id, beeType FROM nest_data WHERE module_id = ?",
+                (canonical,),
+            ).fetchall()
+            # Delete in reverse-FK order so each statement is FK-clean
+            # in isolation (DuckDB checks per-statement).
             con.execute(
-                "UPDATE module_configs SET display_name = ?, updated_at = NOW() "
-                "WHERE id = ?",
+                "DELETE FROM daily_progress WHERE nest_id IN "
+                "(SELECT nest_id FROM nest_data WHERE module_id = ?)",
+                (canonical,),
+            )
+            con.execute(
+                "DELETE FROM nest_data WHERE module_id = ?",
+                (canonical,),
+            )
+            con.execute(
+                "UPDATE module_configs SET display_name = ?, "
+                "updated_at = NOW() WHERE id = ?",
                 (new_value, canonical),
             )
-            con.commit()
+            for nest in nest_rows:
+                con.execute(
+                    "INSERT INTO nest_data (nest_id, module_id, beeType) "
+                    "VALUES (?, ?, ?)",
+                    nest,
+                )
+            for prog in progress_rows:
+                con.execute(
+                    "INSERT INTO daily_progress "
+                    "(progress_id, nest_id, date, empty, sealed, hatched) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    prog,
+                )
             return (
                 jsonify(
                     {
@@ -300,11 +401,9 @@ def set_display_name(module_id):
                 ),
                 200,
             )
-        except Exception as e:
-            con.rollback()
-            return jsonify({"error": str(e)}), 500
-        finally:
-            con.close()
+    except Exception as e:
+        print(f"[set_display_name] {type(e).__name__}: {e}", flush=True)
+        return jsonify({"error": str(e)}), 500
 
 
 @modules_bp.delete("/modules/<module_id>")

--- a/duckdb-service/routes/modules.py
+++ b/duckdb-service/routes/modules.py
@@ -357,11 +357,10 @@ def set_display_name(module_id):
                 (canonical,),
             ).fetchall()
 
-            def _restore_children() -> None:
-                """Re-insert the snapshotted children. Called from the
-                exception handler. Idempotent: deletes any partial
-                state first so a re-insert that failed mid-loop on
-                the happy path can be cleanly re-attempted."""
+            def _delete_children() -> None:
+                """DELETE in reverse-FK order so each statement is
+                FK-clean in isolation (DuckDB checks per-statement
+                in autocommit)."""
                 con.execute(
                     "DELETE FROM daily_progress WHERE nest_id IN "
                     "(SELECT nest_id FROM nest_data WHERE module_id = ?)",
@@ -371,6 +370,11 @@ def set_display_name(module_id):
                     "DELETE FROM nest_data WHERE module_id = ?",
                     (canonical,),
                 )
+
+            def _insert_children() -> None:
+                """INSERT the snapshotted children in forward-FK
+                order (nest_data before daily_progress that
+                references it)."""
                 for nest in nest_rows:
                     con.execute(
                         "INSERT INTO nest_data (nest_id, module_id, beeType) "
@@ -385,17 +389,16 @@ def set_display_name(module_id):
                         prog,
                     )
 
+            def _restore_children() -> None:
+                """Compensating-restore: DELETE any partial state
+                from a half-finished dance, then re-INSERT the full
+                snapshot. Idempotent across any intermediate state."""
+                _delete_children()
+                _insert_children()
+
             try:
                 # Phase 1: DELETE children in reverse-FK order.
-                con.execute(
-                    "DELETE FROM daily_progress WHERE nest_id IN "
-                    "(SELECT nest_id FROM nest_data WHERE module_id = ?)",
-                    (canonical,),
-                )
-                con.execute(
-                    "DELETE FROM nest_data WHERE module_id = ?",
-                    (canonical,),
-                )
+                _delete_children()
                 # Phase 2: UPDATE the now-unreferenced parent.
                 con.execute(
                     "UPDATE module_configs SET display_name = ?, "
@@ -403,33 +406,56 @@ def set_display_name(module_id):
                     (new_value, canonical),
                 )
                 # Phase 3: re-insert children.
-                for nest in nest_rows:
-                    con.execute(
-                        "INSERT INTO nest_data (nest_id, module_id, beeType) "
-                        "VALUES (?, ?, ?)",
-                        nest,
-                    )
-                for prog in progress_rows:
-                    con.execute(
-                        "INSERT INTO daily_progress "
-                        "(progress_id, nest_id, date, empty, sealed, hatched) "
-                        "VALUES (?, ?, ?, ?, ?, ?)",
-                        prog,
-                    )
-            except Exception:
+                _insert_children()
+            except Exception as dance_err:
                 # Compensating action: re-establish the children
                 # snapshot. The parent UPDATE may or may not have
                 # landed; we leave it as-is and let the 500 surface
                 # so the operator can retry. The KEY invariant we
                 # restore is "no orphan or missing children".
+                #
+                # If the restore itself raises, the operator needs to
+                # know they've lost data and should restore from
+                # backup — set a flag we'll surface in the response
+                # body. The 500 still fires either way; the body
+                # marker is the difference between "retry the rename"
+                # and "data lost; restore from backup".
+                restore_failed = False
+                restore_err: Exception | None = None
                 try:
                     _restore_children()
-                except Exception as restore_err:
+                except Exception as e:
+                    restore_failed = True
+                    restore_err = e
                     print(
                         f"[set_display_name] CRITICAL: restore failed for "
-                        f"{canonical}: {type(restore_err).__name__}: "
-                        f"{restore_err}",
+                        f"{canonical}: {type(e).__name__}: {e}. Original "
+                        f"dance error: {type(dance_err).__name__}: "
+                        f"{dance_err}. nest_data + daily_progress rows "
+                        f"for this module may be lost; restore from "
+                        f"backup.",
                         flush=True,
+                    )
+                if restore_failed:
+                    return (
+                        jsonify(
+                            {
+                                "error": str(dance_err),
+                                "restore_failed": True,
+                                "restore_error": str(restore_err)
+                                if restore_err is not None
+                                else None,
+                                "module_id": canonical,
+                                "message": (
+                                    "Rename failed AND the compensating "
+                                    "restore of nest_data/daily_progress "
+                                    "raised. Module child rows may be "
+                                    "missing; restore from backup before "
+                                    "retrying."
+                                ),
+                            }
+                        ),
+                        500,
                     )
                 raise
             return (

--- a/duckdb-service/routes/modules.py
+++ b/duckdb-service/routes/modules.py
@@ -329,18 +329,6 @@ def set_display_name(module_id):
                         409,
                     )
 
-            # Bump `updated_at` (row-metadata: the row was touched).
-            # Do NOT bump `last_seen_at` — that column is the device-
-            # liveness signal the backend's `fetchAndAssemble` folds
-            # into `Module.lastSeenAt` (max of last_image_at /
-            # last_seen_at / latestHeartbeat.receivedAt) for the 2 h
-            # status window. An admin edit of the label is not a
-            # heartbeat-equivalent event; bumping `last_seen_at` here
-            # would flip any renamed offline module to "online" for
-            # two hours regardless of telemetry. See chapter 11
-            # "updated_at semantic overload" and issue #97 for the
-            # split rationale; PR B carries the fix.
-            #
             # Snapshot in dependency order so restoration can replay it.
             progress_rows = con.execute(
                 """
@@ -399,7 +387,20 @@ def set_display_name(module_id):
             try:
                 # Phase 1: DELETE children in reverse-FK order.
                 _delete_children()
-                # Phase 2: UPDATE the now-unreferenced parent.
+                # Phase 2: UPDATE the now-unreferenced parent. Bump
+                # `updated_at` (row-metadata: the row was touched).
+                # Do NOT bump `last_seen_at` — that column is the
+                # device-liveness signal the backend's
+                # `fetchAndAssemble` folds into `Module.lastSeenAt`
+                # (max of last_image_at / last_seen_at /
+                # latestHeartbeat.receivedAt) for the 2 h status
+                # window. An admin edit of the label is not a
+                # heartbeat-equivalent event; bumping `last_seen_at`
+                # here would flip any renamed offline module to
+                # "online" for two hours regardless of telemetry.
+                # See chapter 11 "updated_at semantic overload" and
+                # issue #97 for the split rationale; PR B carries
+                # the fix.
                 con.execute(
                     "UPDATE module_configs SET display_name = ?, "
                     "updated_at = NOW() WHERE id = ?",

--- a/duckdb-service/routes/modules.py
+++ b/duckdb-service/routes/modules.py
@@ -242,40 +242,82 @@ def set_display_name(module_id):
             400,
         )
 
-    # Switched from manual `con = get_conn() / con.commit() /
-    # con.rollback()` to the project's `write_transaction()` helper as
-    # part of #105's fix. DuckDB defaults to autocommit; calling
-    # `con.rollback()` in an exception handler with no active
-    # transaction raises a secondary `TransactionException` which
-    # Flask surfaces as its HTML 500 page — backend's JSON parser then
-    # chokes on the `<!doctype ...` prefix and the operator sees
-    # "Unexpected token '<'" instead of the actual error.
-    # `write_transaction` (db/repository.py) swallows the
-    # "no active transaction" rollback gracefully, so the route's
-    # exception path is now clean.
-    try:
-        with write_transaction() as con:
+    # Why this route bypasses `write_transaction`. The helper issues an
+    # explicit `BEGIN` to give multi-statement callers real atomicity
+    # (see db/repository.py / test_write_transaction_rolls_back_partial_writes).
+    # Inside an explicit transaction, DuckDB 1.4.4 (and 1.5.2, verified
+    # at PR B execution) trips the FK over-enforcement on
+    # `UPDATE module_configs SET display_name = ?` because the
+    # transaction snapshot still "sees" the `nest_data` references —
+    # even after we DELETE them in the same transaction. So the
+    # only DuckDB-supported workaround for #105's bug (the temp-table
+    # dance) is incompatible with the helper's BEGIN.
+    #
+    # The dance therefore runs in autocommit mode — each DELETE /
+    # UPDATE / INSERT commits individually, which lets DuckDB's FK
+    # enforcement see each statement's effect immediately and lets the
+    # UPDATE proceed past the now-unreferenced parent row. Atomicity
+    # is provided at the Python layer instead: on any failure we
+    # restore the child rows from the in-memory snapshot before
+    # re-raising. The global `lock` is held for the duration so no
+    # concurrent writer can race with the half-deleted state.
+    #
+    # The compensating-restore approach trades full transactional
+    # atomicity for a recovery semantics that's "best-effort and
+    # observable": if the DELETE phase succeeds and the UPDATE then
+    # fails, we re-insert the children before the operator sees the
+    # error. The remaining failure-window is "DELETE succeeded,
+    # UPDATE succeeded, re-insert raised partway" — recovery does a
+    # DELETE-any-partial + re-insert-full-snapshot to converge.
+    # Operator-visible behaviour: success returns 200; any failure
+    # returns 500 AND leaves the row in its pre-dance state. See
+    # chapter 11 "Admin rename failed silently on seeded modules"
+    # for the full workaround discovery path.
+    #
+    # The DuckDB workarounds the issue's reporter suggested don't
+    # exist in DuckDB:
+    #   - `PRAGMA foreign_keys = OFF` is a SQLite pragma, not a
+    #     DuckDB one (DuckDB returns "Catalog Error: unrecognized
+    #     configuration parameter").
+    #   - `ALTER TABLE nest_data DROP CONSTRAINT ...` raises
+    #     `NotImplementedException: No support for that ALTER
+    #     TABLE option yet`.
+    #   - `INSERT INTO module_configs ... ON CONFLICT (id) DO UPDATE`
+    #     hits the SAME FK over-enforcement when the SET clause
+    #     touches a UNIQUE-constrained column (which `display_name`
+    #     is). Verified empirically; chapter 11 has the receipts.
+    #
+    # Safe because:
+    #   - `display_name` is a non-FK, non-PK column. The end state
+    #     preserves every `nest_data.module_id → module_configs.id`
+    #     reference (children re-inserted with identical `module_id`).
+    #   - duckdb-service serialises writes via a global `lock` (see
+    #     db/connection.py); we hold it for the whole dance, so no
+    #     concurrent reader/writer sees the half-deleted state.
+    #   - Bounded blast radius: only this module's children move
+    #     (the `WHERE module_id = ?` filter pins it). Typical modules
+    #     carry <20 nests and <200 progress rows over their lifetime.
+    with lock:
+        con = get_conn()
+        try:
             existing = con.execute(
                 "SELECT id FROM module_configs WHERE id = ?", (canonical,)
             ).fetchone()
             if not existing:
                 return jsonify({"error": "Module not found"}), 404
 
-            # Skip the UPDATE if a *different* module already holds this
-            # display_name. Catching the UNIQUE-constraint exception
-            # works in principle but DuckDB surfaces it through a
-            # generic ConstraintException whose message format isn't
-            # stable; an explicit pre-check gives a clean 409 with the
-            # actual conflicting MAC.
+            # Skip the UPDATE if a *different* module already holds
+            # this display_name. Catching the UNIQUE-constraint
+            # exception works in principle but DuckDB surfaces it
+            # through a generic ConstraintException whose message
+            # format isn't stable; an explicit pre-check gives a
+            # clean 409 with the actual conflicting MAC.
             if new_value is not None:
                 clash = con.execute(
                     "SELECT id FROM module_configs WHERE display_name = ? AND id != ?",
                     (new_value, canonical),
                 ).fetchone()
                 if clash is not None:
-                    # Returning a non-200 inside the with-block is fine
-                    # — write_transaction commits the empty (no
-                    # mutation) transaction and closes cleanly.
                     return (
                         jsonify(
                             {
@@ -287,67 +329,19 @@ def set_display_name(module_id):
                         409,
                     )
 
-            # Bump `updated_at` (row-metadata: the row was touched). Do
-            # NOT bump `last_seen_at` — that column is the device-liveness
-            # signal the backend's `fetchAndAssemble` folds into
-            # `Module.lastSeenAt` (max of last_image_at / last_seen_at /
-            # latestHeartbeat.receivedAt) for the 2 h status window. An
-            # admin edit of the label is not a heartbeat-equivalent event;
-            # bumping `last_seen_at` here would flip any renamed offline
-            # module to "online" for two hours regardless of telemetry.
-            # See chapter 11 "updated_at semantic overload" and issue #97
-            # for the split rationale; PR B carries the fix.
+            # Bump `updated_at` (row-metadata: the row was touched).
+            # Do NOT bump `last_seen_at` — that column is the device-
+            # liveness signal the backend's `fetchAndAssemble` folds
+            # into `Module.lastSeenAt` (max of last_image_at /
+            # last_seen_at / latestHeartbeat.receivedAt) for the 2 h
+            # status window. An admin edit of the label is not a
+            # heartbeat-equivalent event; bumping `last_seen_at` here
+            # would flip any renamed offline module to "online" for
+            # two hours regardless of telemetry. See chapter 11
+            # "updated_at semantic overload" and issue #97 for the
+            # split rationale; PR B carries the fix.
             #
-            # FK-enforcement workaround for #105: DuckDB 1.4.4 (and 1.5.2,
-            # verified at PR B execution) rejects this UPDATE on any
-            # `module_configs` row whose `id` is referenced by a child
-            # table, even though `display_name` is neither the PK nor an
-            # FK column. The error surfaces as
-            # `ConstraintException: Violates foreign key constraint
-            # because key "module_id: ..." is still referenced`.
-            #
-            # The DuckDB workarounds the issue's reporter suggested don't
-            # exist in DuckDB:
-            #   - `PRAGMA foreign_keys = OFF` is a SQLite pragma, not a
-            #     DuckDB one (DuckDB returns "Catalog Error: unrecognized
-            #     configuration parameter").
-            #   - `ALTER TABLE nest_data DROP CONSTRAINT ...` raises
-            #     `NotImplementedException: No support for that ALTER
-            #     TABLE option yet`.
-            #   - `INSERT INTO module_configs ... ON CONFLICT (id) DO
-            #     UPDATE` hits the SAME FK over-enforcement (DuckDB
-            #     treats the UPSERT branch as a regular UPDATE for FK
-            #     purposes).
-            #
-            # The only workaround DuckDB accepts is to temporarily move
-            # the referencing child rows out of the way: snapshot
-            # `nest_data` + `daily_progress` rows for this module,
-            # delete them in reverse-FK order, run the UPDATE on the
-            # now-unreferenced parent, then re-insert the children. The
-            # full sequence runs inside `write_transaction` so it's
-            # atomic — any failure rolls back to the original state and
-            # the FK invariant is preserved end-to-end.
-            #
-            # Safe because:
-            #   - `display_name` is a non-FK, non-PK column. The end
-            #     state preserves every `nest_data.module_id →
-            #     module_configs.id` reference (children re-inserted
-            #     with identical `module_id`).
-            #   - duckdb-service uses a single shared connection guarded
-            #     by a global `lock` (db/connection.py); write_transaction
-            #     holds the lock for the with-block, so no concurrent
-            #     reader sees the half-deleted state.
-            #   - Bounded blast radius: only this module's children
-            #     move (the `WHERE module_id = ?` filter pins it).
-            #     Typical modules carry <20 nests and <200 progress
-            #     rows over their lifetime.
-            #
-            # See chapter 11 "Admin rename failed silently on seeded
-            # modules" for the incident and the workaround discovery
-            # path.
-            #
-            # Snapshot daily_progress for this module's nests (the
-            # grandchild FK chain).
+            # Snapshot in dependency order so restoration can replay it.
             progress_rows = con.execute(
                 """
                 SELECT dp.progress_id, dp.nest_id, dp.date,
@@ -362,35 +356,82 @@ def set_display_name(module_id):
                 "SELECT nest_id, module_id, beeType FROM nest_data WHERE module_id = ?",
                 (canonical,),
             ).fetchall()
-            # Delete in reverse-FK order so each statement is FK-clean
-            # in isolation (DuckDB checks per-statement).
-            con.execute(
-                "DELETE FROM daily_progress WHERE nest_id IN "
-                "(SELECT nest_id FROM nest_data WHERE module_id = ?)",
-                (canonical,),
-            )
-            con.execute(
-                "DELETE FROM nest_data WHERE module_id = ?",
-                (canonical,),
-            )
-            con.execute(
-                "UPDATE module_configs SET display_name = ?, "
-                "updated_at = NOW() WHERE id = ?",
-                (new_value, canonical),
-            )
-            for nest in nest_rows:
+
+            def _restore_children() -> None:
+                """Re-insert the snapshotted children. Called from the
+                exception handler. Idempotent: deletes any partial
+                state first so a re-insert that failed mid-loop on
+                the happy path can be cleanly re-attempted."""
                 con.execute(
-                    "INSERT INTO nest_data (nest_id, module_id, beeType) "
-                    "VALUES (?, ?, ?)",
-                    nest,
+                    "DELETE FROM daily_progress WHERE nest_id IN "
+                    "(SELECT nest_id FROM nest_data WHERE module_id = ?)",
+                    (canonical,),
                 )
-            for prog in progress_rows:
                 con.execute(
-                    "INSERT INTO daily_progress "
-                    "(progress_id, nest_id, date, empty, sealed, hatched) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    prog,
+                    "DELETE FROM nest_data WHERE module_id = ?",
+                    (canonical,),
                 )
+                for nest in nest_rows:
+                    con.execute(
+                        "INSERT INTO nest_data (nest_id, module_id, beeType) "
+                        "VALUES (?, ?, ?)",
+                        nest,
+                    )
+                for prog in progress_rows:
+                    con.execute(
+                        "INSERT INTO daily_progress "
+                        "(progress_id, nest_id, date, empty, sealed, hatched) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        prog,
+                    )
+
+            try:
+                # Phase 1: DELETE children in reverse-FK order.
+                con.execute(
+                    "DELETE FROM daily_progress WHERE nest_id IN "
+                    "(SELECT nest_id FROM nest_data WHERE module_id = ?)",
+                    (canonical,),
+                )
+                con.execute(
+                    "DELETE FROM nest_data WHERE module_id = ?",
+                    (canonical,),
+                )
+                # Phase 2: UPDATE the now-unreferenced parent.
+                con.execute(
+                    "UPDATE module_configs SET display_name = ?, "
+                    "updated_at = NOW() WHERE id = ?",
+                    (new_value, canonical),
+                )
+                # Phase 3: re-insert children.
+                for nest in nest_rows:
+                    con.execute(
+                        "INSERT INTO nest_data (nest_id, module_id, beeType) "
+                        "VALUES (?, ?, ?)",
+                        nest,
+                    )
+                for prog in progress_rows:
+                    con.execute(
+                        "INSERT INTO daily_progress "
+                        "(progress_id, nest_id, date, empty, sealed, hatched) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        prog,
+                    )
+            except Exception:
+                # Compensating action: re-establish the children
+                # snapshot. The parent UPDATE may or may not have
+                # landed; we leave it as-is and let the 500 surface
+                # so the operator can retry. The KEY invariant we
+                # restore is "no orphan or missing children".
+                try:
+                    _restore_children()
+                except Exception as restore_err:
+                    print(
+                        f"[set_display_name] CRITICAL: restore failed for "
+                        f"{canonical}: {type(restore_err).__name__}: "
+                        f"{restore_err}",
+                        flush=True,
+                    )
+                raise
             return (
                 jsonify(
                     {
@@ -401,9 +442,11 @@ def set_display_name(module_id):
                 ),
                 200,
             )
-    except Exception as e:
-        print(f"[set_display_name] {type(e).__name__}: {e}", flush=True)
-        return jsonify({"error": str(e)}), 500
+        except Exception as e:
+            print(f"[set_display_name] {type(e).__name__}: {e}", flush=True)
+            return jsonify({"error": str(e)}), 500
+        finally:
+            con.close()
 
 
 @modules_bp.delete("/modules/<module_id>")

--- a/duckdb-service/routes/modules.py
+++ b/duckdb-service/routes/modules.py
@@ -100,11 +100,20 @@ def add_module():
             # from either side. Pinned by
             # `test_new_module_re_registration_does_not_clobber_recovered_location`
             # in `tests/test_modules.py`.
+            # `add_module` is the ONLY writer that bumps `last_seen_at` —
+            # that column is the device-liveness signal the backend's
+            # `fetchAndAssemble` folds into `Module.lastSeenAt` for the
+            # 2 h status window (issue #97 / PR B). Every other UPDATE on
+            # `module_configs` (display_name rename, heartbeat row-patch,
+            # heartbeat-side geo-patch) is row-metadata and bumps only
+            # `updated_at`. Re-registration is a "device was heard from"
+            # event, so the UPSERT path bumps both.
             con.execute(
                 """
                 INSERT INTO module_configs
-                    (id, name, lat, lng, first_online, battery_level, email, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, NOW())
+                    (id, name, lat, lng, first_online, battery_level, email,
+                     updated_at, last_seen_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
                 ON CONFLICT (id) DO UPDATE SET
                     name = EXCLUDED.name,
                     lat = CASE
@@ -121,7 +130,8 @@ def add_module():
                     END,
                     battery_level = EXCLUDED.battery_level,
                     email = EXCLUDED.email,
-                    updated_at = NOW()
+                    updated_at = NOW(),
+                    last_seen_at = NOW()
                 """,
                 (
                     mac_str,
@@ -264,19 +274,19 @@ def set_display_name(module_id):
                         409,
                     )
 
-            # Do NOT bump `updated_at`. That column is the liveness
-            # timestamp the backend's `fetchAndAssemble` folds into
-            # `lastSeenAt` (max of last_image_at / updated_at /
-            # latestHeartbeat.receivedAt) and uses to derive
-            # `Module.status` within a 2 h window. An admin edit of
-            # the *label* is not a heartbeat-equivalent event; bumping
-            # `updated_at` here would flip any renamed offline module
-            # to "online" for two hours regardless of telemetry.
-            # See `contracts/src/index.ts` Module.updatedAt — "set on
-            # every registration/UPSERT" — which this route honours by
-            # leaving it alone.
+            # Bump `updated_at` (row-metadata: the row was touched). Do
+            # NOT bump `last_seen_at` — that column is the device-liveness
+            # signal the backend's `fetchAndAssemble` folds into
+            # `Module.lastSeenAt` (max of last_image_at / last_seen_at /
+            # latestHeartbeat.receivedAt) for the 2 h status window. An
+            # admin edit of the label is not a heartbeat-equivalent event;
+            # bumping `last_seen_at` here would flip any renamed offline
+            # module to "online" for two hours regardless of telemetry.
+            # See chapter 11 "updated_at semantic overload" and issue #97
+            # for the split rationale; PR B carries the fix.
             con.execute(
-                "UPDATE module_configs SET display_name = ? WHERE id = ?",
+                "UPDATE module_configs SET display_name = ?, updated_at = NOW() "
+                "WHERE id = ?",
                 (new_value, canonical),
             )
             con.commit()
@@ -407,14 +417,16 @@ def get_modules():
         modules = query_all(
             """
             SELECT m.id, m.name, m.display_name, m.lat, m.lng, m.first_online,
-                   m.battery_level, m.image_count, m.email, m.updated_at,
+                   m.battery_level, m.image_count, m.email,
+                   m.updated_at, m.last_seen_at,
                    m.last_silence_alert_at,
                    COUNT(i.id) AS real_image_count,
                    MAX(i.uploaded_at) AS last_image_at
             FROM module_configs m
             LEFT JOIN image_uploads i ON m.id = i.module_id
             GROUP BY m.id, m.name, m.display_name, m.lat, m.lng, m.first_online,
-                     m.battery_level, m.image_count, m.email, m.updated_at,
+                     m.battery_level, m.image_count, m.email,
+                     m.updated_at, m.last_seen_at,
                      m.last_silence_alert_at
             """
         )
@@ -474,12 +486,20 @@ def heartbeat(module_id):
         # INSERT). The schema declares `NOT NULL`, so this branch is
         # unreachable in production but defensive against legacy /
         # manually-inserted rows. Background: issue #75.
+        #
+        # `updated_at` is bumped (row was touched). `last_seen_at` is
+        # NOT bumped here — the legacy /modules/<id>/heartbeat route
+        # records battery + image_count metadata; the new heartbeat
+        # path (`heartbeats.py::post_heartbeat`) writes to the dedicated
+        # `module_heartbeats` table, which the backend folds into
+        # liveness separately. See issue #97 / PR B split.
         con.execute(
             """
             UPDATE module_configs
             SET battery_level = ?,
                 first_online = COALESCE(first_online, ?),
-                image_count = image_count + 1
+                image_count = image_count + 1,
+                updated_at = NOW()
             WHERE id = ?
             """,
             (battery, now, canonical),

--- a/duckdb-service/services/silence_watcher.py
+++ b/duckdb-service/services/silence_watcher.py
@@ -3,8 +3,10 @@ Silence watcher — periodic check that fires Discord alerts when a module
 goes quiet, and a recovery message when it comes back.
 
 Considers any of three liveness signals: module re-registration
-(`module_configs.updated_at`), most recent image upload, most recent
-heartbeat. Whichever is freshest wins.
+(`module_configs.last_seen_at`), most recent image upload, most recent
+heartbeat. Whichever is freshest wins. (Pre-#97 split this read
+`module_configs.updated_at`; that column is now row-metadata only —
+see chapter 11 "updated_at semantic overload".)
 """
 
 from datetime import datetime
@@ -38,7 +40,7 @@ def check_silence():
             """
             SELECT m.id,
                    m.name,
-                   m.updated_at,
+                   m.last_seen_at,
                    m.last_silence_alert_at,
                    (SELECT MAX(uploaded_at)
                       FROM image_uploads
@@ -51,11 +53,11 @@ def check_silence():
         ).fetchall()
 
         for row in rows:
-            mid, name, updated_at, alerted_at, last_image_at, last_hb_at = row
+            mid, name, last_seen_at, alerted_at, last_image_at, last_hb_at = row
 
             # lastSeenAt = freshest of the three liveness signals; ignore NULLs.
             candidates = [
-                t for t in (updated_at, last_image_at, last_hb_at) if t is not None
+                t for t in (last_seen_at, last_image_at, last_hb_at) if t is not None
             ]
             if not candidates:
                 continue  # never seen — don't alert; setup is in progress.

--- a/duckdb-service/tests/test_heartbeats_endpoint.py
+++ b/duckdb-service/tests/test_heartbeats_endpoint.py
@@ -281,3 +281,75 @@ def test_heartbeat_with_lat_lng_for_unregistered_module_does_not_crash(
     )
     assert resp.status_code == 200
     # No row to fetch — assertion is just "we didn't 500".
+
+
+def test_heartbeat_geo_patch_bumps_updated_at_not_last_seen_at(client, fresh_db):
+    """Post-#97 split: the (0,0) → real-fix recovery is a row-metadata
+    write (the row was touched). It MUST bump `updated_at` but MUST
+    NOT bump `last_seen_at` — the heartbeat itself is already
+    recorded in the `module_heartbeats` table (which the backend
+    folds into the derived `lastSeenAt` separately), so bumping
+    `last_seen_at` here would double-count the same liveness event.
+
+    The test seeds a module at (0,0) using `add_module` (the normal
+    registration path), waits, fires a plausible-fix heartbeat, and
+    asserts the timestamp deltas."""
+    import time
+
+    # Seed via the normal registration path so both timestamps start
+    # at a known value.
+    resp = client.post(
+        "/new_module",
+        json={
+            "esp_id": CANONICAL_MAC,
+            "module_name": "TestHive",
+            "latitude": 0.0,
+            "longitude": 0.0,
+            "battery_level": 80,
+        },
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+    con = fresh_db.connection.get_conn()
+    try:
+        before_updated, before_seen = con.execute(
+            "SELECT updated_at, last_seen_at FROM module_configs WHERE id = ?",
+            (CANONICAL_MAC,),
+        ).fetchone()
+    finally:
+        con.close()
+
+    time.sleep(0.01)
+
+    resp = client.post(
+        "/heartbeat",
+        data={
+            "mac": CANONICAL_MAC,
+            "battery": 50,
+            "latitude": "47.79",
+            "longitude": "9.62",
+            "accuracy": "50",
+        },
+    )
+    assert resp.status_code == 200
+
+    con = fresh_db.connection.get_conn()
+    try:
+        after_updated, after_seen = con.execute(
+            "SELECT updated_at, last_seen_at FROM module_configs WHERE id = ?",
+            (CANONICAL_MAC,),
+        ).fetchone()
+    finally:
+        con.close()
+
+    # Sanity: the geo-patch fired, so lat/lng changed from (0,0).
+    assert _fetch_module_lat_lng(fresh_db, CANONICAL_MAC) == (47.79, 9.62)
+    assert after_updated > before_updated, (
+        f"updated_at must move on geo-patch (row was touched); "
+        f"was {before_updated!r}, is {after_updated!r}"
+    )
+    assert after_seen == before_seen, (
+        f"last_seen_at must NOT move on geo-patch (the liveness was "
+        f"already recorded in module_heartbeats); "
+        f"was {before_seen!r}, is {after_seen!r}"
+    )

--- a/duckdb-service/tests/test_modules.py
+++ b/duckdb-service/tests/test_modules.py
@@ -412,26 +412,31 @@ def test_patch_display_name_rejects_non_string(client, fresh_db):
     assert r.status_code == 400
 
 
-def test_patch_display_name_does_not_bump_updated_at(client, fresh_db):
-    """Renaming is a metadata edit, not a liveness event. `updated_at`
-    drives `Module.lastSeenAt` and the 2 h online window in
-    `backend/src/database.ts::fetchAndAssemble`; bumping it on rename
-    would flip any renamed offline module to "online" for two hours
-    regardless of telemetry. Regression for PR-I senior review."""
+def test_patch_display_name_bumps_updated_at_not_last_seen_at(client, fresh_db):
+    """Post-#97 split: renaming is a row-metadata edit (bumps
+    `updated_at`) but NOT a liveness event (does NOT bump
+    `last_seen_at`). The backend's `fetchAndAssemble` folds
+    `last_seen_at` into `Module.lastSeenAt` for the 2 h status window,
+    so bumping `last_seen_at` on rename would flip any renamed offline
+    module to "online" for two hours regardless of telemetry. This is
+    the inverted form of the pre-#97-split regression test (which
+    pinned `updated_at` unchanged, because back then `updated_at` did
+    double duty for both roles)."""
     import time
 
     client.post("/new_module", json=_payload(TEST_MAC_A, "BeeOne"))
 
     con = fresh_db.connection.get_conn()
     try:
-        before = con.execute(
-            "SELECT updated_at FROM module_configs WHERE id = ?", (TEST_MAC_A,)
-        ).fetchone()[0]
+        before_updated, before_seen = con.execute(
+            "SELECT updated_at, last_seen_at FROM module_configs WHERE id = ?",
+            (TEST_MAC_A,),
+        ).fetchone()
     finally:
         con.close()
 
-    # Force a measurable gap so any bump would surface as a non-equal
-    # value, not a sub-second tie.
+    # Force a measurable gap so any bump surfaces as a non-equal value,
+    # not a sub-second tie.
     time.sleep(0.01)
 
     r = client.patch(
@@ -441,13 +446,19 @@ def test_patch_display_name_does_not_bump_updated_at(client, fresh_db):
 
     con = fresh_db.connection.get_conn()
     try:
-        after = con.execute(
-            "SELECT updated_at FROM module_configs WHERE id = ?", (TEST_MAC_A,)
-        ).fetchone()[0]
+        after_updated, after_seen = con.execute(
+            "SELECT updated_at, last_seen_at FROM module_configs WHERE id = ?",
+            (TEST_MAC_A,),
+        ).fetchone()
     finally:
         con.close()
-    assert after == before, (
-        f"updated_at must not move on rename; was {before!r}, is {after!r}"
+    assert after_updated > before_updated, (
+        f"updated_at must move on rename (row was touched); "
+        f"was {before_updated!r}, is {after_updated!r}"
+    )
+    assert after_seen == before_seen, (
+        f"last_seen_at must NOT move on rename (not a liveness event); "
+        f"was {before_seen!r}, is {after_seen!r}"
     )
 
 
@@ -490,3 +501,94 @@ def test_add_module_accepts_module_name_at_100_chars(client, fresh_db):
     r = client.post("/new_module", json=_payload(TEST_MAC_A, exactly_100))
     assert r.status_code == 200
     assert r.get_json()["name"] == exactly_100
+
+
+def test_add_module_re_registration_bumps_both_timestamps(client, fresh_db):
+    """Post-#97 split: `add_module` is the only writer that bumps
+    `last_seen_at` (the device-liveness signal). It also bumps
+    `updated_at` because the row was touched (the new "bump on every
+    write" rule for row-metadata). Both timestamps must advance on a
+    re-registration UPSERT.
+
+    The companion `test_patch_display_name_bumps_updated_at_not_last_seen_at`
+    pins the inverse for metadata-only writes."""
+    import time
+
+    client.post("/new_module", json=_payload(TEST_MAC_A, "BeeOne"))
+
+    con = fresh_db.connection.get_conn()
+    try:
+        before_updated, before_seen = con.execute(
+            "SELECT updated_at, last_seen_at FROM module_configs WHERE id = ?",
+            (TEST_MAC_A,),
+        ).fetchone()
+    finally:
+        con.close()
+
+    time.sleep(0.01)
+
+    # Re-register the same MAC (the ON CONFLICT path of `add_module`).
+    r = client.post("/new_module", json=_payload(TEST_MAC_A, "BeeOne"))
+    assert r.status_code == 200
+
+    con = fresh_db.connection.get_conn()
+    try:
+        after_updated, after_seen = con.execute(
+            "SELECT updated_at, last_seen_at FROM module_configs WHERE id = ?",
+            (TEST_MAC_A,),
+        ).fetchone()
+    finally:
+        con.close()
+    assert after_updated > before_updated, (
+        f"updated_at must move on re-registration; "
+        f"was {before_updated!r}, is {after_updated!r}"
+    )
+    assert after_seen > before_seen, (
+        f"last_seen_at must move on re-registration (the only writer "
+        f"that bumps it); was {before_seen!r}, is {after_seen!r}"
+    )
+
+
+def test_legacy_heartbeat_bumps_updated_at_not_last_seen_at(client, fresh_db):
+    """The legacy `/modules/<id>/heartbeat` route updates battery +
+    image_count metadata; it does NOT represent a registration event.
+    Post-#97 split, this route bumps `updated_at` (row was touched)
+    but not `last_seen_at` (the new heartbeat path
+    `heartbeats.py::post_heartbeat` writes to `module_heartbeats` and
+    the backend folds that into the derived liveness separately).
+    Pinning the contract so a future refactor that accidentally
+    promotes legacy heartbeat to a liveness signal trips this test."""
+    import time
+
+    client.post("/new_module", json=_payload(TEST_MAC_A, "BeeOne"))
+
+    con = fresh_db.connection.get_conn()
+    try:
+        before_updated, before_seen = con.execute(
+            "SELECT updated_at, last_seen_at FROM module_configs WHERE id = ?",
+            (TEST_MAC_A,),
+        ).fetchone()
+    finally:
+        con.close()
+
+    time.sleep(0.01)
+
+    r = client.post(f"/modules/{TEST_MAC_A}/heartbeat", json={"battery": 73})
+    assert r.status_code == 200, r.get_json()
+
+    con = fresh_db.connection.get_conn()
+    try:
+        after_updated, after_seen = con.execute(
+            "SELECT updated_at, last_seen_at FROM module_configs WHERE id = ?",
+            (TEST_MAC_A,),
+        ).fetchone()
+    finally:
+        con.close()
+    assert after_updated > before_updated, (
+        f"updated_at must move on legacy heartbeat; "
+        f"was {before_updated!r}, is {after_updated!r}"
+    )
+    assert after_seen == before_seen, (
+        f"last_seen_at must NOT move on legacy heartbeat (not a "
+        f"registration event); was {before_seen!r}, is {after_seen!r}"
+    )

--- a/duckdb-service/tests/test_modules.py
+++ b/duckdb-service/tests/test_modules.py
@@ -601,6 +601,215 @@ def test_set_display_name_works_on_module_with_nest_data(client, fresh_db):
     assert orphans == 0, "the FK invariant must hold after the workaround"
 
 
+def test_set_display_name_preserves_full_fk_chain_nest_and_progress(client, fresh_db):
+    """Issue #105 — the temp-table dance must restore BOTH FK arms:
+    `nest_data` AND `daily_progress`. The dance deletes in reverse-FK
+    order (daily_progress first, nest_data second) and re-inserts in
+    forward-FK order. This test seeds both arms and asserts they
+    survive the rename intact.
+
+    Without this test, a refactor that only restored nest_data would
+    pass `test_set_display_name_works_on_module_with_nest_data` but
+    silently drop the operator's image-classification history."""
+    client.post("/new_module", json=_payload(TEST_MAC_A, "BeeOne"))
+
+    con = fresh_db.connection.get_conn()
+    try:
+        con.execute(
+            "INSERT INTO nest_data (nest_id, module_id, beeType) VALUES (?, ?, ?)",
+            ("nest-fc-1", TEST_MAC_A, "blackmasked"),
+        )
+        con.execute(
+            "INSERT INTO nest_data (nest_id, module_id, beeType) VALUES (?, ?, ?)",
+            ("nest-fc-2", TEST_MAC_A, "resin"),
+        )
+        con.execute(
+            "INSERT INTO daily_progress "
+            "(progress_id, nest_id, date, empty, sealed, hatched) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("prog-fc-1", "nest-fc-1", "2026-05-01", 3, 12, 4),
+        )
+        con.execute(
+            "INSERT INTO daily_progress "
+            "(progress_id, nest_id, date, empty, sealed, hatched) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("prog-fc-2", "nest-fc-2", "2026-05-02", 5, 7, 2),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    r = client.patch(
+        f"/modules/{TEST_MAC_A}/display_name",
+        json={"display_name": "DanceFull"},
+    )
+    assert r.status_code == 200, r.get_json()
+
+    # Both FK arms must survive intact — IDs, FK references, and the
+    # payload columns (empty/sealed/hatched) all preserved verbatim.
+    con = fresh_db.connection.get_conn()
+    try:
+        nests = sorted(
+            con.execute(
+                "SELECT nest_id, module_id, beeType FROM nest_data "
+                "WHERE module_id = ? ORDER BY nest_id",
+                (TEST_MAC_A,),
+            ).fetchall()
+        )
+        progress = sorted(
+            con.execute(
+                "SELECT progress_id, nest_id, date, empty, sealed, hatched "
+                "FROM daily_progress WHERE nest_id IN "
+                "(SELECT nest_id FROM nest_data WHERE module_id = ?) "
+                "ORDER BY progress_id",
+                (TEST_MAC_A,),
+            ).fetchall()
+        )
+    finally:
+        con.close()
+
+    assert len(nests) == 2
+    assert nests[0][0] == "nest-fc-1" and nests[0][2] == "blackmasked"
+    assert nests[1][0] == "nest-fc-2" and nests[1][2] == "resin"
+    assert len(progress) == 2
+    # Payload columns survive verbatim through the snapshot+restore.
+    assert progress[0][3:] == (3, 12, 4), progress
+    assert progress[1][3:] == (5, 7, 2), progress
+
+
+def test_set_display_name_restores_children_on_mid_dance_failure(client, fresh_db):
+    """Issue #105 / senior-review round 1 — pin the compensating-restore
+    contract. If the dance fails partway through (e.g. the re-insert
+    phase trips a constraint), the route MUST restore the children
+    from the snapshot before the 500 surfaces.
+
+    Without compensating restore, a partial failure would leave the
+    operator with a module that's lost its nests/progress permanently —
+    the worst kind of silent data loss because the operator just sees
+    'Save failed' and retries with no idea anything else broke.
+
+    We force a mid-dance failure by monkey-patching the route's
+    `_restore_children` upcall: NO — that wouldn't be representative.
+    Instead we trigger a real failure: seed a `nest_data` row with a
+    pre-existing `nest_id` that will collide on re-insert (the dance
+    DELETEs and re-INSERTs by snapshot; a PK collision can't happen
+    on the same snapshot it was read from, so we synthesise one by
+    pre-inserting a sibling `nest_data` row whose `nest_id` matches
+    one in the snapshot).
+
+    Actually the cleanest forcing function is via the `daily_progress`
+    arm: insert a `daily_progress` row whose `progress_id` matches a
+    snapshotted progress_id. After the snapshot, before the dance, we
+    inject a row that ISN'T deleted (different nest_id, same
+    progress_id) so when the dance's re-insert phase runs, the PK
+    collision fires. The compensating restore must put the original
+    children back."""
+    client.post("/new_module", json=_payload(TEST_MAC_A, "BeeOne"))
+    client.post("/new_module", json=_payload(TEST_MAC_B, "BeeTwo"))
+
+    con = fresh_db.connection.get_conn()
+    try:
+        # Seed module A with one nest + one progress row.
+        con.execute(
+            "INSERT INTO nest_data (nest_id, module_id, beeType) VALUES (?, ?, ?)",
+            ("nest-rescue-1", TEST_MAC_A, "blackmasked"),
+        )
+        con.execute(
+            "INSERT INTO daily_progress "
+            "(progress_id, nest_id, date, empty, sealed, hatched) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("prog-rescue-1", "nest-rescue-1", "2026-05-01", 3, 12, 4),
+        )
+        # Seed module B with a nest whose nest_id matches what we'll
+        # need NOT to collide with — actually, the cleanest forcing
+        # path is to monkey-patch `con.execute` at the route level
+        # rather than from outside. We can't easily monkey-patch the
+        # route's connection from here because get_conn() returns a
+        # fresh con per call. Instead, we lean on a different forcing
+        # function: insert a `nest_data` row referencing module B but
+        # using nest_id "nest-rescue-1" — that's not possible because
+        # `nest_id` is a PRIMARY KEY, so the seed insertion above
+        # blocks any duplicate. The forcing function is therefore
+        # synthetic: corrupt the snapshot path by patching the
+        # connection's `execute` method just before the re-insert
+        # phase. This is a unit-test fault-injection, not a
+        # representative failure mode, but it exercises the same code
+        # path the operator-visible failure would trigger.
+        con.commit()
+    finally:
+        con.close()
+
+    # Take an in-route fault-injection approach: wrap the duckdb
+    # connection in a thin proxy that fails on the FIRST
+    # "INSERT INTO nest_data" call (the dance's first re-insert in
+    # phase 3). Direct attribute-patching of a DuckDBPyConnection
+    # doesn't work because its attributes are read-only, so we use
+    # a wrapper class that delegates everything except `execute`.
+    import routes.modules as routes_modules
+
+    real_get_conn = routes_modules.get_conn
+    call_counter = {"nest_inserts": 0}
+
+    class _FaultInjectingConn:
+        def __init__(self, real_con):
+            self._con = real_con
+
+        def execute(self, sql, params=None):
+            if "INSERT INTO nest_data" in sql:
+                call_counter["nest_inserts"] += 1
+                if call_counter["nest_inserts"] == 1:
+                    raise RuntimeError("injected fault: re-insert failure")
+            if params is None:
+                return self._con.execute(sql)
+            return self._con.execute(sql, params)
+
+        def __getattr__(self, name):
+            return getattr(self._con, name)
+
+    def patched_get_conn():
+        return _FaultInjectingConn(real_get_conn())
+
+    import unittest.mock as _mock
+
+    with _mock.patch.object(routes_modules, "get_conn", patched_get_conn):
+        r = client.patch(
+            f"/modules/{TEST_MAC_A}/display_name",
+            json={"display_name": "ShouldFail"},
+        )
+
+    assert r.status_code == 500, r.get_json()
+
+    # Now the critical assertion: the children must be restored, even
+    # though the dance failed mid-re-insert.
+    con = fresh_db.connection.get_conn()
+    try:
+        nest_count = con.execute(
+            "SELECT COUNT(*) FROM nest_data WHERE module_id = ?",
+            (TEST_MAC_A,),
+        ).fetchone()[0]
+        progress_count = con.execute(
+            "SELECT COUNT(*) FROM daily_progress WHERE nest_id IN "
+            "(SELECT nest_id FROM nest_data WHERE module_id = ?)",
+            (TEST_MAC_A,),
+        ).fetchone()[0]
+        orphans = con.execute(
+            "SELECT COUNT(*) FROM nest_data n "
+            "LEFT JOIN module_configs m ON m.id = n.module_id "
+            "WHERE m.id IS NULL"
+        ).fetchone()[0]
+    finally:
+        con.close()
+
+    assert nest_count == 1, (
+        f"compensating restore must put the snapshotted nest back; found {nest_count}"
+    )
+    assert progress_count == 1, (
+        f"compensating restore must put the snapshotted progress back; "
+        f"found {progress_count}"
+    )
+    assert orphans == 0, "FK invariant must hold after the rescue"
+
+
 def test_set_display_name_409_collision_still_works_with_nest_data(client, fresh_db):
     """The FK workaround for #105 must not regress the existing UNIQUE
     collision contract. Seed two modules — both with nest_data rows —

--- a/duckdb-service/tests/test_modules.py
+++ b/duckdb-service/tests/test_modules.py
@@ -785,6 +785,86 @@ def test_set_display_name_restores_children_on_mid_dance_failure(client, fresh_d
     assert orphans == 0, "FK invariant must hold after the rescue"
 
 
+def test_set_display_name_surfaces_restore_failed_marker_on_double_failure(
+    client, fresh_db
+):
+    """Issue #105 / senior-review round 2 P1 — pin the
+    `restore_failed: true` 500-body marker shape. The compensating
+    restore is best-effort; if it itself raises, the operator needs to
+    know data may be lost. The 500 body must carry a stable
+    machine-readable flag so the backend can render "restore from
+    backup" rather than "retry".
+
+    The fault injection here raises on EVERY ``INSERT INTO nest_data``
+    so both the dance's phase-3 re-insert AND the compensating
+    `_restore_children`'s inner re-insert fail. The outer route then
+    serves a 500 with `restore_failed: true` instead of re-raising the
+    original dance error.
+
+    Without this test, a refactor that drops the `restore_failed` flag
+    (e.g. simplifying the inner-except to a plain ``raise dance_err``)
+    would pass `test_set_display_name_restores_children_on_mid_dance_failure`
+    while silently killing the contract that ADR-013 documents."""
+    client.post("/new_module", json=_payload(TEST_MAC_A, "BeeOne"))
+
+    con = fresh_db.connection.get_conn()
+    try:
+        con.execute(
+            "INSERT INTO nest_data (nest_id, module_id, beeType) VALUES (?, ?, ?)",
+            ("nest-restore-fail-1", TEST_MAC_A, "blackmasked"),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    import routes.modules as routes_modules
+
+    real_get_conn = routes_modules.get_conn
+
+    class _FaultInjectingConnAlways:
+        """Like the proxy in
+        `test_set_display_name_restores_children_on_mid_dance_failure`
+        but raises on EVERY ``INSERT INTO nest_data`` — so the
+        dance's phase-3 re-insert fails AND the compensating restore's
+        inner re-insert also fails, triggering the restore-failed
+        branch."""
+
+        def __init__(self, real_con):
+            self._con = real_con
+
+        def execute(self, sql, params=None):
+            if "INSERT INTO nest_data" in sql:
+                raise RuntimeError("injected fault: restore phase also fails")
+            if params is None:
+                return self._con.execute(sql)
+            return self._con.execute(sql, params)
+
+        def __getattr__(self, name):
+            return getattr(self._con, name)
+
+    def patched_get_conn():
+        return _FaultInjectingConnAlways(real_get_conn())
+
+    import unittest.mock as _mock
+
+    with _mock.patch.object(routes_modules, "get_conn", patched_get_conn):
+        r = client.patch(
+            f"/modules/{TEST_MAC_A}/display_name",
+            json={"display_name": "ShouldFailTwice"},
+        )
+
+    assert r.status_code == 500
+    assert r.content_type.startswith("application/json"), r.data[:200]
+    body = r.get_json()
+    # Stable shape the backend will render against — drift on any
+    # of these keys is a contract break.
+    assert body["restore_failed"] is True, body
+    assert body["module_id"] == TEST_MAC_A, body
+    assert "error" in body, body
+    assert "restore_error" in body, body
+    assert "restore from backup" in body["message"].lower(), body
+
+
 def test_set_display_name_409_collision_still_works_with_nest_data(client, fresh_db):
     """The FK workaround for #105 must not regress the existing UNIQUE
     collision contract. Seed two modules — both with nest_data rows —

--- a/duckdb-service/tests/test_modules.py
+++ b/duckdb-service/tests/test_modules.py
@@ -680,30 +680,20 @@ def test_set_display_name_preserves_full_fk_chain_nest_and_progress(client, fres
 def test_set_display_name_restores_children_on_mid_dance_failure(client, fresh_db):
     """Issue #105 / senior-review round 1 — pin the compensating-restore
     contract. If the dance fails partway through (e.g. the re-insert
-    phase trips a constraint), the route MUST restore the children
-    from the snapshot before the 500 surfaces.
+    phase raises), the route MUST restore the children from the
+    snapshot before the 500 surfaces.
 
     Without compensating restore, a partial failure would leave the
     operator with a module that's lost its nests/progress permanently —
     the worst kind of silent data loss because the operator just sees
     'Save failed' and retries with no idea anything else broke.
 
-    We force a mid-dance failure by monkey-patching the route's
-    `_restore_children` upcall: NO — that wouldn't be representative.
-    Instead we trigger a real failure: seed a `nest_data` row with a
-    pre-existing `nest_id` that will collide on re-insert (the dance
-    DELETEs and re-INSERTs by snapshot; a PK collision can't happen
-    on the same snapshot it was read from, so we synthesise one by
-    pre-inserting a sibling `nest_data` row whose `nest_id` matches
-    one in the snapshot).
-
-    Actually the cleanest forcing function is via the `daily_progress`
-    arm: insert a `daily_progress` row whose `progress_id` matches a
-    snapshotted progress_id. After the snapshot, before the dance, we
-    inject a row that ISN'T deleted (different nest_id, same
-    progress_id) so when the dance's re-insert phase runs, the PK
-    collision fires. The compensating restore must put the original
-    children back."""
+    We force a mid-dance failure by wrapping the route's connection
+    in a thin proxy that raises on the first ``INSERT INTO nest_data``
+    call — the dance's first re-insert in phase 3. The proxy
+    delegates everything else via ``__getattr__`` because
+    ``DuckDBPyConnection`` attributes are read-only and can't be
+    monkey-patched directly."""
     client.post("/new_module", json=_payload(TEST_MAC_A, "BeeOne"))
     client.post("/new_module", json=_payload(TEST_MAC_B, "BeeTwo"))
 
@@ -720,21 +710,6 @@ def test_set_display_name_restores_children_on_mid_dance_failure(client, fresh_d
             "VALUES (?, ?, ?, ?, ?, ?)",
             ("prog-rescue-1", "nest-rescue-1", "2026-05-01", 3, 12, 4),
         )
-        # Seed module B with a nest whose nest_id matches what we'll
-        # need NOT to collide with — actually, the cleanest forcing
-        # path is to monkey-patch `con.execute` at the route level
-        # rather than from outside. We can't easily monkey-patch the
-        # route's connection from here because get_conn() returns a
-        # fresh con per call. Instead, we lean on a different forcing
-        # function: insert a `nest_data` row referencing module B but
-        # using nest_id "nest-rescue-1" — that's not possible because
-        # `nest_id` is a PRIMARY KEY, so the seed insertion above
-        # blocks any duplicate. The forcing function is therefore
-        # synthetic: corrupt the snapshot path by patching the
-        # connection's `execute` method just before the re-insert
-        # phase. This is a unit-test fault-injection, not a
-        # representative failure mode, but it exercises the same code
-        # path the operator-visible failure would trigger.
         con.commit()
     finally:
         con.close()

--- a/duckdb-service/tests/test_modules.py
+++ b/duckdb-service/tests/test_modules.py
@@ -549,6 +549,120 @@ def test_add_module_re_registration_bumps_both_timestamps(client, fresh_db):
     )
 
 
+def test_set_display_name_works_on_module_with_nest_data(client, fresh_db):
+    """Issue #105 regression. Pre-fix, DuckDB 1.4.4 rejected
+    `UPDATE module_configs SET display_name = ?` on any row whose `id`
+    was referenced by `nest_data.module_id`, even though the UPDATE
+    didn't touch the FK column. The compose stack seeds five modules
+    all with `nest_data` rows, so all five were unrenamable out of
+    the box.
+
+    Test: seed a module via the normal `/new_module` path, INSERT a
+    `nest_data` row pointing at it, then PATCH `display_name`. Must
+    return 200 + the new label."""
+    client.post("/new_module", json=_payload(TEST_MAC_A, "BeeOne"))
+
+    con = fresh_db.connection.get_conn()
+    try:
+        # Insert a nest_data row pointing at this module — this is what
+        # would have tripped the FK over-enforcement pre-fix.
+        con.execute(
+            "INSERT INTO nest_data (nest_id, module_id, beeType) VALUES (?, ?, ?)",
+            ("nest-test-a", TEST_MAC_A, "blackmasked"),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    r = client.patch(
+        f"/modules/{TEST_MAC_A}/display_name",
+        json={"display_name": "RenamedWithNest"},
+    )
+    assert r.status_code == 200, r.get_json()
+    assert r.get_json()["display_name"] == "RenamedWithNest"
+
+    # Confirm the rename actually persisted (FK workaround must not
+    # silently no-op the UPDATE).
+    rows = client.get("/modules").get_json()["modules"]
+    row = next(m for m in rows if m["id"] == TEST_MAC_A)
+    assert row["display_name"] == "RenamedWithNest"
+
+    # Confirm the FK invariant still holds — nest_data.module_id still
+    # points at a real module_configs row.
+    con = fresh_db.connection.get_conn()
+    try:
+        orphans = con.execute(
+            "SELECT COUNT(*) FROM nest_data n "
+            "LEFT JOIN module_configs m ON m.id = n.module_id "
+            "WHERE m.id IS NULL"
+        ).fetchone()[0]
+    finally:
+        con.close()
+    assert orphans == 0, "the FK invariant must hold after the workaround"
+
+
+def test_set_display_name_409_collision_still_works_with_nest_data(client, fresh_db):
+    """The FK workaround for #105 must not regress the existing UNIQUE
+    collision contract. Seed two modules — both with nest_data rows —
+    rename module 1 to a label, try to rename module 2 to the same
+    label; must 409 (not 500), and the body must carry the
+    conflicting MAC."""
+    client.post("/new_module", json=_payload(TEST_MAC_A, "BeeOne"))
+    client.post("/new_module", json=_payload(TEST_MAC_B, "BeeTwo"))
+
+    con = fresh_db.connection.get_conn()
+    try:
+        con.execute(
+            "INSERT INTO nest_data (nest_id, module_id, beeType) VALUES (?, ?, ?)",
+            ("nest-test-a", TEST_MAC_A, "blackmasked"),
+        )
+        con.execute(
+            "INSERT INTO nest_data (nest_id, module_id, beeType) VALUES (?, ?, ?)",
+            ("nest-test-b", TEST_MAC_B, "blackmasked"),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    r1 = client.patch(
+        f"/modules/{TEST_MAC_A}/display_name",
+        json={"display_name": "Shared Label"},
+    )
+    assert r1.status_code == 200
+
+    r2 = client.patch(
+        f"/modules/{TEST_MAC_B}/display_name",
+        json={"display_name": "Shared Label"},
+    )
+    assert r2.status_code == 409, r2.get_json()
+    body = r2.get_json()
+    assert body["display_name"] == "Shared Label"
+    assert body["conflicting_module_id"] == TEST_MAC_A
+
+
+def test_set_display_name_handles_missing_module_with_clean_rollback(client, fresh_db):
+    """Pinning the fix for #105's Bug 2 (the stacked rollback). The
+    route's old shape called `con.rollback()` in its exception handler
+    even though DuckDB was in autocommit mode; that raised a secondary
+    `TransactionException` which masked the real error and surfaced
+    Flask's HTML 500 page to the operator. The fix switches the route
+    to the project's `write_transaction()` helper, which handles the
+    "no active transaction" rollback gracefully.
+
+    Test: PATCH a non-existent module — the early-return 404 path must
+    NOT crash on rollback. We assert (a) status 404, (b) body is JSON
+    (not HTML), (c) body carries the expected error key."""
+    r = client.patch(
+        "/modules/ffffffffffff/display_name",
+        json={"display_name": "Doesn't matter"},
+    )
+    assert r.status_code == 404
+    # JSON, not HTML — if write_transaction's rollback path is broken,
+    # Flask falls back to its default HTML 500.
+    assert r.content_type.startswith("application/json"), r.data[:200]
+    assert r.get_json()["error"] == "Module not found"
+
+
 def test_legacy_heartbeat_bumps_updated_at_not_last_seen_at(client, fresh_db):
     """The legacy `/modules/<id>/heartbeat` route updates battery +
     image_count metadata; it does NOT represent a registration event.

--- a/duckdb-service/tests/test_repository.py
+++ b/duckdb-service/tests/test_repository.py
@@ -83,3 +83,46 @@ def test_write_transaction_propagates_exception_and_closes(fresh_db):
     assert raised
     # Lock must have been released — a follow-up read must not hang/block.
     assert repo.query_all("SELECT id FROM module_configs WHERE id = 'nope'") == []
+
+
+def test_write_transaction_rolls_back_partial_writes(fresh_db):
+    """Pins the multi-statement atomicity contract. PR B's senior-review
+    caught that the helper was missing an explicit ``BEGIN`` — DuckDB
+    defaults to autocommit, so the first INSERT below would have been
+    committed before the second INSERT's PK collision raised. The
+    rollback in the helper's exception handler would then have failed
+    with ``cannot rollback - no transaction is active`` and the stray
+    row would have been left in the table.
+
+    After the fix (the helper now issues ``BEGIN`` before yielding),
+    the rollback restores the empty state. ``set_display_name``'s
+    temp-table-dance (#105) depends on this contract — if the
+    re-insert phase ever raises, the helper must roll back the parent
+    UPDATE AND the child DELETEs together, restoring the row's
+    original state."""
+    repo = importlib.import_module("db.repository")
+
+    raised = False
+    try:
+        with repo.write_transaction() as con:
+            con.execute(
+                "INSERT INTO module_configs (id, name, lat, lng, first_online) "
+                "VALUES ('rollback-test', 'First', 47.8, 9.6, '2024-01-01')"
+            )
+            # PK collision on second insert — must raise.
+            con.execute(
+                "INSERT INTO module_configs (id, name, lat, lng, first_online) "
+                "VALUES ('rollback-test', 'Second', 47.8, 9.6, '2024-01-01')"
+            )
+    except Exception:
+        raised = True
+
+    assert raised, "PK collision must propagate out of the with-block"
+    rows = repo.query_all(
+        "SELECT id, name FROM module_configs WHERE id = 'rollback-test'"
+    )
+    assert rows == [], (
+        f"write_transaction must roll back partial writes on exception; "
+        f"found stranded row(s): {rows!r}. If this fires, the helper "
+        f"likely lost its explicit BEGIN — see PR B chapter-11 entry."
+    )

--- a/duckdb-service/tests/test_repository.py
+++ b/duckdb-service/tests/test_repository.py
@@ -95,11 +95,16 @@ def test_write_transaction_rolls_back_partial_writes(fresh_db):
     row would have been left in the table.
 
     After the fix (the helper now issues ``BEGIN`` before yielding),
-    the rollback restores the empty state. ``set_display_name``'s
-    temp-table-dance (#105) depends on this contract — if the
-    re-insert phase ever raises, the helper must roll back the parent
-    UPDATE AND the child DELETEs together, restoring the row's
-    original state."""
+    the rollback restores the empty state. ``add_module``,
+    ``record_image``, the legacy ``/modules/<id>/heartbeat`` route,
+    and ``add_progress_for_module`` rely on this contract for their
+    own multi-statement writes. ``set_display_name`` deliberately
+    OPTS OUT of ``write_transaction`` (because DuckDB's transaction
+    snapshot view trips the FK over-enforcement that motivated #105's
+    temp-table dance); it provides atomicity at the Python layer
+    via a compensating-restore handler instead — see its in-route
+    comment for the rationale and ``test_set_display_name_restores_
+    children_on_mid_dance_failure`` for the pinning test."""
     repo = importlib.import_module("db.repository")
 
     raised = False

--- a/duckdb-service/tests/test_schema_migration.py
+++ b/duckdb-service/tests/test_schema_migration.py
@@ -430,3 +430,84 @@ def test_display_name_unique_constraint(fresh_db):
             ), f"unexpected exception: {e!r}"
     finally:
         con.close()
+
+
+def test_last_seen_at_migration_backfills_from_updated_at(fresh_db):
+    """Issue #97 / PR B — when an operator volume comes up against a
+    schema that has `updated_at` but not `last_seen_at`, the migration
+    must (a) add `last_seen_at` and (b) backfill it from `updated_at`
+    so the "module last seen" timestamp survives the column split.
+    Without the backfill, every existing module would snap to NOW() on
+    the first boot after the migration and the 2 h status window would
+    lie about every offline module for two hours."""
+    con = fresh_db.connection.get_conn()
+    try:
+        # Drop and recreate without `last_seen_at` to simulate a
+        # deployment that came up before the PR B migration shipped.
+        # FK-dependent tables must be dropped first.
+        con.execute("DROP TABLE IF EXISTS daily_progress")
+        con.execute("DROP TABLE IF EXISTS nest_data")
+        con.execute("DROP TABLE IF EXISTS module_configs")
+        con.execute(
+            """
+            CREATE TABLE module_configs (
+                id VARCHAR(20) PRIMARY KEY,
+                name VARCHAR(100) NOT NULL,
+                display_name VARCHAR(100) UNIQUE,
+                lat DECIMAL(9,6) NOT NULL,
+                lng DECIMAL(9,6) NOT NULL,
+                first_online DATE NOT NULL,
+                battery_level INTEGER,
+                image_count INTEGER NOT NULL DEFAULT 0,
+                email VARCHAR(255),
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                last_silence_alert_at TIMESTAMP
+            )
+            """
+        )
+        # Insert a row with an EXPLICIT updated_at value distinct from
+        # NOW() — this is the pre-split "module last seen" timestamp
+        # the backfill must preserve.
+        con.execute(
+            "INSERT INTO module_configs "
+            "(id, name, lat, lng, first_online, battery_level, image_count, "
+            " updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "aabbccddeeff",
+                "TestHive",
+                47.8,
+                9.6,
+                "2024-01-01",
+                80,
+                0,
+                "2024-06-15 12:00:00",
+            ),
+        )
+        cols = [
+            c[1] for c in con.execute("PRAGMA table_info(module_configs)").fetchall()
+        ]
+        assert "last_seen_at" not in cols
+    finally:
+        con.close()
+
+    fresh_db.schema.init_db()
+
+    con = fresh_db.connection.get_conn()
+    try:
+        cols = [
+            c[1] for c in con.execute("PRAGMA table_info(module_configs)").fetchall()
+        ]
+        assert "last_seen_at" in cols, (
+            "last_seen_at should have been added by the additive migration"
+        )
+        # Backfill must copy `updated_at` verbatim, not snap to NOW().
+        row = con.execute(
+            "SELECT updated_at, last_seen_at FROM module_configs WHERE id = ?",
+            ("aabbccddeeff",),
+        ).fetchone()
+        assert row[0] == row[1], (
+            f"last_seen_at must equal updated_at after backfill; "
+            f"got updated_at={row[0]!r}, last_seen_at={row[1]!r}"
+        )
+    finally:
+        con.close()

--- a/homepage/src/__tests__/useSetupWizard.test.ts
+++ b/homepage/src/__tests__/useSetupWizard.test.ts
@@ -93,7 +93,7 @@ describe('useSetupWizard.startVerification — mid-poll classification (#44)', (
     // making the test pass for the wrong reason if the threshold ever
     // changes. Same pattern as the third case below.
     getAllModules.mockResolvedValueOnce([
-      { id: 'pre-existing-aabbccddeeff', name: 'Pre-existing', updatedAt: '2024-01-01' },
+      { id: 'pre-existing-aabbccddeeff', name: 'Pre-existing', lastSeenAt: '2024-01-01' },
     ]);
     // First 23 poll attempts fail.
     for (let i = 0; i < 23; i++) {
@@ -125,7 +125,7 @@ describe('useSetupWizard.startVerification — mid-poll classification (#44)', (
     // Mount with a non-empty snapshot so startVerification skips its
     // fallback fetch — keeps the call accounting honest.
     getAllModules.mockResolvedValueOnce([
-      { id: 'pre-existing-aabbccddeeff', name: 'Pre-existing', updatedAt: '2024-01-01' },
+      { id: 'pre-existing-aabbccddeeff', name: 'Pre-existing', lastSeenAt: '2024-01-01' },
     ]);
     // First poll succeeds (resets counter to 0)…
     getAllModules.mockResolvedValueOnce([]);

--- a/homepage/src/components/setup/useSetupWizard.ts
+++ b/homepage/src/components/setup/useSetupWizard.ts
@@ -96,7 +96,12 @@ export function useSetupWizard() {
   // Load firmware info, detect LAN IP, and snapshot modules on mount.
   // The module snapshot must be taken NOW (before the user configures the ESP)
   // so that when the ESP later calls /new_module, we can detect the changed
-  // updated_at in the verification poll.
+  // `lastSeenAt` in the verification poll. (Pre-#97 split this used
+  // `updatedAt`, which then bumped only on registration; post-split
+  // `updatedAt` bumps on every metadata write — including renames and
+  // heartbeat-side geo-patches — which would cause false positives.
+  // `lastSeenAt` is the derived liveness signal and is the correct
+  // field for "did this module just come alive?".)
   useEffect(() => {
     loadFirmware();
     detectLanIp();
@@ -131,7 +136,9 @@ export function useSetupWizard() {
   const snapshotModules = async () => {
     try {
       const existing = await api.getAllModules();
-      knownModuleSnapshotRef.current = new Map(existing.map((m: Module) => [m.id, m.updatedAt]));
+      knownModuleSnapshotRef.current = new Map(
+        existing.map((m: Module) => [m.id, m.lastSeenAt ?? undefined]),
+      );
       console.log('[SetupWizard] Module snapshot taken on mount:', [
         ...knownModuleSnapshotRef.current.keys(),
       ]);
@@ -277,7 +284,9 @@ export function useSetupWizard() {
     if (knownModuleSnapshotRef.current.size === 0) {
       try {
         const existing = await api.getAllModules();
-        knownModuleSnapshotRef.current = new Map(existing.map((m: Module) => [m.id, m.updatedAt]));
+        knownModuleSnapshotRef.current = new Map(
+          existing.map((m: Module) => [m.id, m.lastSeenAt ?? undefined]),
+        );
         console.log('[Step5] Fallback snapshot:', [...knownModuleSnapshotRef.current.keys()]);
       } catch {
         knownModuleSnapshotRef.current = new Map();
@@ -340,13 +349,14 @@ export function useSetupWizard() {
         const now = Date.now();
         const detectedModule = modules.find((m: Module) => {
           const prevTimestamp = knownModuleSnapshotRef.current.get(m.id);
-          // New ID (not in snapshot) OR re-registered (updatedAt changed)
+          // New ID (not in snapshot) OR re-seen (lastSeenAt changed).
+          // See the mount-effect comment for the post-#97 rationale.
           if (prevTimestamp === undefined) return true;
-          if (m.updatedAt !== prevTimestamp) return true;
+          if ((m.lastSeenAt ?? undefined) !== prevTimestamp) return true;
           // Recency fallback for wizard-reload scenarios
-          if (m.updatedAt) {
-            const updatedMs = Date.parse(m.updatedAt);
-            if (!isNaN(updatedMs) && now - updatedMs < RECENT_MS) return true;
+          if (m.lastSeenAt) {
+            const seenMs = Date.parse(m.lastSeenAt);
+            if (!isNaN(seenMs) && now - seenMs < RECENT_MS) return true;
           }
           return false;
         });


### PR DESCRIPTION
## Summary

Two cofade-filed issues converge on `duckdb-service`'s write path for `module_configs`:

- **#97** — `module_configs.updated_at` carried two semantically distinct roles across a service boundary: row-metadata timestamp by DDL convention, but device-liveness signal as read by [`backend/src/database.ts`'s `fetchAndAssemble`](backend/src/database.ts) (folded into `lastSeenAt` for the 2 h status window). The column comment in the DDL named neither role; PR #96's first cut of `set_display_name` shipped exactly this bug (would have flipped renamed offline modules to `'online'` for two hours), caught by senior-reviewer but the underlying ambiguity remained. **Split shipped**: `updated_at` (row-metadata, bumped on every UPDATE) + `last_seen_at` (device-liveness, bumped only on `add_module`'s per-boot registration UPSERT).

- **#105** — admin-side rename of any seeded module ("Save failed" + JSON-parse error in backend logs) caused by two stacked bugs in [`set_display_name`](duckdb-service/routes/modules.py): (1) DuckDB 1.4.4 (and 1.5.2, verified) rejects `UPDATE module_configs SET display_name = ?` on any row whose `id` is FK-referenced by `nest_data` even though `display_name` is neither the PK nor an FK column; (2) the route's manual `con.rollback()` raised a secondary `TransactionException` because DuckDB defaults to autocommit, surfacing as Flask's HTML 500 page that the backend's JSON parser then choked on. **Fix**: bespoke autocommit + compensating-restore pattern — snapshot child rows, DELETE in reverse-FK order, UPDATE the now-unreferenced parent, re-INSERT children; if any phase raises, the snapshot is restored before the 500 surfaces. Pattern documented in [ADR-013](docs/09-architecture-decisions/adr-013-compensating-restore-for-duckdb-fk-update.md).

Senior-reviewer iterated through three rounds. Round 1 caught a P0 (`write_transaction` was missing its explicit `BEGIN`, so the "atomic" rollback was a no-op in DuckDB autocommit). Round 2 caught the missing ADR for the new pattern and a misleading test docstring. Round 3 caught a missing test for the `restore_failed: true` 500-body marker. All addressed.

## Test plan

- [x] `cd duckdb-service; pytest tests/ -q` — 113/113 green (was 106 pre-PR; +1 atomicity test, +5 set_display_name tests, +1 schema migration test)
- [x] `cd backend; npm test` — 124/124 green
- [x] `cd homepage; npm test` — 102/102 green
- [x] `cd image-service; pytest tests/ -q` — 61/61 green
- [x] V1 PRE-fix repro on `dc8435e`: rename Garten 12 returned 500 with `SyntaxError: Unexpected token '<'`; duckdb-service logs showed `ConstraintException: Violates foreign key constraint because key "module_id: 000000000002" is still referenced` followed by `TransactionException: cannot rollback - no transaction is active`. Captured in `c:\tmp\pr-b-v1-repro.txt`.
- [x] V3 migration verification: fresh `docker compose up --build -d` shows both `updated_at` and `last_seen_at` columns on `module_configs`, both `TIMESTAMP`, both DEFAULT-fired on the seed INSERT.
- [x] V5 POST-fix operator verification: `curl -X PATCH /api/modules/000000000002/name` with `{"display_name":"Garten 12 renamed"}` returned 200; the rename persisted; `updatedAt` advanced to NOW; `lastSeenAt` stayed at the seed time (the #97 split held under the new write path); nest_data integrity preserved (4 nests, 4 progress rows, 0 orphans verified via direct DuckDB query).
- [x] V7 lint gates: `check-doc-citations` 7 OK / 0 problem; `check-stale-display-name-rule` clean; `check-no-hardcoded-api-keys` OK; `check-stale-reset-prose` OK.
- [x] V9 auto-close keyword sweep on commit log: exactly 2 matches (`closes #97`, `closes #105`), both on subject lines, zero body leaks.
- [x] V10 senior-reviewer cleared in three rounds (round 1 P0 + P1s + P2s; round 2 P1s + P2s; round 3 final P1 + P2 nits).

## Out of scope (deliberate)

- `heartbeats.py`'s `post_heartbeat`, `silence_watcher.py`'s `check_silence`, `delete_module`, and `delete_image_upload` still use the manual `with lock: con = get_conn()` lifecycle with no `con.close()` / `con.commit()`. Pre-existing on `main` (leaks one connection per call). Now that `write_transaction()` has real `BEGIN` semantics, these should migrate — but the change is orthogonal to PR B's scope and the routes are stable enough that the leak hasn't surfaced as a production problem. Worth a follow-up issue.
- DuckDB upstream relaxation of the FK over-enforcement. Tried 1.5.2 first per the plan; same bug. Worth revisiting if a future DuckDB release fixes the constraint behaviour upstream — at that point the autocommit + compensating-restore pattern in `set_display_name` can be reverted to a plain `write_transaction()` UPDATE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)