### PR TITLE
chore(senior-reviewer): flag missing UI specs on wire-shape diffs

### DIFF
--- a/.claude/agents/senior-reviewer.md
+++ b/.claude/agents/senior-reviewer.md
@@ -26,7 +26,7 @@ Cover the following dimensions; only report findings, not the dimensions themsel
 
 1. **Correctness against requirements.** Does the change do what the linked issue / task description / PR title claims? Identify gaps (claimed but not implemented), overreach (scope creep), and silent regressions in adjacent code.
 2. **Code quality and patterns.** Does new code follow the existing patterns in the codebase, or did the author invent a parallel mechanism? Premature abstractions, copy-paste duplication, defensive code for impossible states, swallowed errors, fallbacks that hide failures, half-finished implementations.
-3. **Tests.** Coverage of the risky paths (not happy paths only). Tests that pin behaviour vs tests that assert implementation details. New code paths that are not exercised. Tests that depend on internal constants or timing in a fragile way.
+3. **Tests.** Coverage of the risky paths (not happy paths only). Tests that pin behaviour vs tests that assert implementation details. New code paths that are not exercised. Tests that depend on internal constants or timing in a fragile way. If the diff touches a view that renders wire-shape data — homepage components rendering `Module` / `TelemetryEntry`, dashboard or setup-wizard surfaces, or any new field crossing the backend↔homepage boundary — verify that a corresponding spec exists or was updated under `tests/ui/tests/`. Vitest + jsdom is necessary, not sufficient (CLAUDE.md "Verifying UI claims" rule 4 and ADR-014 codify why: TS-optional fields collapse to `undefined` silently under mocked APIs, and jsdom never exercises SPA routing or nginx serving). A UI-rendering change without a Playwright spec is a P1 by default; escalate to P0 if the missing coverage maps onto one of the chapter-11 regressions the layer was built to pin (telemetry envelope drift, dashboard side-list filtering).
 4. **Documentation accuracy.** Where the change touches behaviour described in docs (CLAUDE.md, arc42 chapters, ADRs, runbooks, READMEs), do the docs still match? Did the author update them per CLAUDE.md's mandatory-update table? Documentation drift is debt that compounds; flag it.
 5. **Cross-document consistency.** When several docs reference the same concept, do they agree after the change, or did the author update one and forget the others? Re-grep for stale references (renamed files, retired modules, old URLs, removed flags).
 6. **Hidden contracts.** Wire shapes between services, NVS keys, environment variables, file paths in volumes — anything that crosses a boundary. Drift between caller and callee is the single biggest source of field bugs in this codebase.
@@ -35,6 +35,7 @@ Cover the following dimensions; only report findings, not the dimensions themsel
    - Are the "never violate" rules respected?
    - Were the mandatory doc updates from the "Updating documentation" table actually performed?
    - For lessons-learned-worthy bugs, was an entry added to chapter 11?
+   - If the diff touches UI rendering or wire-shape boundaries, was a Playwright spec added / updated per CLAUDE.md "Verifying UI claims" rule 4? (See ADR-014.)
 
 ## How to investigate
 


### PR DESCRIPTION
## Summary

Teaches the `senior-reviewer` agent about the new Playwright UI test layer that landed in PR #122, so future diffs that add a wire-shape field or new dashboard view without a matching `tests/ui/tests/*.spec.ts` companion are caught by the standard pre-merge review sweep.

Two edits to `.claude/agents/senior-reviewer.md`:

- **Dimension 3 — Tests.** Appends a sentence covering the UI-rendering trigger (homepage components rendering `Module` / `TelemetryEntry`, dashboard/setup-wizard surfaces, or any new backend↔homepage boundary field). Default severity **P1**, escalating to **P0** if the gap maps onto a chapter-11 regression the layer was built to pin (telemetry envelope drift, dashboard side-list filtering).
- **Dimension 8 — CLAUDE.md compliance.** Appends a sub-bullet pointing at CLAUDE.md "Verifying UI claims" rule 4 and ADR-014, so the reviewer cross-checks the compliance angle regardless of which lens it's applying.

## Why this matters

CLAUDE.md rule 4 was added in PR #122 to close the regression mode where TS-optional wire-shape fields collapsed to `undefined` silently under mocked APIs (vitest + jsdom never exercised the real DOM). Without the reviewer knowing about that rule, a future PR could land without a Playwright spec and re-open exactly the gap PR #122 closed.

Rationale for the dual touchpoint (Tests + CLAUDE.md compliance):
- Dimension 3 anchors the **trigger** (what code shape calls for the check).
- Dimension 8 anchors the **compliance angle** (which CLAUDE.md rule).

The default-P1-escalate-to-P0 rubric matches the existing severity discipline already documented in the agent's operating principles.

## Test plan

- [x] Diff against `main` is a 2-line markdown change to `.claude/agents/senior-reviewer.md` only.
- [x] No other agent definitions exist in `.claude/agents/` (verified) — `senior-reviewer` is the only project-defined persona that reviews diffs against a testing rubric.
- [ ] CI green on the existing matrix (markdown-only change; no test surface to add).

Companion follow-up: issue #123 (drop the `ui-playwright` diagnostic step after 5 green runs) has an execution recipe in the plan file; not part of this PR.

https://claude.ai/code/session_01UZ212NLFdhm9V9ikjucj2V

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZ212NLFdhm9V9ikjucj2V)_