### PR TITLE
Docs/readme and license

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -71,5 +71,5 @@ Except for the licenses and representations above, the Contribution is provided
 
 By submitting a pull request to this repository, You agree to the terms of this
 Contributor License Agreement for that Contribution and all future Contributions.
-First-time contributors will be asked to confirm this once (a maintainer or the
-CLA-check bot will link back to this file).
+A maintainer may ask You to confirm your agreement on the pull request before it
+is merged.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,75 @@
+# HighFive Contributor License Agreement (Individual)
+
+Thank you for contributing to HighFive. This agreement lets us accept your
+contribution **and** keep the ability to offer HighFive under more than one
+license — including the commercial licenses we may sell to fund the project.
+It is short on purpose.
+
+> **Not legal advice.** This is a plain-language template adapted from common
+> contributor agreements. If you are contributing on behalf of an employer, or
+> the stakes are high for you, have your own lawyer review it first.
+
+## 1. Definitions
+
+- **"The Project"** means HighFive and its maintainers (collectively, "we"/"us").
+- **"You"** means the individual agreeing to this document.
+- **"Contribution"** means any original work of authorship — code, documentation,
+  CAD/hardware designs, images, or other material — that You intentionally submit
+  to the Project (for example, via a pull request, patch, or issue attachment).
+
+## 2. Copyright license and right to relicense
+
+You grant the Project a **perpetual, worldwide, non-exclusive, royalty-free,
+irrevocable** copyright license to reproduce, prepare derivative works of,
+publicly display and perform, sublicense, and distribute Your Contribution and
+such derivative works.
+
+Critically, You also grant the Project the right to **license and relicense Your
+Contribution, and works based on it, under any license terms the Project
+chooses — including the [PolyForm Noncommercial License](LICENSE) and separate
+proprietary or commercial license terms.** This is what allows the Project to
+remain free for noncommercial use while offering paid commercial licenses.
+
+## 3. Patent license
+
+You grant the Project a perpetual, worldwide, non-exclusive, royalty-free,
+irrevocable patent license to make, use, sell, offer to sell, import, and
+otherwise transfer Your Contribution, where such license applies only to patent
+claims You can license that are necessarily infringed by Your Contribution alone
+or by its combination with the Project.
+
+## 4. You keep your ownership
+
+This agreement is **non-exclusive**. You retain all right, title, and interest in
+Your Contribution and may use it for any other purpose. You are not assigning
+copyright — only granting the licenses above.
+
+## 5. Your representations
+
+You represent that:
+
+1. Each Contribution is **Your original creation**, or You have the right to
+   submit it under the terms of this agreement.
+2. If Your employer has rights to intellectual property You create, You have
+   received permission to make the Contribution on behalf of that employer, or
+   the employer has waived such rights for the Contribution.
+3. Your Contribution does not, to Your knowledge, violate any third party's
+   rights, and You will flag any third-party material (and its license) you are
+   aware of in the Contribution.
+
+## 6. No obligation
+
+You understand the Project is under no obligation to use or include Your
+Contribution. Support and warranty obligations are entirely the Project's choice.
+
+## 7. Disclaimer
+
+Except for the licenses and representations above, the Contribution is provided
+"as is", without warranty of any kind.
+
+## How to accept
+
+By submitting a pull request to this repository, You agree to the terms of this
+Contributor License Agreement for that Contribution and all future Contributions.
+First-time contributors will be asked to confirm this once (a maintainer or the
+CLA-check bot will link back to this file).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,20 @@ The body (optional, separated by a blank line) explains _why_, not _what_.
 Do not commit `.env`, secrets, or large binaries. The `assets/` folder
 holds CAD files (`.FCStd`, `.dxf`) — those are intentional.
 
+## Licensing & contributor agreement
+
+HighFive is **source-available, not open source**: it is free for any
+**noncommercial** use under the [PolyForm Noncommercial License 1.0.0](LICENSE),
+and **commercial use requires a separate license** from the maintainers
+(contact <mark.schutera@mailbox.org>).
+
+Because we keep the option to offer commercial licenses, every contribution is
+accepted under our [Contributor License Agreement](CLA.md). It is short: you keep
+ownership of your work and grant the project the right to relicense it (including
+commercially). By opening a pull request you agree to it; first-time contributors
+will be asked to confirm once. Please don't submit third-party code without
+flagging its origin and license.
+
 ## Reporting issues
 
 Open a GitHub issue with reproduction steps, expected vs actual

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,81 @@
+Required Notice: Copyright (c) 2026 The HighFive maintainers <mark.schutera@mailbox.org>
+
+HighFive is source-available software, free for noncommercial use under the
+terms below. Commercial use requires a separate license from the HighFive
+maintainers; contact <mark.schutera@mailbox.org>.
+
+================================================================================
+
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ HighFive captures images of wild-bee hotels with solar-powered ESP32-CAM modules
 analyzes nest activity, and renders the results on an interactive dashboard, map,
 and setup wizard. Everything runs locally under Docker Compose.
 
-<p align="center">
-  <img src="docs/_images/dashboard.png" alt="HighFive dashboard" width="640"/>
-</p>
-
 <br>
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 <h1 align="center">🙌 HighFive</h1>
 
 <p align="center">
-  <img src="docs/_images/HiveHive_Logo.png" alt="HighFive Logo" width="180"/>
+  <img src="docs/_images/highfive-logo.svg" alt="HighFive logo" width="120"/>
+</p>
+
+<p align="center">
+  <em>An open monitoring pipeline for wild-bee nesting activity.</em>
 </p>
 
 <p align="center">
@@ -10,9 +14,8 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/frontend-React%20%2B%20Vite-61DAFB?logo=react&logoColor=white" alt="React + Vite" />
-  <img src="https://img.shields.io/badge/language-TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/backend-Node.js%20%2B%20Express-339933?logo=node.js&logoColor=white" alt="Node.js + Express" />
-  <img src="https://img.shields.io/badge/image--service-Python%20%2B%20Flask-3776AB?logo=python&logoColor=white" alt="Python + Flask" />
+  <img src="https://img.shields.io/badge/services-Python%20%2B%20Flask-3776AB?logo=python&logoColor=white" alt="Python + Flask" />
   <img src="https://img.shields.io/badge/database-DuckDB-FFC107?logoColor=white" alt="DuckDB" />
   <img src="https://img.shields.io/badge/hardware-ESP32--CAM-E7352C?logoColor=white" alt="ESP32-CAM" />
   <img src="https://img.shields.io/badge/deploy-Docker%20Compose-2496ED?logo=docker&logoColor=white" alt="Docker Compose" />
@@ -20,73 +23,50 @@
 
 <br>
 
-Automated monitoring pipeline that captures images of wild bee hotels, analyzes nest activity, and displays the results on an interactive dashboard. The system is built on ESP32-CAM hardware, a Python image service, and a React web application — fully containerized with Docker Compose.
+HighFive captures images of wild-bee hotels with solar-powered ESP32-CAM modules,
+analyzes nest activity, and renders the results on an interactive dashboard, map,
+and setup wizard. Everything runs locally under Docker Compose.
+
+<p align="center">
+  <img src="docs/_images/dashboard.png" alt="HighFive dashboard" width="640"/>
+</p>
 
 <br>
 
-## System Components
-
-- **homepage** — React + Vite frontend, served on port `5173`
-- **backend** — Node.js + Express API, served on port `3002`
-- **image-service** — Python + Flask image ingestion and analysis service, port `8000`
-- **duckdb-service** — Python + Flask database service, port `8002`
-- **ESP32-CAM** — edge hardware module for image capture and upload
-
-<br>
-
-## Documentation
-
-| Guide                                                                | Description                                                                                                                                                                                                 |
-| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Deployment Guide](docs/07-deployment-view/docker-compose.md)        | How to run all services with Docker Compose                                                                                                                                                                 |
-| [Homepage](docs/05-building-block-view/homepage.md)                  | Frontend pages, routes, and backend connection                                                                                                                                                              |
-| [ESP Deployment](docs/07-deployment-view/esp-flashing.md)            | ESP32 firmware flashing, WiFi setup, configuration. **Read this before building firmware** — the Google Geolocation API key is build-time injected via `ESP32-CAM/GEO_API_KEY` (gitignored), not hardcoded. |
-| [Troubleshooting](docs/troubleshooting.md)                           | ESP32-CAM setup issues, server connectivity, Windows Firewall                                                                                                                                               |
-| [API Reference](docs/api-reference.md)                               | All API endpoints with example requests and responses                                                                                                                                                       |
-| [Architecture (arc42)](docs/05-building-block-view/README.md)        | System architecture, building blocks, and design decisions                                                                                                                                                  |
-| [Image Service](docs/05-building-block-view/image-service.md)        | Image ingestion and analysis service                                                                                                                                                                        |
-| [DuckDB & Data Model](docs/05-building-block-view/duckdb-service.md) | Database schema and query reference                                                                                                                                                                         |
-
-<br>
-
-## Quick Start
+## Quick start
 
 ```bash
 git clone https://github.com/schutera/highfive.git
 cd highfive
+cp .env.example .env       # then edit if needed
+docker compose up --build  # homepage on http://localhost:5173
 ```
 
-Create a `.env` file in the root directory:
-
-```env
-DEBUG=true
-DUCKDB_SERVICE_URL=http://duckdb-service:8000
-```
-
-Start all services:
-
-```bash
-docker compose up --build
-```
-
-See [Deployment Guide](docs/07-deployment-view/docker-compose.md) for full setup instructions.
+Full setup, ports, and service map: **[Deployment Guide](docs/07-deployment-view/docker-compose.md)**.
 
 <br>
 
-## Development
+## Where to go next
 
-### Backend
+| If you want to…              | Start here                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------------- |
+| **Contribute**               | [CONTRIBUTING.md](CONTRIBUTING.md) — setup, conventions, branch & test workflow |
+| Understand the architecture  | [Architecture (arc42)](docs/05-building-block-view/README.md)                   |
+| Flash an ESP32-CAM module    | [ESP Deployment](docs/07-deployment-view/esp-flashing.md)                       |
+| Call the API                 | [API Reference](docs/api-reference.md)                                          |
+| Fix a setup problem          | [Troubleshooting](docs/troubleshooting.md)                                      |
+| See what's planned / changed | [Roadmap](docs/roadmap.md) · [Changelog](CHANGELOG.md)                          |
 
-```bash
-cd backend
-npm install
-npm run dev
-```
+<br>
 
-### Frontend
+## License
 
-```bash
-cd homepage
-npm install
-npm run dev        # runs on port 5173
-```
+HighFive is **source-available, not open source**: free for any **noncommercial**
+use under the [PolyForm Noncommercial License 1.0.0](LICENSE). **Commercial use
+requires a separate license** — contact <mark.schutera@mailbox.org>.
+
+Contributions are welcome under our [Contributor License Agreement](CLA.md).
+
+<br>
+
+<sub>Built for citizen science. 🐝</sub>

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "private": true,
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@highfive/contracts": "*",
     "cors": "^2.8.5",

--- a/docs/_images/highfive-logo.svg
+++ b/docs/_images/highfive-logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="HighFive">
+  <text y=".9em" font-size="90">🙌</text>
+</svg>


### PR DESCRIPTION
# Pull Request

## What changed

Updated readme and license



## Why

So it is easier to read and navigate for contributors. 
Also added further licensing and a CTA to allow later licensing if that is something we want, and still allow wide-spread (student) contributions. 


## How tested

Locally.

Mark each suite that was run locally and passed. Leave unchecked if not applicable
(but explain why in a comment).

- [x ] ESP32-CAM native (`pio test -e native`)
- [ x] End-to-end (`pytest tests/e2e`)
- [x ] Backend unit (Node 22 + TS)
- [x ] image-service unit (Python 3.11)
- [x ] duckdb-service unit (Python 3.11)
- [x ] Homepage unit (React 19 + Vite)
- [x ] Manual / hardware-in-the-loop verification (describe below)

Tested all locally while preparing for deployment of main on prod, however should not affect any. 

