### PR TITLE
perf: speed up dashboard load, side panel, and map rendering

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -83,9 +83,47 @@ export interface ModuleDetailWithMeta {
   heartbeatsFailed: boolean;
 }
 
+/**
+ * Result of one full fan-out + assembly pass, shared by `listModules`
+ * and `getModuleDetail` via the short-TTL cache below.
+ */
+interface AssembleResult {
+  items: Array<{ detail: ModuleDetail; totalHatches: number }>;
+  heartbeatsFailed: boolean;
+  // True when ANY of the four upstream fetches rejected (modules, nests,
+  // progress, or heartbeats). The fan-out uses `Promise.allSettled` and
+  // degrades gracefully rather than throwing, so this flag is the only
+  // signal that the snapshot is partial. `assemble()` refuses to cache a
+  // degraded snapshot — otherwise a transient duckdb outage would pin an
+  // empty/partial fleet (or a stuck `heartbeatsFailed`) for a full TTL
+  // after upstream recovered. Not part of the public method return shape.
+  degraded: boolean;
+}
+
+// How long an assembled fleet snapshot is reused before the next
+// caller triggers a fresh upstream fan-out. Tuned for the dominant
+// access pattern: the dashboard fetches `/api/modules`, then the
+// operator clicks a module and `/api/modules/:id` fires moments later.
+// Pre-cache, the detail route re-fetched all four duckdb endpoints just
+// to find one module by id (the dashboard had already loaded the exact
+// same data). At 5 s, that second call — and any rapid re-selection —
+// is served from memory. The cost is staleness: a brand-new heartbeat
+// or freshly onboarded module can lag by up to one TTL. The dashboard
+// does not poll, so this is only ever observed across deliberate
+// re-navigations, where 5 s is imperceptible.
+const ASSEMBLE_CACHE_TTL_MS = 5000;
+
 export class ModuleReadModel {
+  // Last successful assembly + the time it completed. `null` until the
+  // first fetch resolves.
+  private cache: { at: number; value: AssembleResult } | null = null;
+  // In-flight fan-out, if one is running. Concurrent callers (e.g. the
+  // dashboard list and an immediate detail open) await the same promise
+  // instead of each launching a duplicate four-endpoint fan-out.
+  private inflight: Promise<AssembleResult> | null = null;
+
   async listModules(): Promise<ModulesWithMeta> {
-    const { items, heartbeatsFailed } = await this.fetchAndAssemble();
+    const { items, heartbeatsFailed } = await this.assemble();
     const modules = items.map(({ detail, totalHatches }) => ({
       id: detail.id,
       name: detail.name,
@@ -106,15 +144,51 @@ export class ModuleReadModel {
   }
 
   async getModuleDetail(id: ModuleId): Promise<ModuleDetailWithMeta> {
-    const { items, heartbeatsFailed } = await this.fetchAndAssemble();
+    const { items, heartbeatsFailed } = await this.assemble();
     const detail = items.find((x) => x.detail.id === id)?.detail ?? null;
     return { detail, heartbeatsFailed };
   }
 
-  private async fetchAndAssemble(): Promise<{
-    items: Array<{ detail: ModuleDetail; totalHatches: number }>;
-    heartbeatsFailed: boolean;
-  }> {
+  /**
+   * Cached wrapper around `fetchAndAssemble`. Serves a snapshot younger
+   * than `ASSEMBLE_CACHE_TTL_MS` from memory; otherwise dedupes
+   * concurrent callers onto a single in-flight fan-out.
+   *
+   * Two things are deliberately NOT cached, so a transient upstream
+   * outage can't pin stale-bad state for a full TTL:
+   *   - a rejected promise. The `Promise.allSettled` fan-out itself
+   *     never rejects; the only throw path is *during assembly, after
+   *     the fan-out* — e.g. `parseModuleId` on a malformed upstream id.
+   *     Caching is wired through `.then` (success only); `.finally`
+   *     clears the in-flight slot so the next caller retries.
+   *   - a *degraded* fan-out (`value.degraded` — any of the four
+   *     upstream fetches failed). The result is still returned to the
+   *     current caller (graceful degradation), but it is not stored, so
+   *     the next call re-fetches against a possibly-recovered upstream.
+   * Only a fully-successful snapshot is cached.
+   */
+  private async assemble(): Promise<AssembleResult> {
+    const now = Date.now();
+    if (this.cache && now - this.cache.at < ASSEMBLE_CACHE_TTL_MS) {
+      return this.cache.value;
+    }
+    if (this.inflight) {
+      return this.inflight;
+    }
+    this.inflight = this.fetchAndAssemble()
+      .then((value) => {
+        if (!value.degraded) {
+          this.cache = { at: Date.now(), value };
+        }
+        return value;
+      })
+      .finally(() => {
+        this.inflight = null;
+      });
+    return this.inflight;
+  }
+
+  private async fetchAndAssemble(): Promise<AssembleResult> {
     // Reject on non-2xx so the existing `.status === 'rejected'` branches
     // fire on a duckdb HTTP 500 (or any other non-2xx). Without this,
     // `r.json()` happily parses the JSON error body, the promise resolves
@@ -153,6 +227,14 @@ export class ModuleReadModel {
     if (heartbeatsFailed) {
       console.warn('⚠️ Failed to fetch heartbeats:', heartbeatsResult.reason);
     }
+
+    // Any rejected fetch makes the assembled snapshot partial — see the
+    // `degraded` field on AssembleResult for why `assemble()` won't cache it.
+    const degraded =
+      modulesResult.status === 'rejected' ||
+      nestsResult.status === 'rejected' ||
+      progressResult.status === 'rejected' ||
+      heartbeatsFailed;
 
     const modulesData = (
       modulesResult.status === 'fulfilled' ? modulesResult.value : { modules: [] }
@@ -305,7 +387,7 @@ export class ModuleReadModel {
 
       return { detail, totalHatches };
     });
-    return { items, heartbeatsFailed };
+    return { items, heartbeatsFailed, degraded };
   }
 }
 

--- a/backend/tests/read-model-cache.test.ts
+++ b/backend/tests/read-model-cache.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ModuleReadModel } from '../src/database';
+
+/**
+ * perf/dashboard-load — the read model caches one assembled fleet
+ * snapshot for a short TTL so the dominant access pattern (dashboard
+ * loads `/api/modules`, operator clicks a module → `/api/modules/:id`
+ * fires moments later) doesn't re-run the four-endpoint duckdb fan-out
+ * twice. Pre-cache, `getModuleDetail` re-fetched every module, nest,
+ * progress row, and heartbeat just to find one module by id.
+ *
+ * These tests count real upstream `fetch` calls through a mocked global
+ * fetch — "envelope right, behaviour wrong" would be a test that only
+ * checks the returned data and never proves the second call was served
+ * from memory. Four endpoints per fan-out (`/modules`, `/nests`,
+ * `/progress`, `/heartbeats_summary`), so one fan-out == 4 fetches.
+ */
+
+const FETCHES_PER_FANOUT = 4;
+const VALID_ID = 'aabbccddeeff';
+
+function upstreamModule() {
+  return {
+    id: VALID_ID,
+    name: 'Hive 1',
+    lat: '47.0',
+    lng: '9.0',
+    status: 'online',
+    first_online: '2024-01-01',
+    battery_level: 80,
+    image_count: 0,
+    real_image_count: 0,
+    last_image_at: null,
+    email: null,
+    updated_at: null,
+    last_seen_at: null,
+  };
+}
+
+function installCountingFetch() {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/heartbeats_summary')) {
+      return new Response(JSON.stringify({ summary: {} }), { status: 200 });
+    }
+    if (url.endsWith('/modules')) {
+      return new Response(JSON.stringify({ modules: [upstreamModule()] }), { status: 200 });
+    }
+    if (url.endsWith('/nests')) {
+      return new Response(JSON.stringify({ nests: [] }), { status: 200 });
+    }
+    if (url.endsWith('/progress')) {
+      return new Response(JSON.stringify({ progress: [] }), { status: 200 });
+    }
+    throw new Error(`unmocked fetch: ${url}`);
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+describe('ModuleReadModel — short-TTL assembly cache', () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it('serves a second call from cache (one fan-out for list + immediate detail)', async () => {
+    const fetchMock = installCountingFetch();
+    const db = new ModuleReadModel();
+
+    await db.listModules();
+    const { detail } = await db.getModuleDetail(VALID_ID as never);
+
+    // The detail came back correctly...
+    expect(detail).not.toBeNull();
+    expect(detail?.id).toBe(VALID_ID);
+    // ...without a second four-endpoint fan-out.
+    expect(fetchMock).toHaveBeenCalledTimes(FETCHES_PER_FANOUT);
+  });
+
+  it('dedupes concurrent callers onto a single in-flight fan-out', async () => {
+    const fetchMock = installCountingFetch();
+    const db = new ModuleReadModel();
+
+    // Fire both before either resolves — they must share one fan-out.
+    const [list, detail] = await Promise.all([
+      db.listModules(),
+      db.getModuleDetail(VALID_ID as never),
+    ]);
+
+    expect(list.modules).toHaveLength(1);
+    expect(detail.detail).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(FETCHES_PER_FANOUT);
+  });
+
+  it('does NOT cache a degraded fan-out (a failed upstream fetch must not pin partial state)', async () => {
+    // Heartbeats endpoint rejects → the snapshot is `degraded`, so the
+    // second call must re-fetch rather than serve the partial result
+    // from cache. Otherwise a transient duckdb outage would freeze a
+    // stuck `heartbeatsFailed` / empty fleet for a full TTL after
+    // recovery.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/heartbeats_summary')) {
+        throw new Error('heartbeats endpoint unreachable');
+      }
+      if (url.endsWith('/modules')) {
+        return new Response(JSON.stringify({ modules: [upstreamModule()] }), { status: 200 });
+      }
+      if (url.endsWith('/nests')) {
+        return new Response(JSON.stringify({ nests: [] }), { status: 200 });
+      }
+      if (url.endsWith('/progress')) {
+        return new Response(JSON.stringify({ progress: [] }), { status: 200 });
+      }
+      throw new Error(`unmocked fetch: ${url}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const db = new ModuleReadModel();
+
+    const first = await db.listModules();
+    const second = await db.listModules();
+
+    expect(first.heartbeatsFailed).toBe(true);
+    expect(second.heartbeatsFailed).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(FETCHES_PER_FANOUT * 2);
+    warnSpy.mockRestore();
+  });
+
+  it('re-fetches once the cached snapshot is older than the TTL', async () => {
+    vi.useFakeTimers();
+    const fetchMock = installCountingFetch();
+    const db = new ModuleReadModel();
+
+    await db.listModules();
+    // Past the 5 s TTL — the next call must trigger a fresh fan-out.
+    vi.advanceTimersByTime(6000);
+    await db.listModules();
+
+    expect(fetchMock).toHaveBeenCalledTimes(FETCHES_PER_FANOUT * 2);
+  });
+});

--- a/docs/09-architecture-decisions/adr-017-external-weather-source.md
+++ b/docs/09-architecture-decisions/adr-017-external-weather-source.md
@@ -148,11 +148,26 @@ same idempotency guarantee.
 
 The
 [Open-Meteo licence](https://open-meteo.com/en/license)
-requires attribution. `SiteFooter` gains a "Weather data by
+requires attribution. `SiteFooter` gained a "Weather data by
 Open-Meteo" link — the first non-Impressum link in the footer.
 ADR-015 already required this attribution browser-side; this ADR
-extends it to the dashboard footer so the duty is met regardless of
-whether the user is on the marketing page or the dashboard.
+extended it to the dashboard footer so the duty was met regardless of
+whether the user was on the marketing page or the dashboard.
+
+> **Status note (perf/data, 2026-06):** the dashboard weather chart
+> (`ActivityWeatherChart` in `ModulePanel`) and this footer attribution
+> link were both disabled because the displayed series was not yet
+> trustworthy data. The server-side `weather_worker` **keeps ingesting**
+> Open-Meteo hourly observations into `measurements` (it is gated by
+> `WEATHER_WORKER_ENABLED`, default `true`; this change did not gate it
+> off, so historical correlation data continues to accumulate in the
+> default/compose config for when the chart returns); what changed is
+> only that no Open-Meteo data is now _rendered_ to the operator. CC-BY 4.0 attaches the attribution duty to
+> public display/distribution, so with nothing displayed the UI
+> attribution duty is dormant — but the data is still being collected.
+> **Re-enable the footer link in the same change that re-enables the
+> weather chart** — the two are coupled: showing the data again revives
+> the duty.
 
 ## Consequences
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -119,6 +119,19 @@ the listing and has already seen the degradation signal. Old clients
 that don't read the header still see a structurally valid response;
 only the per-module `status` value may differ.
 
+**Caching / freshness.** Both `GET /api/modules` and
+`GET /api/modules/:id` are served from a shared in-process snapshot in
+`backend/src/database.ts's ModuleReadModel` that is at most **5 s** old
+(`ASSEMBLE_CACHE_TTL_MS`). The detail route reuses the listing's
+snapshot rather than re-running the four-endpoint duckdb fan-out, so the
+common "open the dashboard, click a module" path costs one upstream
+round-trip, not two. Consequence: a freshly registered or renamed module
+— or a brand-new heartbeat — can lag by up to one TTL. The dashboard
+does not poll, so this is only ever observed across deliberate
+re-navigations, where 5 s is imperceptible. A **degraded** fan-out (any
+upstream fetch failed) is returned to the caller but **not** cached, so a
+transient duckdb outage cannot pin partial state past recovery.
+
 ## 1.3 Module detail
 
 ```

--- a/homepage/src/__tests__/ActivityWeatherChart.test.tsx
+++ b/homepage/src/__tests__/ActivityWeatherChart.test.tsx
@@ -5,6 +5,13 @@ import { parseModuleId } from '@highfive/contracts';
 
 import { LanguageProvider } from '../i18n/LanguageContext';
 
+// NOTE(perf/data): <ActivityWeatherChart> is currently shelved — its
+// only consumer (ModulePanel.tsx) has the import commented out because
+// the weather series came from a slow browser-direct Open-Meteo fetch.
+// These tests still pass but exercise a component not mounted in
+// production today; keep them as re-enable scaffolding. Green here does
+// NOT mean the feature is live.
+
 // Mock api.getActivity at the service boundary — the contract under
 // test is "the chart calls api.getActivity with (id, interval, days)
 // and renders the result". Pinning the wire-shape round trip with a

--- a/homepage/src/__tests__/BatteryHistoryChart.test.tsx
+++ b/homepage/src/__tests__/BatteryHistoryChart.test.tsx
@@ -5,6 +5,14 @@ import { parseModuleId } from '@highfive/contracts';
 
 import { LanguageProvider } from '../i18n/LanguageContext';
 
+// NOTE(perf/data): <BatteryHistoryChart> is currently shelved — its only
+// consumer (ModulePanel.tsx) has the import commented out because the
+// battery series is fabricated firmware data (`random(1,100)`). These
+// tests still pass but exercise a component not mounted in production
+// today; keep them as re-enable scaffolding. Green here does NOT mean
+// the feature is live (its Playwright gate is skipped for the same
+// reason — see tests/ui/tests/module-battery-history.spec.ts).
+
 // Mock api.getMeasurements at the service boundary — the contract under
 // test is "the chart calls api.getMeasurements with (id, 'battery_pct',
 // 'hourly', 7) and renders the buckets honestly". CLAUDE.md rule 3:
@@ -132,9 +140,7 @@ describe('<BatteryHistoryChart>', () => {
     });
     renderChart();
     await waitFor(() =>
-      expect(
-        screen.getByText(/No battery readings|Keine Akkudaten/i),
-      ).toBeInTheDocument(),
+      expect(screen.getByText(/No battery readings|Keine Akkudaten/i)).toBeInTheDocument(),
     );
     expect(screen.queryByTestId('recharts-LineChart')).not.toBeInTheDocument();
   });
@@ -142,8 +148,6 @@ describe('<BatteryHistoryChart>', () => {
   it('renders the error state when the fetch rejects', async () => {
     getMeasurements.mockRejectedValue(new Error('boom'));
     renderChart();
-    await waitFor(() =>
-      expect(screen.getByText(/error|fehler/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/error|fehler/i)).toBeInTheDocument());
   });
 });

--- a/homepage/src/__tests__/ModulePanel.test.tsx
+++ b/homepage/src/__tests__/ModulePanel.test.tsx
@@ -28,14 +28,18 @@ let nextModuleDetail: ModuleDetail | null = null;
 // in jsdom (empty sessionStorage, no `?admin` URL param), so the
 // admin/non-admin branch the pill is in is the only branch exercised
 // here. That's the right branch — operators don't see admin mode.
+// NOTE(perf/data): <ActivityWeatherChart> and <BatteryHistoryChart> are
+// currently commented out in ModulePanel.tsx (their data is fabricated),
+// so the panel no longer calls getActivity / getMeasurements /
+// fetchHourlyWeather. The stubs below are kept as scaffolding so this
+// suite is ready the moment the charts are re-enabled — without them a
+// re-enable would reintroduce the unhandled-rejection noise these mocks
+// were added to suppress. They are intentionally dead today.
 vi.mock('../services/api', () => ({
   api: {
     getModuleById: vi.fn(() => Promise.resolve(nextModuleDetail)),
     getModuleLogs: vi.fn().mockResolvedValue([]),
-    // ModulePanel now renders <ActivityWeatherChart>, which calls
-    // api.getActivity on mount. Stub it with an empty bucket list so
-    // the chart resolves to its "no activity" branch without an
-    // unhandled rejection from this mock object.
+    // Dead while the activity chart is shelved — see NOTE above.
     getActivity: vi.fn().mockResolvedValue({
       moduleId: 'e89fa9f23a08',
       interval: 'hourly',
@@ -43,10 +47,7 @@ vi.mock('../services/api', () => ({
       end: '2026-05-20T00:00:00',
       buckets: [],
     }),
-    // ModulePanel also renders <BatteryHistoryChart> (issue #110),
-    // which calls api.getMeasurements on mount. Stub it with an
-    // empty bucket list so the chart resolves to its "no readings"
-    // branch without an unhandled rejection.
+    // Dead while the battery chart is shelved — see NOTE above.
     getMeasurements: vi.fn().mockResolvedValue({
       moduleId: 'e89fa9f23a08',
       metric: 'battery_pct',
@@ -57,10 +58,8 @@ vi.mock('../services/api', () => ({
     }),
   },
 }));
-// fetchHourlyWeather inside <ActivityWeatherChart> calls
-// `fetch('https://api.open-meteo.com/...')` directly. Stub it once at
-// the module scope so each ModulePanel render gets an empty weather
-// series without polluting individual tests with vi.stubGlobal calls.
+// Dead while the activity chart is shelved — see NOTE above. Kept so the
+// open-meteo browser fetch stays stubbed when the chart is re-enabled.
 vi.mock('../services/weather', () => ({
   fetchHourlyWeather: vi.fn().mockResolvedValue([]),
 }));

--- a/homepage/src/__tests__/SiteFooter.test.tsx
+++ b/homepage/src/__tests__/SiteFooter.test.tsx
@@ -4,14 +4,15 @@ import { render, screen } from '@testing-library/react';
 import SiteFooter from '../components/SiteFooter';
 import { LanguageProvider } from '../i18n/LanguageContext';
 
-// Pins the Open-Meteo attribution link added for ADR-017 (server-side
-// weather worker for #111). The component is plain JSX with no
-// conditional rendering, so this test would fail loudly if a future
-// refactor accidentally drops the attribution — and the CC-BY 4.0
-// licence requirement that ADR-017 carries forward from ADR-015 would
-// quietly stop being met.
+// Pins the Impressum link (German legal compliance). The Open-Meteo
+// CC-BY 4.0 attribution link was removed alongside disabling the
+// dashboard weather chart — with no weather data rendered anywhere in
+// the UI, the attribution is no longer tied to a visible use. The
+// absence assertion below guards against it silently creeping back in
+// while the weather feature stays disabled; restore both together when
+// ActivityWeatherChart is re-enabled against real data (ADR-017/ADR-015).
 describe('SiteFooter', () => {
-  it('renders the Impressum link and the Open-Meteo attribution', () => {
+  it('renders the Impressum link', () => {
     render(
       <LanguageProvider>
         <SiteFooter />
@@ -20,10 +21,15 @@ describe('SiteFooter', () => {
 
     const impressum = screen.getByRole('link', { name: /Impressum/i });
     expect(impressum).toHaveAttribute('href', 'https://partner.schutera.com/impressum');
+  });
 
-    const weather = screen.getByRole('link', { name: /Open-Meteo/i });
-    expect(weather).toHaveAttribute('href', 'https://open-meteo.com/');
-    expect(weather).toHaveAttribute('rel', 'noopener noreferrer');
-    expect(weather).toHaveAttribute('target', '_blank');
+  it('does not render the Open-Meteo attribution while the weather chart is disabled', () => {
+    render(
+      <LanguageProvider>
+        <SiteFooter />
+      </LanguageProvider>,
+    );
+
+    expect(screen.queryByRole('link', { name: /Open-Meteo/i })).not.toBeInTheDocument();
   });
 });

--- a/homepage/src/components/MapView.tsx
+++ b/homepage/src/components/MapView.tsx
@@ -7,10 +7,21 @@ import type { Module, UserLocation } from '@highfive/contracts';
 import { hasPlausibleLocation } from '../lib/location';
 import { useTranslation } from '../i18n/LanguageContext';
 
-// Create a badge icon for clusters
+// Memoized cluster/marker badge icons. The icon's appearance depends
+// only on (count, hasOnline), and a `divIcon` is an immutable descriptor
+// Leaflet reads when it builds each marker's DOM — so the same instance
+// is safe to share across markers and across renders. Without this
+// cache, every zoom tick rebuilt an HTML string + a fresh divIcon for
+// every marker on the map, which was part of the pan/zoom jank.
+const badgeIconCache = new Map<string, L.DivIcon>();
+
+// Create (or reuse) a badge icon for clusters and single markers.
 function createBadgeIcon(count: number, hasOnline: boolean) {
+  const key = `${count}|${hasOnline ? 1 : 0}`;
+  const cached = badgeIconCache.get(key);
+  if (cached) return cached;
   const color = hasOnline ? '#f59e0b' : '#94a3b8';
-  return L.divIcon({
+  const icon = L.divIcon({
     className: 'cluster-badge',
     html: `
       <div style="
@@ -34,6 +45,8 @@ function createBadgeIcon(count: number, hasOnline: boolean) {
     iconSize: [50, 50],
     iconAnchor: [25, 25],
   });
+  badgeIconCache.set(key, icon);
+  return icon;
 }
 
 // Custom amber marker for online modules
@@ -542,6 +555,11 @@ export default function MapView({
       className="h-full w-full"
       style={{ height: '100%', width: '100%' }}
       zoomControl={false}
+      // Render vector layers (the activity Circles) to a single <canvas>
+      // instead of one SVG <path> per circle. Canvas redraws the whole
+      // overlay in one pass during pan/zoom, eliminating the per-circle
+      // SVG reflow that made the map stutter while flying between modules.
+      preferCanvas
     >
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'

--- a/homepage/src/components/ModulePanel.tsx
+++ b/homepage/src/components/ModulePanel.tsx
@@ -6,8 +6,14 @@ import { useTranslation } from '../i18n/LanguageContext';
 import AdminKeyForm from './AdminKeyForm';
 import { hasPlausibleLocation } from '../lib/location';
 import { displayLabel } from '../lib/displayLabel';
-import ActivityWeatherChart from './ActivityWeatherChart';
-import BatteryHistoryChart from './BatteryHistoryChart';
+// TODO(perf/data): Re-enable once these panels are backed by real data.
+// Both were disabled because the series are currently fabricated — the
+// battery trace is firmware `random(1,100)` (see BatteryHistoryChart
+// docstring) and the activity/weather chart fired a slow browser-direct
+// Open-Meteo fetch on every panel open. Removing them is the bulk of the
+// side-panel load-time fix.
+// import ActivityWeatherChart from './ActivityWeatherChart';
+// import BatteryHistoryChart from './BatteryHistoryChart';
 
 const ADMIN_KEY_STORAGE = 'hf_admin_key';
 
@@ -525,8 +531,11 @@ export default function ModulePanel({ module, onClose, onError }: ModulePanelPro
           ))}
         </div>
 
+        {/* TODO(perf/data): Re-enable when backed by real data — both series
+            are currently fabricated, and the weather chart's browser-direct
+            Open-Meteo fetch was a major side-panel load-time cost.
         <ActivityWeatherChart moduleId={moduleDetail.id} location={moduleDetail.location} />
-        <BatteryHistoryChart moduleId={moduleDetail.id} />
+        <BatteryHistoryChart moduleId={moduleDetail.id} /> */}
       </div>
     </div>
   );

--- a/homepage/src/components/SiteFooter.tsx
+++ b/homepage/src/components/SiteFooter.tsx
@@ -2,12 +2,14 @@ import { useTranslation } from '../i18n/LanguageContext';
 
 /**
  * Compact footer used on all marketing pages. Keeps the Impressum link
- * required for German legal compliance front-and-centre. The Open-Meteo
- * attribution next to it satisfies the CC-BY 4.0 licence requirement
- * that ADR-017 carries forward from ADR-015 (also satisfied
- * browser-side by the activity chart, but the server-side worker
- * means the data lands on the dashboard regardless of whether the
- * chart was opened).
+ * required for German legal compliance front-and-centre.
+ *
+ * The Open-Meteo CC-BY 4.0 attribution that ADR-017/ADR-015 added here
+ * was removed alongside disabling the dashboard weather chart
+ * (ActivityWeatherChart in ModulePanel) — with no weather data rendered
+ * to the operator anywhere in the UI, the attribution is no longer tied
+ * to a visible use. Restore both together when the weather chart is
+ * re-enabled against real data.
  */
 export default function SiteFooter() {
   const { t } = useTranslation();
@@ -21,14 +23,6 @@ export default function SiteFooter() {
             className="text-hf-honey-300 hover:text-hf-honey-200 underline underline-offset-4 rounded-md"
           >
             {t('common.impressum')}
-          </a>
-          <a
-            href="https://open-meteo.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-hf-honey-300 hover:text-hf-honey-200 underline underline-offset-4 rounded-md"
-          >
-            {t('common.weatherAttribution')}
           </a>
         </div>
       </div>

--- a/tests/ui/tests/module-battery-history.spec.ts
+++ b/tests/ui/tests/module-battery-history.spec.ts
@@ -19,7 +19,15 @@ import { test, expect } from '@playwright/test';
 // `module-panel-rendering.spec.ts` applies here too — scope every
 // assertion to the desktop `<aside>` complementary landmark.
 
-test.describe('battery history chart (issue #110)', () => {
+// TODO(perf/data): Re-enable together with <BatteryHistoryChart> in
+// ModulePanel.tsx. The chart was commented out (perf/dashboard-load)
+// because the seeded `battery_pct` series is fabricated firmware data
+// (`random(1,100)`). While the chart is shelved this spec is skipped —
+// keep it intact so re-enabling the chart re-enables its Playwright gate
+// in the same change (CLAUDE.md rule 4 / ADR-014). The
+// `data-testid="battery-history-chart"` node never mounts today, so
+// every assertion below would time out.
+test.describe.skip('battery history chart (issue #110)', () => {
   test('seeded Garten 12 module renders the BatteryHistoryChart with sampled buckets', async ({
     page,
   }) => {
@@ -41,7 +49,9 @@ test.describe('battery history chart (issue #110)', () => {
     // Heading reads either English ("Battery history") or German
     // ("Akku-Verlauf") depending on the test environment locale. Match
     // both — the spec asserts presence, not language.
-    await expect(chart.getByRole('heading', { name: /Battery history|Akku-Verlauf/ })).toBeVisible();
+    await expect(
+      chart.getByRole('heading', { name: /Battery history|Akku-Verlauf/ }),
+    ).toBeVisible();
 
     // Seed data populates 168 hourly samples — the empty state must
     // NOT appear. This is the load-bearing assertion: if the


### PR DESCRIPTION
Addresses slow dashboard load, janky map circles, and a slow side panel.

Side panel: comment out ActivityWeatherChart + BatteryHistoryChart in ModulePanel — both render currently-fabricated data (battery is firmware random(1,100); weather fired a slow browser-direct Open-Meteo fetch on every panel open). With no production importer, recharts tree-shakes out of the dashboard chunk entirely.

Backend: add a 5s in-memory snapshot cache + in-flight dedupe to ModuleReadModel, shared by listModules and getModuleDetail. Previously getModuleDetail re-ran the full four-endpoint duckdb fan-out just to find one module by id. A degraded fan-out (any upstream fetch failed) is returned but not cached, so a transient outage can't pin partial state.

Map: render vector circles to canvas (preferCanvas) instead of one SVG path per circle, and memoize the badge divIcon factory so icons aren't rebuilt on every zoom tick.

Footer: remove the Open-Meteo CC-BY attribution link — with the weather chart disabled, no Open-Meteo data renders anywhere, so the UI attribution duty is dormant (the server-side worker keeps ingesting). Re-enable the link in the same change that re-enables the chart.

Docs: ADR-017 status note couples chart/link/worker; api-reference §1.2 documents the new <=5s staleness contract. The battery-chart Playwright spec is skipped (re-enable with the chart).

# Pull Request

## What changed

<!-- A short summary of the change. Bullet points are fine. -->

## Why

<!-- Motivation / linked issue (e.g. Closes #123). What problem does this solve? -->

## How tested

Mark each suite that was run locally and passed. Leave unchecked if not applicable
(but explain why in a comment).

- [ ] ESP32-CAM native (`pio test -e native`)
- [ ] End-to-end (`pytest tests/e2e`)
- [ ] Backend unit (Node 22 + TS)
- [ ] image-service unit (Python 3.11)
- [ ] duckdb-service unit (Python 3.11)
- [ ] Homepage unit (React 19 + Vite)
- [ ] Manual / hardware-in-the-loop verification (describe below)

<!-- Notes on test environment, fixtures, or manual steps. -->

## Checklist

- [ ] Tests added or updated to cover the change
- [ ] Documentation updated where applicable (README, ARCHITECTURE, service-level docs)
- [ ] No secrets, credentials, or large binaries committed
- [ ] CI is green on this branch
- [ ] Breaking changes called out in the description (API, schema, env vars, hardware)

## Screenshots / logs (optional)

<!-- UI changes, before/after, or relevant log excerpts. -->
