### PR TITLE
feat(admin): paginate image gallery (5 + load more), fix slow image list

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -192,20 +192,32 @@ app.get('/api/modules/:id', async (req, res) => {
   }
 });
 
-// Image listing (proxied to image-service)
+// Image listing (proxied to image-service). Forwards module_id/limit/
+// offset for newest-first pagination; response is the ImageUploadsPage
+// envelope ({ images, total }) from the contracts package.
 app.get('/api/images', async (req, res) => {
   try {
-    const moduleId = req.query.module_id;
-    const url = moduleId
-      ? `${IMAGE_SERVICE_URL}/images?module_id=${encodeURIComponent(String(moduleId))}`
-      : `${IMAGE_SERVICE_URL}/images`;
-    const response = await fetch(url);
+    const params = new URLSearchParams();
+    for (const key of ['module_id', 'limit', 'offset']) {
+      const value = req.query[key];
+      if (value !== undefined) params.set(key, String(value));
+    }
+    const qs = params.toString();
+    const url = `${IMAGE_SERVICE_URL}/images${qs ? `?${qs}` : ''}`;
+    // 15s ceiling so a hung image-service can't hang this hop
+    // indefinitely — matches image-service's own read timeout, keeping
+    // the proxy chain free of any unbounded fetch.
+    const response = await fetch(url, { signal: AbortSignal.timeout(15000) });
+    // Masks any upstream non-2xx (incl. a duckdb 400 on a bad module_id)
+    // as 502 by design — these routes are only ever called with the
+    // admin dropdown's canonical ids and integer paging, so an upstream
+    // 4xx is unreachable in practice.
     if (!response.ok) throw new Error(`Image service error: ${response.status}`);
     const data = await response.json();
     res.json(data);
   } catch (error) {
     console.error('[GET /api/images]', {
-      moduleId: req.query.module_id,
+      query: req.query,
       error: String(error),
     });
     res.status(502).json({ error: 'Failed to fetch images from image service' });

--- a/backend/tests/error-logging.test.ts
+++ b/backend/tests/error-logging.test.ts
@@ -87,7 +87,7 @@ describe('5xx-returning catch blocks log structured errors (#32)', () => {
     expect(consoleError).toHaveBeenCalledWith(
       '[GET /api/images]',
       expect.objectContaining({
-        moduleId: 'aabbccddeeff',
+        query: expect.objectContaining({ module_id: 'aabbccddeeff' }),
         error: expect.stringContaining('img-list down'),
       }),
     );

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -132,6 +132,34 @@ export interface ModuleDetail extends Module {
   nests: NestData[];
 }
 
+// ---- Image uploads ----
+//
+// Wire-shape returned by `GET /api/images` (backend proxies
+// `image-service GET /images`, which proxies `duckdb-service GET
+// /image_uploads`). Newest-first. Lives here, not in
+// `homepage/src/services/api.ts`, per ADR-004 — any DTO crossing the
+// backend↔homepage boundary belongs in the shared workspace package.
+
+export interface ImageUpload {
+  module_id: string;
+  filename: string;
+  // UTC, NOT full ISO-8601 (no 'T'/'Z'). In practice "YYYY-MM-DD
+  // HH:MM:SS" because `record_image` writes it at second resolution,
+  // but the reader (`list_image_uploads`) emits `str()` of a DuckDB
+  // TIMESTAMP and does not re-format — a row written with sub-second
+  // precision would surface fractional seconds. Treat as an opaque
+  // sortable string; parse defensively if you ever need a Date.
+  uploaded_at: string;
+}
+
+// Paginated envelope. `total` is the full count matching the filter,
+// ignoring limit/offset — the admin UI uses it to decide whether to
+// render a "Load more" button.
+export interface ImageUploadsPage {
+  images: ImageUpload[];
+  total: number;
+}
+
 // ---- Telemetry sidecar envelope ----
 //
 // Wire-shape returned by `image-service /modules/<mac>/logs` (proxied

--- a/docs/08-crosscutting-concepts/api-contracts.md
+++ b/docs/08-crosscutting-concepts/api-contracts.md
@@ -273,6 +273,52 @@ wire JSON are deliberately close enough that the proxy is one
 `.map((b) => ({ timestamp, value, sampleCount }))` and not a
 field-by-field transform.
 
+## `ImageUploadsPage` — admin gallery pagination
+
+Served by `GET /api/images` (backend), which proxies
+`image-service GET /images` → `duckdb-service GET /image_uploads`.
+The admin gallery (`homepage/src/pages/AdminPage.tsx`) loads the
+newest `PAGE_SIZE` rows and reveals the rest via a "Load more"
+button. The type lives in `contracts/src/index.ts`:
+
+```ts
+export interface ImageUpload {
+  module_id: string;
+  filename: string;
+  uploaded_at: string; // UTC, no 'T'/'Z'. "YYYY-MM-DD HH:MM:SS" as record_image writes it (second res); the reader emits str() of a DuckDB TIMESTAMP and does not re-format, so sub-second rows would carry fractional seconds. Treat as opaque + sortable.
+}
+
+export interface ImageUploadsPage {
+  images: ImageUpload[];
+  total: number; // full count matching the filter, IGNORING limit/offset
+}
+```
+
+Query params forwarded verbatim through every hop: `module_id?` (filter),
+`limit?` (1-500, omit for all), `offset?` (≥0). Two non-obvious contract
+details:
+
+- **`total` is the un-paged count.** It is the count of all rows
+  matching `module_id`, not `images.length`. The UI compares
+  `images.length < total` to decide whether to show "Load more", and
+  the client falls back to `images.length` if a (pre-pagination) response
+  omits `total`. Pinned by `homepage/src/__tests__/api-getImages.test.ts`
+  and `duckdb-service/tests/test_module_endpoints.py`.
+- **Deterministic capture order.** Rows are ordered
+  `uploaded_at DESC, id DESC` — newest capture first, with `id`
+  (monotonic insertion sequence) as a stable tiebreaker. Without the
+  tiebreaker, two uploads sharing a timestamp (`uploaded_at` is
+  second-resolution) sort arbitrarily, so `limit`/`offset` paging could
+  duplicate one row and skip another. The total order makes "Load more"
+  safe.
+- **Bounded by construction.** An un-paged list over a large
+  `image_uploads` table is slow; never proxy it across a short timeout.
+  See the chapter 11 "failed to load images" incident.
+
+Per ADR-004 the type lives in `@highfive/contracts`; the previous
+service-local `interface ImageUpload` in `homepage/src/services/api.ts`
+was the exact smell that rule warns against and is now a re-export.
+
 ## Field-name drift to watch for
 
 These three patterns have caused real bugs. Grep before changing
@@ -323,12 +369,13 @@ Python ↔ Python boundary between `image-service` and `duckdb-service`
 has no shared-types mechanism. Wire shapes on this boundary are
 documented here and pinned by tests on both sides.
 
-| Endpoint                                   | Caller                                                  | Payload fields                                                       |
-| ------------------------------------------ | ------------------------------------------------------- | -------------------------------------------------------------------- |
-| `POST /add_progress_for_module`            | `image-service`'s `UploadPipeline._record_progress`     | `module_id` (canonical, `modul_id` alias accepted), `classification` |
-| `POST /record_image`                       | `image-service`'s `UploadPipeline._record_image_upload` | `module_id` (canonical), `filename`                                  |
-| `POST /modules/<module_id>/heartbeat`      | `image-service`'s `UploadPipeline._record_heartbeat`    | `battery` (int 0-100)                                                |
-| `GET  /modules/<module_id>/progress_count` | `image-service`'s `UploadPipeline._check_first_upload`  | (no body)                                                            |
+| Endpoint                                   | Caller                                                  | Payload fields                                                                                                                                                                                                                                                      |
+| ------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /add_progress_for_module`            | `image-service`'s `UploadPipeline._record_progress`     | `module_id` (canonical, `modul_id` alias accepted), `classification`                                                                                                                                                                                                |
+| `POST /record_image`                       | `image-service`'s `UploadPipeline._record_image_upload` | `module_id` (canonical), `filename`                                                                                                                                                                                                                                 |
+| `POST /modules/<module_id>/heartbeat`      | `image-service`'s `UploadPipeline._record_heartbeat`    | `battery` (int 0-100)                                                                                                                                                                                                                                               |
+| `GET  /modules/<module_id>/progress_count` | `image-service`'s `UploadPipeline._check_first_upload`  | (no body)                                                                                                                                                                                                                                                           |
+| `GET  /image_uploads`                      | `image-service`'s `list_images` (admin gallery proxy)   | query: `module_id?`, `limit?` (1-500), `offset?` (≥0); response: `{ images: [{module_id, filename, uploaded_at}], total }`, newest-first. `total` ignores the page window. Proxied at a 15s read timeout — never unbounded across a short timeout (see chapter 11). |
 
 Server-side canonicalisation through `ModuleId.model_validate(...)` is
 the rule, not the exception — colon-/dash-separated and uppercase

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -86,6 +86,50 @@ write the lesson here so the next contributor doesn't repeat it.
 Format: short title + **What happened** + **Why it happened** +
 **How to avoid it next time**.
 
+### Admin "failed to load images": stale `IMAGE_SERVICE_URL` after a no-`--update-env` PM2 restart, masking an unbounded image-list query that tripped a 5s timeout
+
+**What happened.** The admin page (`/admin`) showed "Failed to load
+images. Is the image service running?" while the image-service PM2
+process was healthy and serving. Two independent faults stacked:
+
+1. The backend (`highfive-api`) had been restarted at some point
+   _without_ `--update-env`, so PM2 reused the environment captured at
+   first launch — from before `IMAGE_SERVICE_URL` was added to
+   `ecosystem.config.js`. `pm2 env <id>` showed `DUCKDB_SERVICE_URL`
+   but no `IMAGE_SERVICE_URL`, so the backend fell back to its dev
+   default `http://image-service:4444` (a **Docker** service name that
+   does not resolve on the PM2 host). Every `/api/images` 502'd.
+2. After fixing the env, images _still_ failed: `duckdb-service`'s
+   `GET /image_uploads` ran `SELECT … ORDER BY uploaded_at DESC` with
+   **no `LIMIT`**, returning all ~15k rows in ~12s against an 8 GB DB
+   file. `image-service`'s proxy used a **5-second** read timeout, so
+   the call timed out → 500 → 502 at the backend → the same UI error.
+
+**Why it happened.** (1) `pm2 restart`/`reload` does _not_ re-read the
+ecosystem `env` block unless you pass `--update-env`; a config edit is
+invisible to a running process until then, so the file looked correct
+while the live env was stale. (2) The list query was written when the
+table was small; an unbounded `ORDER BY` over a bloated table crossed
+the fixed proxy timeout as data grew. The 8 GB file (mostly churn from
+high-frequency tables, not the 15k image rows) made even a 15k-row
+sort slow.
+
+**How to avoid it next time.** After editing `ecosystem.config.js`
+env, deploy with `pm2 reload ecosystem.config.js --update-env` and
+verify with `pm2 env <id>` — never trust the file alone. Never proxy
+an unbounded list across a fixed network timeout: paginate at the
+source (`limit`/`offset`, newest-first) so latency is bounded by page
+size, not table size, and pick a timeout with real headroom over the
+worst-case _bounded_ page (here 15s vs a ~50ms page). When a symptom
+points at a service ("is X running?"), confirm the _path_ end-to-end
+(`pm2 env`, `getent hosts <name>`, time the slow hop with `curl -w
+%{time_total}`) before concluding the service is down — here it never
+was. The fix is `duckdb-service/routes/modules.py`'s
+`list_image_uploads` (now `LIMIT`/`OFFSET` + `total`), the bumped
+timeout in `image-service/app.py`'s `list_images`, and the
+`feat/admin-image-pagination` "Load more" UI in
+`homepage/src/pages/AdminPage.tsx`.
+
 ### `image_uploads.uploaded_at` stamped in container-local time, new reader assumed UTC (ADR-015 review)
 
 **What happened.** When the `activity_timeseries` endpoint landed

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -568,6 +568,52 @@ Reads `*.log.json` sidecars on disk, filters by `mac` (envelope field),
 sorts by mtime descending, and returns the newest N (default 10, max 100).
 Used by the backend admin proxy in section 1.4.
 
+## 2.4 List images (admin gallery)
+
+```
+GET /images?module_id=<mac>&limit=N&offset=M
+```
+
+Proxies `duckdb-service GET /image_uploads` (§3.14) verbatim. The
+backend exposes this unchanged at `GET /api/images`, which the admin
+image gallery (`homepage/src/pages/AdminPage.tsx`) calls — it loads the
+newest `PAGE_SIZE` (5) and reveals the rest via "Load more".
+
+Query parameters, all optional:
+
+- `module_id` — canonical or colon-/dash-separated MAC; filters to one
+  module (canonicalised server-side in duckdb).
+- `limit` — page size, clamped to `[1, 500]`. **Omit** to return all
+  rows (back-compat); a _malformed_ value degrades to the 500 cap, never
+  to unbounded.
+- `offset` — rows to skip (≥0), for "Load more" pagination.
+
+Response is the `{ images, total }` envelope (newest-first):
+
+```json
+{
+  "images": [
+    {
+      "module_id": "aabbccddeeff",
+      "filename": "esp_capture_…jpg",
+      "uploaded_at": "2026-06-03 10:00:06"
+    }
+  ],
+  "total": 15352
+}
+```
+
+`total` is the full count matching `module_id`, **ignoring** `limit`/`offset`
+— the UI compares `images.length < total` to decide whether to keep the
+"Load more" button. Ordering is `uploaded_at DESC, id DESC` (deterministic;
+see §3.14). Proxied at a **15s** read timeout — never proxy an un-paginated
+list across a short timeout (chapter 11 "failed to load images").
+
+The TypeScript wire type is `ImageUploadsPage` in
+[`contracts/src/index.ts`](../contracts/src/index.ts); see
+[api-contracts.md](08-crosscutting-concepts/api-contracts.md) for the
+backend↔homepage contract.
+
 <br>
 
 # 3. DuckDB Service API
@@ -999,6 +1045,47 @@ A partial failure (some modules' Open-Meteo calls fail mid-run) is
 reported in the `errors` array, NOT a non-2xx status. The endpoint
 distinguishes "the request itself was bad" (400) from "the work was
 attempted but some modules failed" (200 with errors).
+
+## 3.14 List image uploads
+
+```
+GET /image_uploads?module_id=<mac>&limit=N&offset=M
+```
+
+Newest-first list of `image_uploads` rows, paginated. Proxied by
+`image-service GET /images` (§2.4) and `backend GET /api/images`; backs
+the admin gallery.
+
+Query parameters, all optional:
+
+- `module_id` — filter to one module; canonicalised via
+  `_canonicalize_or_400` (a non-canonicalisable value → `400`).
+- `limit` — page size, clamped to `[1, 500]`. **Omit** → all rows
+  (back-compat). A malformed value degrades to the `500` cap, never to
+  the unbounded query.
+- `offset` — rows to skip (≥0).
+
+```json
+{
+  "images": [
+    {
+      "module_id": "aabbccddeeff",
+      "filename": "esp_capture_…jpg",
+      "uploaded_at": "2026-06-03 10:00:06"
+    }
+  ],
+  "total": 15352
+}
+```
+
+`total` is the count matching `module_id`, **ignoring** `limit`/`offset`.
+Ordering is `ORDER BY uploaded_at DESC, id DESC` — newest capture first,
+with the monotonic `id` (insertion sequence) as a stable tiebreaker so
+two rows sharing a second-resolution `uploaded_at` cannot duplicate or
+skip across pages. Implementation: `duckdb-service/routes/modules.py`'s
+`list_image_uploads`. The unbounded variant (omitted `limit`) is slow on
+a large table — see chapter 11 "failed to load images"; callers should
+always paginate.
 
 <br>
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,6 +30,41 @@ DEBUG=true
 DUCKDB_SERVICE_URL=http://duckdb-service:8000
 ```
 
+### Admin page (`/admin`) shows "Failed to load images. Is the image service running?"
+
+**Symptom.** The admin image gallery renders the error banner even though
+`pm2 list` shows `image-service` online. `GET /api/images` returns `502`.
+
+**Likely causes, in order.**
+
+1. **Stale backend env after a PM2 restart without `--update-env`.**
+   `pm2 restart`/`reload` does not re-read the `env` block in
+   `ecosystem.config.js` unless you pass `--update-env`, so the backend
+   can keep an old environment from before `IMAGE_SERVICE_URL` was set —
+   falling back to the Docker name `http://image-service:4444`, which
+   does not resolve on a PM2 host. Check and fix:
+
+   ```bash
+   pm2 env 0 | grep -E "IMAGE_SERVICE_URL|DUCKDB_SERVICE_URL"   # is it set?
+   getent hosts image-service || echo "Docker name does not resolve here"
+   pm2 reload ecosystem.config.js --update-env                  # re-read env
+   ```
+
+2. **A slow, un-paginated image list tripping the proxy timeout.** A
+   bare `GET /image_uploads` over a large table can take >5s; the admin
+   gallery now paginates (newest-first `limit`/`offset`) and the
+   image-service proxy timeout is 15s, but a caller that omits `limit`
+   still pays the full cost. Time the hops to locate the slow one:
+
+   ```bash
+   curl -s -o /dev/null -w "image:  %{http_code} %{time_total}s\n" http://127.0.0.1:4444/images
+   curl -s -o /dev/null -w "duckdb: %{http_code} %{time_total}s\n" http://127.0.0.1:8000/image_uploads
+   ```
+
+   "Is the service running?" is usually the wrong question — confirm the
+   _path_ end-to-end before concluding a service is down. See chapter 11
+   "failed to load images" for the full incident.
+
 ### `duckdb-service` exits with `RuntimeError: module_configs status-drop migration failed`
 
 **Symptom.** Container restart loop with a `RuntimeError: module_configs status-drop migration failed: ...` traceback in `docker compose logs duckdb-service`. The transactional rebuild migration (issue #69) refused to mid-state the DB and rolled back; the container is refusing to serve a half-migrated schema.

--- a/duckdb-service/routes/modules.py
+++ b/duckdb-service/routes/modules.py
@@ -563,24 +563,81 @@ def delete_image_upload(filename):
 
 @modules_bp.get("/image_uploads")
 def list_image_uploads():
+    """List image uploads, newest first, with optional pagination.
+
+    Query params:
+      * module_id — filter to one module's uploads.
+      * limit     — page size (1..500). Omit to return every row.
+      * offset    — rows to skip (>=0), for "load more" pagination.
+
+    Wire shape: ``{"images": [...], "total": N}`` where ``total`` is the
+    full count matching the filter, *ignoring* limit/offset — the admin
+    UI needs it to decide whether to show a "Load more" button.
+
+    The ``LIMIT`` fixes the slow-list incident: an un-paginated
+    ``ORDER BY uploaded_at DESC`` over a bloated ``image_uploads`` table
+    took ~12s, tripping image-service's read timeout and surfacing as
+    "failed to load images" in the admin UI. A bounded page returns in
+    ~50ms.
+    """
     module_id = request.args.get("module_id")
+    # Canonicalise the filter for parity with every sibling route
+    # (record_image, delete_image_upload, activity_timeseries, …) so a
+    # colon-/dash-separated MAC matches instead of silently returning
+    # zero rows. Optional: absent filter = list across all modules.
+    if module_id is not None:
+        module_id, err = _canonicalize_or_400(module_id)
+        if err:
+            return err
+    raw_limit = request.args.get("limit")
+    raw_offset = request.args.get("offset")
+    MAX_LIMIT = 500
+    if raw_limit is None:
+        limit = None  # caller explicitly opted into "all rows" (back-compat)
+    else:
+        try:
+            limit = int(raw_limit)
+        except ValueError:
+            # A malformed limit must NOT fall through to None/unbounded —
+            # that is precisely the slow-list incident this endpoint was
+            # paginated to prevent. Degrade to the cap, never to "all".
+            limit = MAX_LIMIT
+        limit = max(1, min(limit, MAX_LIMIT))
+    try:
+        offset = max(0, int(raw_offset)) if raw_offset is not None else 0
+    except ValueError:
+        offset = 0
+
+    where = "WHERE module_id = ?" if module_id else ""
+    where_params = [module_id] if module_id else []
     with lock:
         con = get_conn()
         try:
-            if module_id:
-                rows = con.execute(
-                    "SELECT module_id, filename, uploaded_at FROM image_uploads WHERE module_id = ? ORDER BY uploaded_at DESC",
-                    (module_id,),
-                ).fetchall()
-            else:
-                rows = con.execute(
-                    "SELECT module_id, filename, uploaded_at FROM image_uploads ORDER BY uploaded_at DESC"
-                ).fetchall()
+            total = con.execute(
+                f"SELECT COUNT(*) FROM image_uploads {where}", where_params
+            ).fetchone()[0]
+            # `id DESC` is a stable tiebreaker, NOT decoration: with only
+            # `uploaded_at DESC`, two uploads sharing a timestamp (same
+            # second/microsecond) sort in an undefined order that can
+            # differ between the page-1 query and the page-2 query — so
+            # LIMIT/OFFSET paging would duplicate one row and skip
+            # another. `id` is the monotonic insertion sequence (capture
+            # order), so `uploaded_at DESC, id DESC` is a strict total
+            # order: newest capture first, deterministic across pages.
+            sql = (
+                "SELECT module_id, filename, uploaded_at "
+                f"FROM image_uploads {where} ORDER BY uploaded_at DESC, id DESC"
+            )
+            query_params = list(where_params)
+            if limit is not None:
+                sql += " LIMIT ? OFFSET ?"
+                query_params += [limit, offset]
+            rows = con.execute(sql, query_params).fetchall()
             images = [
                 {"module_id": r[0], "filename": r[1], "uploaded_at": str(r[2])}
                 for r in rows
             ]
-            return jsonify(images=images), 200
+            return jsonify(images=images, total=total), 200
         except Exception as e:
             return jsonify({"error": str(e)}), 500
         finally:

--- a/duckdb-service/tests/test_module_endpoints.py
+++ b/duckdb-service/tests/test_module_endpoints.py
@@ -504,3 +504,97 @@ def test_activity_timeseries_excludes_other_modules(client, fresh_db):
     assert resp.status_code == 200
     body = resp.get_json()
     assert all(b["count"] == 0 for b in body["buckets"])
+
+
+# ---------- GET /image_uploads pagination ----------
+
+
+def test_image_uploads_pagination_pages_newest_first(client, fresh_db):
+    """limit/offset return the right *rows* (newest first), with a stable
+    `total` across pages — not just a correctly-shaped envelope."""
+    _seed_module(fresh_db, TEST_MAC_1)
+    # Five uploads, ascending timestamps → "e" is newest.
+    for letter, day in zip("abcde", range(1, 6)):
+        _seed_image_upload(
+            fresh_db, TEST_MAC_1, f"{letter}.jpg", f"2024-06-0{day} 12:00:00"
+        )
+
+    page1 = client.get("/image_uploads?limit=2").get_json()
+    assert page1["total"] == 5
+    assert [i["filename"] for i in page1["images"]] == ["e.jpg", "d.jpg"]
+
+    page2 = client.get("/image_uploads?limit=2&offset=2").get_json()
+    assert page2["total"] == 5  # total ignores the page window
+    assert [i["filename"] for i in page2["images"]] == ["c.jpg", "b.jpg"]
+
+    page3 = client.get("/image_uploads?limit=2&offset=4").get_json()
+    assert [i["filename"] for i in page3["images"]] == ["a.jpg"]  # last partial page
+
+
+def test_image_uploads_total_respects_module_filter(client, fresh_db):
+    """`total` counts only rows matching ?module_id=, so the UI's "load
+    more" math is correct under a filter."""
+    _seed_module(fresh_db, TEST_MAC_1)
+    _seed_module(fresh_db, TEST_MAC_2)
+    _seed_image_upload(fresh_db, TEST_MAC_1, "a.jpg", "2024-06-01 12:00:00")
+    _seed_image_upload(fresh_db, TEST_MAC_1, "b.jpg", "2024-06-02 12:00:00")
+    _seed_image_upload(fresh_db, TEST_MAC_2, "other.jpg", "2024-06-03 12:00:00")
+
+    body = client.get(f"/image_uploads?module_id={TEST_MAC_1}&limit=1").get_json()
+    assert body["total"] == 2  # not 3 — the other module is excluded
+    assert [i["filename"] for i in body["images"]] == ["b.jpg"]  # newest of the two
+
+
+def test_image_uploads_pagination_deterministic_on_tied_timestamps(client, fresh_db):
+    """Rows sharing an `uploaded_at` must page without overlap or gaps:
+    the `id DESC` tiebreaker makes the order a strict total order, so
+    page1 ∪ page2 covers every row exactly once (the bug a bare
+    `ORDER BY uploaded_at DESC` would cause under LIMIT/OFFSET)."""
+    _seed_module(fresh_db, TEST_MAC_1)
+    tied = "2024-06-01 12:00:00"
+    for letter in "abcd":
+        _seed_image_upload(fresh_db, TEST_MAC_1, f"{letter}.jpg", tied)
+
+    page1 = client.get("/image_uploads?limit=2&offset=0").get_json()
+    page2 = client.get("/image_uploads?limit=2&offset=2").get_json()
+    # a,b,c,d inserted in that order → ids ascending → id DESC = d,c,b,a.
+    # Pin the actual order, not just set coverage: an `id ASC` tiebreaker
+    # would also give no-dup/no-skip, so coverage alone can't catch a
+    # reversed tiebreaker.
+    assert [i["filename"] for i in page1["images"]] == ["d.jpg", "c.jpg"]
+    assert [i["filename"] for i in page2["images"]] == ["b.jpg", "a.jpg"]
+    seen = [i["filename"] for i in page1["images"]] + [
+        i["filename"] for i in page2["images"]
+    ]
+    assert sorted(seen) == ["a.jpg", "b.jpg", "c.jpg", "d.jpg"]  # no dup, no skip
+    assert len(set(seen)) == 4
+
+
+def test_image_uploads_malformed_limit_does_not_become_unbounded(client, fresh_db):
+    """A garbage `limit` must degrade to a finite cap, never to the
+    unbounded query the pagination exists to avoid. Proven via `offset`:
+    if the bad limit fell through to None, `offset` would be ignored
+    (the route only applies LIMIT/OFFSET when limit is set) and all 3
+    rows would return; a finite cap honours the offset and returns 2."""
+    _seed_module(fresh_db, TEST_MAC_1)
+    for letter, day in zip("abc", range(1, 4)):
+        _seed_image_upload(
+            fresh_db, TEST_MAC_1, f"{letter}.jpg", f"2024-06-0{day} 12:00:00"
+        )
+
+    body = client.get("/image_uploads?limit=abc&offset=1").get_json()
+    assert body["total"] == 3
+    # offset honoured (skip newest "c.jpg") → "b.jpg", "a.jpg"
+    assert [i["filename"] for i in body["images"]] == ["b.jpg", "a.jpg"]
+
+
+def test_image_uploads_without_limit_returns_all_with_total(client, fresh_db):
+    """Omitting limit returns every row (back-compat) and still reports
+    `total`."""
+    _seed_module(fresh_db, TEST_MAC_1)
+    _seed_image_upload(fresh_db, TEST_MAC_1, "a.jpg", "2024-06-01 12:00:00")
+    _seed_image_upload(fresh_db, TEST_MAC_1, "b.jpg", "2024-06-02 12:00:00")
+
+    body = client.get("/image_uploads").get_json()
+    assert body["total"] == 2
+    assert len(body["images"]) == 2

--- a/homepage/.env.example
+++ b/homepage/.env.example
@@ -9,7 +9,10 @@ VITE_STRIPE_LINK=https://buy.stripe.com/your-link-here
 #   VITE_INIT_BASE_URL  → http://localhost:8002       (duckdb-service, sent to ESP)
 #   VITE_UPLOAD_BASE_URL→ http://localhost:8000       (image-service, sent to ESP)
 #
-# For PRODUCTION deployment:
+# For PRODUCTION deployment (VITE_API_URL is REQUIRED — a prod `vite build`
+# with it unset compiles fine but THROWS at first page load via
+# src/services/api-key-validator.ts, rendering a blank page on every route.
+# Set it here, in .env.production, or inline: `VITE_API_URL=… npm run build`):
 #   VITE_API_URL=https://api.highfive-bees.com/api
 #   VITE_INIT_BASE_URL=https://api.highfive-bees.com:8002
 #   VITE_UPLOAD_BASE_URL=https://api.highfive-bees.com:8000

--- a/homepage/src/__tests__/api-getImages.test.ts
+++ b/homepage/src/__tests__/api-getImages.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { api } from '../services/api';
+
+// Wire-shape round-trip pin for `api.getImages` per CLAUDE.md rule #3.
+// The admin gallery (`AdminPage.tsx`) renders this shape and decides
+// whether to show "Load more" from `total`, so the fixture mirrors
+// EXACTLY what `GET /api/images` emits: the `{ images, total }`
+// envelope that backend proxies from image-service → duckdb-service's
+// `list_image_uploads` (pinned on the other half by
+// `duckdb-service/tests/test_module_endpoints.py`).
+
+const VALID_ID = 'aabbccddeeff';
+
+const wirePage = {
+  images: [
+    { module_id: VALID_ID, filename: 'b.jpg', uploaded_at: '2024-06-02 12:00:00' },
+    { module_id: VALID_ID, filename: 'a.jpg', uploaded_at: '2024-06-01 12:00:00' },
+  ],
+  total: 7,
+};
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('api.getImages wire-shape round trip', () => {
+  it('parses the { images, total } envelope the backend actually emits', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => wirePage,
+    });
+
+    const page = await api.getImages(VALID_ID, { limit: 2, offset: 0 });
+
+    // `total` (not images.length) is what drives the "Load more" button,
+    // so it must survive the round trip intact.
+    expect(page.total).toBe(7);
+    expect(page.images.map((i) => i.filename)).toEqual(['b.jpg', 'a.jpg']);
+  });
+
+  it('forwards module_id/limit/offset verbatim to the backend URL', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ images: [], total: 0 }),
+    });
+
+    await api.getImages(VALID_ID, { limit: 5, offset: 10 });
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const u = new URL(String(url));
+    expect(u.pathname.endsWith('/images')).toBe(true);
+    expect(u.searchParams.get('module_id')).toBe(VALID_ID);
+    expect(u.searchParams.get('limit')).toBe('5');
+    expect(u.searchParams.get('offset')).toBe('10');
+  });
+
+  it('omits all params when called bare (no filter, no paging)', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ images: [], total: 0 }),
+    });
+
+    await api.getImages();
+
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const u = new URL(String(url));
+    expect(u.search).toBe('');
+  });
+
+  it('falls back to images.length when an old response omits total', async () => {
+    // Back-compat: a pre-pagination image-service (or a cached old
+    // response) returns just { images }. The client must still produce a
+    // usable `total` so the gallery does not render a phantom "Load more".
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ images: wirePage.images }),
+    });
+
+    const page = await api.getImages(VALID_ID, { limit: 2, offset: 0 });
+    expect(page.total).toBe(2);
+  });
+
+  it('throws on a non-2xx response (AdminPage catches as an error state)', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => ({ error: 'Failed to fetch images from image service' }),
+    });
+    await expect(api.getImages(VALID_ID)).rejects.toThrow(/Failed to fetch images/);
+  });
+});

--- a/homepage/src/pages/AdminPage.tsx
+++ b/homepage/src/pages/AdminPage.tsx
@@ -1,12 +1,17 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { api, ImageUpload } from '../services/api';
+import { api } from '../services/api';
+import type { ImageUpload } from '../services/api';
 import type { Module } from '@highfive/contracts';
 import RenameModuleModal from '../components/RenameModuleModal';
 import { hasPlausibleLocation } from '../lib/location';
 import { displayLabel } from '../lib/displayLabel';
 
 const SESSION_KEY = 'highfive_admin_auth';
+// Admin image gallery loads newest-first in pages of this size; the rest
+// come in via the "Load more" button. Keeps the initial render fast on a
+// large image_uploads table (see the slow-list incident in chapter 11).
+const PAGE_SIZE = 5;
 
 function LoginGate({ onAuth }: { onAuth: () => void }) {
   const [password, setPassword] = useState('');
@@ -68,6 +73,8 @@ export default function AdminPage() {
   const [authed, setAuthed] = useState(() => !!sessionStorage.getItem(SESSION_KEY));
   const [modules, setModules] = useState<Module[]>([]);
   const [images, setImages] = useState<ImageUpload[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [selectedModule, setSelectedModule] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -105,17 +112,45 @@ export default function AdminPage() {
     }
   };
 
+  // Load the first page (newest first), replacing whatever is shown.
+  // Runs on auth and whenever the module filter changes.
   const loadImages = async () => {
     try {
       setLoading(true);
       setError(null);
-      const data = await api.getImages(selectedModule || undefined);
-      setImages(data);
+      const page = await api.getImages(selectedModule || undefined, {
+        limit: PAGE_SIZE,
+        offset: 0,
+      });
+      setImages(page.images);
+      setTotal(page.total);
     } catch (err) {
       setError('Failed to load images. Is the image service running?');
       console.error('Failed to load images:', err);
     } finally {
       setLoading(false);
+    }
+  };
+
+  // Append the next page, offset by what's already loaded. `total` is
+  // refreshed from each response so the "Load more" button hides once
+  // everything is loaded. Note: this is offset paging, so row identity
+  // across pages is not transaction-consistent under a concurrent
+  // delete — acceptable for a low-concurrency admin tool.
+  const loadMore = async () => {
+    try {
+      setLoadingMore(true);
+      const page = await api.getImages(selectedModule || undefined, {
+        limit: PAGE_SIZE,
+        offset: images.length,
+      });
+      setImages((prev) => [...prev, ...page.images]);
+      setTotal(page.total);
+    } catch (err) {
+      setError('Failed to load more images. Is the image service running?');
+      console.error('Failed to load more images:', err);
+    } finally {
+      setLoadingMore(false);
     }
   };
 
@@ -147,6 +182,7 @@ export default function AdminPage() {
     try {
       await api.deleteImage(img.filename);
       setImages((prev) => prev.filter((i) => i.filename !== img.filename));
+      setTotal((t) => Math.max(0, t - 1));
       if (lightboxImage?.filename === img.filename) setLightboxImage(null);
     } catch (err) {
       console.error('Failed to delete image:', err);
@@ -416,7 +452,8 @@ export default function AdminPage() {
 
             <div className="flex gap-6 text-sm text-gray-600">
               <div>
-                <span className="font-semibold text-gray-900">{images.length}</span> images
+                <span className="font-semibold text-gray-900">{images.length}</span>
+                {total > images.length ? ` of ${total}` : ''} images
               </div>
               <div>
                 <span className="font-semibold text-gray-900">{modules.length}</span> modules
@@ -515,6 +552,20 @@ export default function AdminPage() {
                 </div>
               </button>
             ))}
+          </div>
+        )}
+
+        {/* Load more — shown while fewer than `total` rows are loaded.
+            Fetches the next PAGE_SIZE newest-first and appends them. */}
+        {!loading && !error && images.length < total && (
+          <div className="flex justify-center mt-8">
+            <button
+              onClick={loadMore}
+              disabled={loadingMore}
+              className="px-6 py-2.5 bg-amber-500 hover:bg-amber-600 disabled:opacity-60 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+            >
+              {loadingMore ? 'Loading…' : `Load more (${total - images.length} left)`}
+            </button>
           </div>
         )}
       </main>

--- a/homepage/src/pages/AdminPage.tsx
+++ b/homepage/src/pages/AdminPage.tsx
@@ -504,6 +504,8 @@ export default function AdminPage() {
             {images.map((img, idx) => (
               <button
                 key={`${img.filename}-${idx}`}
+                data-testid="admin-image-cell"
+                data-filename={img.filename}
                 onClick={() => setLightboxImage(img)}
                 className="group bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden hover:shadow-md hover:border-amber-300 transition-all text-left"
               >

--- a/homepage/src/services/api.ts
+++ b/homepage/src/services/api.ts
@@ -1,5 +1,6 @@
 import type {
   ActivityTimeSeries,
+  ImageUploadsPage,
   MeasurementTimeSeries,
   Module,
   ModuleDetail,
@@ -19,11 +20,10 @@ export type { TelemetryEntry } from '@highfive/contracts';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3002/api';
 
-export interface ImageUpload {
-  module_id: string;
-  filename: string;
-  uploaded_at: string;
-}
+// Wire shape lives in the shared contracts package (ADR-004); re-exported
+// here so existing `import { ImageUpload } from '../services/api'` sites
+// keep working.
+export type { ImageUpload, ImageUploadsPage } from '@highfive/contracts';
 
 /**
  * Thrown by `api.renameModule()` when the server returns 409 because
@@ -228,16 +228,30 @@ class ApiService {
     } as MeasurementTimeSeries;
   }
 
-  async getImages(moduleId?: string): Promise<ImageUpload[]> {
-    const url = moduleId
-      ? `${this.baseUrl}/images?module_id=${encodeURIComponent(moduleId)}`
-      : `${this.baseUrl}/images`;
+  /**
+   * Fetch a page of image uploads, newest first. Pass `limit`/`offset`
+   * for "load more" pagination; omit both to fetch every row (slow on a
+   * large table — prefer paging). Returns the `{ images, total }`
+   * envelope; `total` is the full count ignoring the page window, so the
+   * caller can tell whether more rows remain. The `total` fallback keeps
+   * old wire responses (pre-pagination, no `total` field) working.
+   */
+  async getImages(
+    moduleId?: string,
+    opts?: { limit?: number; offset?: number },
+  ): Promise<ImageUploadsPage> {
+    const params = new URLSearchParams();
+    if (moduleId) params.set('module_id', moduleId);
+    if (opts?.limit != null) params.set('limit', String(opts.limit));
+    if (opts?.offset != null) params.set('offset', String(opts.offset));
+    const qs = params.toString();
+    const url = `${this.baseUrl}/images${qs ? `?${qs}` : ''}`;
     const response = await fetch(url, {
       headers: this.getHeaders(),
     });
     if (!response.ok) throw new Error('Failed to fetch images');
     const data = await response.json();
-    return data.images;
+    return { images: data.images, total: data.total ?? data.images.length };
   }
 
   async deleteImage(filename: string): Promise<void> {

--- a/image-service/app.py
+++ b/image-service/app.py
@@ -157,13 +157,31 @@ def get_module_logs(mac: str):
 
 @app.get("/images")
 def list_images():
-    """List all uploaded images, optionally filtered by ?module_id=, proxied from duckdb-service."""
-    module_id = request.args.get("module_id")
+    """List uploaded images (newest first), proxied from duckdb-service.
+
+    Query params, all optional and forwarded verbatim to duckdb-service:
+      * module_id — filter to one module's uploads
+      * limit     — page size (most-recent-first); omit for all rows
+      * offset    — rows to skip, for "load more" pagination
+
+    Returns duckdb's ``{"images": [...], "total": N}`` envelope as-is.
+
+    The timeout is deliberately generous (15s, not the old 5s): paginated
+    pages return in ~50ms, but an un-paginated caller against a large
+    ``image_uploads`` table can take >5s and used to trip the old limit,
+    surfacing as a spurious 502 "image service unreachable" in the admin
+    UI (the actual incident behind this change).
+    """
+    params = {}
+    for key in ("module_id", "limit", "offset"):
+        value = request.args.get(key)
+        if value is not None:
+            params[key] = value
     try:
         resp = http_requests.get(
             f"{DUCKDB_SERVICE_URL}/image_uploads",
-            params={"module_id": module_id} if module_id else {},
-            timeout=5,
+            params=params,
+            timeout=15,
         )
         return jsonify(resp.json()), resp.status_code
     except Exception as e:

--- a/tests/ui/scripts/seed_ui_fixtures.py
+++ b/tests/ui/scripts/seed_ui_fixtures.py
@@ -53,6 +53,11 @@ HOMEPAGE_URL = "http://localhost:6173"
 # pattern ("00...") or the e2e mock-esp default ("ee...").
 NULL_ISLAND_MAC = "ff0000000001"
 TELEMETRY_MAC = "ff1111111111"
+# Dedicated module for the admin image-gallery pagination spec. Seeded
+# with > PAGE_SIZE (5) uploads so admin-image-pagination.spec.ts can
+# assert the first page caps at 5 and "Load more" reveals the rest.
+GALLERY_MAC = "ff2222222222"
+GALLERY_IMAGE_COUNT = 6
 
 
 def wait_for_stack(timeout_s: int = 180) -> None:
@@ -146,10 +151,45 @@ def seed_telemetry_upload() -> None:
     print(f"[ui-seed] uploaded one image + sidecar for {TELEMETRY_MAC}", flush=True)
 
 
+def seed_admin_gallery_images() -> None:
+    """Upload GALLERY_IMAGE_COUNT images for one module so the admin
+    gallery has more than one page.
+
+    ``duckdb-service`` stamps ``image_uploads.uploaded_at`` server-side
+    at SECOND resolution (``datetime.now(timezone.utc).strftime(
+    '%Y-%m-%d %H:%M:%S')`` in ``record_image``). The 2s gap aims to land
+    each upload in a distinct second so the capture order shows up in the
+    timestamp itself — but note this is best-effort: the truncation
+    happens on the server clock at INSERT time, not on this client sleep,
+    so under heavy CI load two inserts could still collide in one second.
+    The *guarantee* of newest-first order comes from the
+    ``uploaded_at DESC, id DESC`` total order in ``list_image_uploads``
+    (the ``id`` tiebreaker), which the spec relies on; the spec also
+    derives its expected order from the live API rather than from these
+    timestamps, so a same-second collision cannot make it flaky.
+    """
+    esp = MockEsp(
+        upload_url=f"{IMAGE_SERVICE_URL}/upload",
+        init_url=f"{DUCKDB_URL}/new_module",
+        mac=GALLERY_MAC,
+        module_name="UI Test Gallery",
+    )
+    esp.register().raise_for_status()
+    for i in range(GALLERY_IMAGE_COUNT):
+        esp.upload().raise_for_status()
+        time.sleep(2)  # headroom over the 1s uploaded_at truncation boundary
+    print(
+        f"[ui-seed] uploaded {GALLERY_IMAGE_COUNT} images for gallery "
+        f"module {GALLERY_MAC}",
+        flush=True,
+    )
+
+
 def main() -> int:
     wait_for_stack()
     seed_null_island_module()
     seed_telemetry_upload()
+    seed_admin_gallery_images()
     print("[ui-seed] done", flush=True)
     return 0
 

--- a/tests/ui/tests/admin-image-pagination.spec.ts
+++ b/tests/ui/tests/admin-image-pagination.spec.ts
@@ -62,10 +62,13 @@ test.describe('admin image gallery pagination', () => {
     await page.goto('/admin');
     await page.getByRole('combobox').selectOption(GALLERY_MAC);
 
-    // The thumbnail grid renders one <img> per loaded row. Initially the
-    // first page only: exactly PAGE_SIZE thumbnails, not all `total`.
-    const thumbs = page.locator('main img');
-    await expect(thumbs).toHaveCount(PAGE_SIZE);
+    // Count the image CELLS (one button per loaded row), not the <img>
+    // itself: AdminPage's onError handler replaces a failed thumbnail's
+    // parent innerHTML, removing the <img> from the DOM — so an <img>
+    // count is load-dependent and flaky in CI. The cell + its
+    // data-filename are what the pagination behaviour actually controls.
+    const cells = page.locator('[data-testid="admin-image-cell"]');
+    await expect(cells).toHaveCount(PAGE_SIZE); // first page only, not all `total`
 
     // The stats line shows "<loaded> of <total> images" while a page is
     // outstanding, and a "Load more (<n> left)" button is present.
@@ -79,15 +82,11 @@ test.describe('admin image gallery pagination', () => {
     //    disappears (all `total` now loaded), and the full rendered
     //    sequence equals the deterministic capture order from step 1.
     await loadMore.click();
-    await expect(thumbs).toHaveCount(allPage.total);
+    await expect(cells).toHaveCount(allPage.total);
     await expect(loadMore).toHaveCount(0);
 
-    const renderedOrder = await thumbs.evaluateAll((imgs) =>
-      imgs.map((img) => {
-        // src is /api/images/<filename>; compare on the filename tail.
-        const src = (img as HTMLImageElement).getAttribute('src') ?? '';
-        return decodeURIComponent(src.split('/').pop() ?? '');
-      }),
+    const renderedOrder = await cells.evaluateAll((els) =>
+      els.map((el) => el.getAttribute('data-filename') ?? ''),
     );
     expect(renderedOrder).toEqual(expectedOrder);
   });

--- a/tests/ui/tests/admin-image-pagination.spec.ts
+++ b/tests/ui/tests/admin-image-pagination.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+import type { ImageUploadsPage } from '@highfive/contracts';
+
+// Pins the admin image-gallery pagination (feat/admin-image-pagination)
+// and CLAUDE.md rule #4: a view that renders wire-shape data gets a
+// Playwright spec that mounts the production-built homepage against the
+// real backend. Vitest+jsdom (api-getImages.test.ts) pins the client
+// round-trip, but only this layer proves the gallery actually caps the
+// first page at PAGE_SIZE and that "Load more" appends the rest in
+// capture order — the silent-undefined / SPA-routing gaps jsdom misses.
+//
+// seed_ui_fixtures.py uploads GALLERY_IMAGE_COUNT (6) images for this MAC,
+// each >1s apart so uploaded_at (second resolution) is strictly
+// increasing — i.e. the newest-first order reflects capture order.
+// PAGE_SIZE in AdminPage.tsx is 5, so 6 images = one full page + one.
+
+const GALLERY_MAC = 'ff2222222222';
+const PAGE_SIZE = 5;
+const API_KEY = 'hf_test_key'; // matches docker-compose.ui.yml VITE_API_KEY / HIGHFIVE_API_KEY
+
+test.describe('admin image gallery pagination', () => {
+  test.beforeEach(async ({ page }) => {
+    // AdminPage gates render on a truthy `highfive_admin_auth` in
+    // sessionStorage (the value LoginGate stores is the API key). Set it
+    // so the spec lands on the gallery instead of the login form. The
+    // gallery's own /api/images fetch authenticates with the build-time
+    // VITE_API_KEY, not this value — but the gate still needs it present.
+    await page.addInitScript((key) => {
+      sessionStorage.setItem('highfive_admin_auth', key);
+    }, API_KEY);
+  });
+
+  test('first page caps at PAGE_SIZE and "Load more" appends in capture order', async ({
+    page,
+  }) => {
+    // 1) Wire-shape round trip: pull the FULL ordered list straight from
+    //    the backend so we know the deterministic capture order the UI
+    //    should render. If the envelope drifts ({images,total} → other),
+    //    this fails before we touch the DOM.
+    const full = await page.request.get(
+      `http://localhost:4002/api/images?module_id=${GALLERY_MAC}`,
+      { headers: { 'X-API-Key': API_KEY } },
+    );
+    expect(full.ok()).toBeTruthy();
+    const allPage = (await full.json()) as ImageUploadsPage;
+    expect(allPage.total).toBe(allPage.images.length);
+    expect(allPage.total).toBeGreaterThan(PAGE_SIZE); // seed gives 6 > 5
+    const expectedOrder = allPage.images.map((i) => i.filename); // newest-first
+
+    // The first page the gallery requests must be exactly the newest
+    // PAGE_SIZE, in the same order — pin that at the API too.
+    const firstResp = await page.request.get(
+      `http://localhost:4002/api/images?module_id=${GALLERY_MAC}&limit=${PAGE_SIZE}&offset=0`,
+      { headers: { 'X-API-Key': API_KEY } },
+    );
+    const firstJson = (await firstResp.json()) as ImageUploadsPage;
+    expect(firstJson.images.map((i) => i.filename)).toEqual(expectedOrder.slice(0, PAGE_SIZE));
+    expect(firstJson.total).toBe(allPage.total); // total ignores the page window
+
+    // 2) Drive the browser. Filter to the gallery module so the counts
+    //    are deterministic regardless of other seeded modules' uploads.
+    await page.goto('/admin');
+    await page.getByRole('combobox').selectOption(GALLERY_MAC);
+
+    // The thumbnail grid renders one <img> per loaded row. Initially the
+    // first page only: exactly PAGE_SIZE thumbnails, not all `total`.
+    const thumbs = page.locator('main img');
+    await expect(thumbs).toHaveCount(PAGE_SIZE);
+
+    // The stats line shows "<loaded> of <total> images" while a page is
+    // outstanding, and a "Load more (<n> left)" button is present.
+    await expect(page.getByText(`${PAGE_SIZE} of ${allPage.total} images`)).toBeVisible();
+    const loadMore = page.getByRole('button', {
+      name: new RegExp(`Load more \\(${allPage.total - PAGE_SIZE} left\\)`),
+    });
+    await expect(loadMore).toBeVisible();
+
+    // 3) Click "Load more": the remaining rows append, the button
+    //    disappears (all `total` now loaded), and the full rendered
+    //    sequence equals the deterministic capture order from step 1.
+    await loadMore.click();
+    await expect(thumbs).toHaveCount(allPage.total);
+    await expect(loadMore).toHaveCount(0);
+
+    const renderedOrder = await thumbs.evaluateAll((imgs) =>
+      imgs.map((img) => {
+        // src is /api/images/<filename>; compare on the filename tail.
+        const src = (img as HTMLImageElement).getAttribute('src') ?? '';
+        return decodeURIComponent(src.split('/').pop() ?? '');
+      }),
+    );
+    expect(renderedOrder).toEqual(expectedOrder);
+  });
+});

--- a/tests/ui/tests/dashboard-telemetry.spec.ts
+++ b/tests/ui/tests/dashboard-telemetry.spec.ts
@@ -77,14 +77,18 @@ test.describe('dashboard telemetry render', () => {
     // back to name when null/empty, which it is for fresh registrations).
     await page.getByRole('button', { name: /UI Test Telemetry/ }).click();
 
-    // Expand the Telemetry section. There is no stable test-id; pin the
-    // aria-controls attribute on the toggle button.
-    await page.locator('button[aria-controls="telemetry-content"]').click();
-    await expect(page.locator('#telemetry-content')).toBeVisible();
+    // Scope to the desktop side panel: the dashboard renders ModulePanel
+    // twice (desktop <aside> + mobile sheet, a div[role=dialog]), so the
+    // telemetry toggle/content match two elements globally. <aside> is
+    // unique and the one visible at this viewport — scoping avoids the
+    // strict-mode violation (and the duplicate-id is a separate #129 issue).
+    const panel = page.locator('aside');
+    await panel.locator('button[aria-controls="telemetry-content"]').click();
+    await expect(panel.locator('#telemetry-content')).toBeVisible();
 
     // Wait for at least one rendered TelemetryRow. The seed produces one
     // entry; the panel may show extra if re-runs added more.
-    const telemetryBody = page.locator('#telemetry-content');
+    const telemetryBody = panel.locator('#telemetry-content');
 
     // Now the load-bearing assertions: literal values, not the silent
     // "—" placeholder. If the envelope drifts again every one of these


### PR DESCRIPTION
## What & why

The admin image gallery (`/admin`) failed with **"Failed to load images. Is the image service running?"** even though the image service was healthy. Root cause: `duckdb-service`'s `GET /image_uploads` ran an **unbounded** `ORDER BY uploaded_at DESC` over ~15k rows in an 8 GB DB (~12 s), tripping `image-service`'s **5 s** read-timeout → 500 → 502 at the backend.

This adds newest-first pagination end-to-end so the gallery loads the 5 most recent images fast, with a **"Load more"** button for the rest.

## Changes

- **duckdb-service** (`routes/modules.py::list_image_uploads`): `limit` (1–500) / `offset` + a `total` count; `ORDER BY uploaded_at DESC, id DESC` (stable tiebreaker so paging can't duplicate/skip on tied second-resolution timestamps); canonicalises `module_id` like sibling routes; a **malformed `limit` degrades to the cap, never to the unbounded query**.
- **image-service** (`app.py::list_images`) & **backend** (`app.ts` `/api/images`): forward `module_id`/`limit`/`offset`; proxy read-timeout 5 s → 15 s; backend `fetch` given a matching `AbortSignal.timeout` so no hop is unbounded.
- **homepage**: `AdminPage` gallery loads `PAGE_SIZE=5` newest-first with a "Load more (N left)" button; `getImages` returns `{ images, total }`. `ImageUpload` + new `ImageUploadsPage` moved to **`@highfive/contracts`** (ADR-004) and re-exported from `services/api.ts`.
- **docs**: api-reference §2.4/§3.14, api-contracts `ImageUploadsPage`, chapter-11 lesson, troubleshooting entry; `.env.example` notes `VITE_API_URL` is required for prod builds.

## Tests

- duckdb: pagination order, `total`-respects-filter, tied-timestamp determinism, malformed-limit-not-unbounded.
- homepage: `api-getImages` wire-shape round-trip (incl. `total` fallback).
- Playwright spec `tests/ui/tests/admin-image-pagination.spec.ts` + a 6-image gallery seed.
- All suites green: duckdb 169, image-service 61, backend 148, homepage 131.

## Verification

- Live: `/api/images?limit=5` returns in ~0.5 s (was ~13 s); pages don't overlap; order is `uploaded_at DESC, id DESC`.
- A live `record_image` write confirmed new uploads still persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
