### PR TITLE
fix(dashboard): fit module side panel to window height

### DIFF
--- a/homepage/src/components/ModulePanel.tsx
+++ b/homepage/src/components/ModulePanel.tsx
@@ -360,7 +360,7 @@ export default function ModulePanel({ module, onClose, onError }: ModulePanelPro
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto p-4 hf-cq">
+      <div className="flex-1 min-h-0 overflow-y-auto p-4 hf-cq">
         {/* Telemetry / Logs — admin */}
         {adminMode && (
           <div className="mb-4 hf-card overflow-hidden">

--- a/homepage/src/components/ModulePanel.tsx
+++ b/homepage/src/components/ModulePanel.tsx
@@ -359,11 +359,13 @@ export default function ModulePanel({ module, onClose, onError }: ModulePanelPro
         </div>
       </div>
 
-      {/* Content */}
-      <div className="flex-1 min-h-0 overflow-y-auto p-4 hf-cq">
+      {/* Content. Mobile (default): natural-height + scroll inside the sheet.
+          Desktop (md+): a non-scrolling flex column so the species grid below
+          fills the available window height instead of overflowing the aside. */}
+      <div className="flex-1 min-h-0 overflow-y-auto p-4 hf-cq md:flex md:flex-col md:overflow-hidden">
         {/* Telemetry / Logs — admin */}
         {adminMode && (
-          <div className="mb-4 hf-card overflow-hidden">
+          <div className="mb-4 hf-card overflow-hidden md:shrink-0">
             <button
               onClick={toggleLogs}
               className="w-full flex items-center justify-between px-4 py-3 hover:bg-hf-fg/5 transition-colors"
@@ -411,7 +413,7 @@ export default function ModulePanel({ module, onClose, onError }: ModulePanelPro
             {logsOpen && (
               <div
                 id="telemetry-content"
-                className="border-t border-hf-border p-3 space-y-3"
+                className="border-t border-hf-border p-3 space-y-3 md:max-h-[40vh] md:overflow-y-auto"
                 style={{ background: 'var(--hf-line-soft)' }}
               >
                 {!hasKey && (
@@ -462,9 +464,13 @@ export default function ModulePanel({ module, onClose, onError }: ModulePanelPro
           </div>
         )}
 
-        {/* Species cards — single column on small panel widths, 2-col when there's room (container query) */}
+        {/* Species cards. The auto-fit grid flows to 2 columns once the panel is
+            wide enough (xl aside ≈ 560px). On desktop the grid grows to fill the
+            remaining panel height and its rows share that height equally
+            (grid-auto-rows 1fr), so the cards adapt to the window instead of the
+            panel scrolling; a card with more nests than fit scrolls internally. */}
         <div
-          className="grid gap-3 md:gap-4"
+          className="grid gap-3 md:gap-4 md:min-h-0 md:flex-1 md:[grid-auto-rows:minmax(0,1fr)]"
           style={{
             gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 220px), 1fr))',
           }}
@@ -472,13 +478,13 @@ export default function ModulePanel({ module, onClose, onError }: ModulePanelPro
           {beeTypeSummaries.map((summary) => (
             <article
               key={summary.key}
-              className="rounded-hf-lg p-3 md:p-4 shadow-hf-1 border-2 transition-transform active:scale-[0.98] md:active:scale-100"
+              className="rounded-hf-lg p-3 md:p-4 shadow-hf-1 border-2 transition-transform active:scale-[0.98] md:active:scale-100 md:flex md:flex-col md:h-full md:min-h-0 md:overflow-hidden"
               style={{
                 backgroundColor: summary.lightColor,
                 borderColor: summary.color,
               }}
             >
-              <div className="flex items-start justify-between mb-2">
+              <div className="flex items-start justify-between mb-2 md:shrink-0">
                 <div className="text-hf-md font-bold" style={{ color: summary.color }}>
                   {summary.size}
                 </div>
@@ -493,7 +499,7 @@ export default function ModulePanel({ module, onClose, onError }: ModulePanelPro
                 </div>
               </div>
 
-              <ul className="space-y-2 mt-3">
+              <ul className="space-y-2 mt-3 md:flex-1 md:min-h-0 md:overflow-y-auto">
                 {summary.nests.map((nest, index) => (
                   <li key={nest.nest_id}>
                     <div className="flex items-center justify-between mb-1">

--- a/homepage/src/pages/DashboardPage.tsx
+++ b/homepage/src/pages/DashboardPage.tsx
@@ -241,7 +241,7 @@ export default function DashboardPage() {
         {/* Desktop: right side panel */}
         {!error && selectedModule && (
           <aside
-            className="hidden md:flex w-[360px] lg:w-[400px] min-h-0 shadow-hf-2 overflow-hidden flex-col border-l border-hf-border bg-hf-surface"
+            className="hidden md:flex w-[360px] lg:w-[400px] xl:w-[560px] 2xl:w-[600px] min-h-0 shadow-hf-2 overflow-hidden flex-col border-l border-hf-border bg-hf-surface"
             aria-label={t('dashboard.moduleDetails')}
           >
             {/* Brittle invariant: ModulePanel is always opened from

--- a/homepage/src/pages/DashboardPage.tsx
+++ b/homepage/src/pages/DashboardPage.tsx
@@ -166,7 +166,7 @@ export default function DashboardPage() {
       )}
 
       {/* Main content */}
-      <div className="flex-1 flex flex-col md:flex-row overflow-hidden relative">
+      <div className="flex-1 min-h-0 flex flex-col md:flex-row overflow-hidden relative">
         {/* Error state — backend down */}
         {error && (
           <div
@@ -241,7 +241,7 @@ export default function DashboardPage() {
         {/* Desktop: right side panel */}
         {!error && selectedModule && (
           <aside
-            className="hidden md:flex w-[360px] lg:w-[400px] shadow-hf-2 overflow-hidden flex-col border-l border-hf-border bg-hf-surface"
+            className="hidden md:flex w-[360px] lg:w-[400px] min-h-0 shadow-hf-2 overflow-hidden flex-col border-l border-hf-border bg-hf-surface"
             aria-label={t('dashboard.moduleDetails')}
           >
             {/* Brittle invariant: ModulePanel is always opened from

--- a/tests/ui/tests/dashboard-telemetry.spec.ts
+++ b/tests/ui/tests/dashboard-telemetry.spec.ts
@@ -77,14 +77,18 @@ test.describe('dashboard telemetry render', () => {
     // back to name when null/empty, which it is for fresh registrations).
     await page.getByRole('button', { name: /UI Test Telemetry/ }).click();
 
-    // Expand the Telemetry section. There is no stable test-id; pin the
-    // aria-controls attribute on the toggle button.
-    await page.locator('button[aria-controls="telemetry-content"]').click();
-    await expect(page.locator('#telemetry-content')).toBeVisible();
+    // Scope to the desktop side panel: the dashboard renders ModulePanel
+    // twice (desktop <aside> + mobile sheet, a div[role=dialog]), so the
+    // telemetry toggle/content match two elements globally. <aside> is
+    // unique and the one visible at this viewport — scoping avoids the
+    // strict-mode violation (and the duplicate-id is a separate #129 issue).
+    const panel = page.locator('aside');
+    await panel.locator('button[aria-controls="telemetry-content"]').click();
+    await expect(panel.locator('#telemetry-content')).toBeVisible();
 
     // Wait for at least one rendered TelemetryRow. The seed produces one
     // entry; the panel may show extra if re-runs added more.
-    const telemetryBody = page.locator('#telemetry-content');
+    const telemetryBody = panel.locator('#telemetry-content');
 
     // Now the load-bearing assertions: literal values, not the silent
     // "—" placeholder. If the envelope drifts again every one of these


### PR DESCRIPTION
## What & why

The dashboard module detail panel (the right-side `<aside>`) overflowed the window: its content (module header + 4 species cards) grew past the viewport and was clipped/scrolled. This makes the panel **fit the available window height** — cards adapt to the height instead of the panel scrolling.

## Changes (homepage only, desktop `md:` and up)

- **Widen the panel on large screens** (`DashboardPage.tsx`): aside `xl:w-[560px] 2xl:w-[600px]` so the existing `auto-fit` species grid flows to **2 columns** (a 2×2 card layout). The map is `flex-1` and simply yields the space.
- **Height-filling layout** (`ModulePanel.tsx`): the content body becomes a non-scrolling flex column on `md:`; the species grid grows to fill the remaining height with equal `1fr` rows so cards stretch to share it.
- **Per-card internal scroll as the only fallback**: each card is a flex column whose nest list scrolls *inside the card* if one species has more nests than fit its cell — so the **panel itself never scrolls**. Admin telemetry, when expanded, is bounded (`md:max-h-[40vh]`) so it can't push the grid out.
- All new classes are `md:` variants, so the **mobile** full-screen sheet keeps its natural-height scroll (correct for phones).

The first commit adds the `min-h-0` height-chain (so the panel bounds to the viewport); the second replaces the scroll with the height-fill grid.

## Verification

Headless (Playwright) at multiple viewports, module selected:
- **xl 1440×900**: 2 columns, panel doesn't scroll, grid fills height, map ~880px. ✓
- **lg 1024×768**: 1 column, panel doesn't scroll (internal card scroll fallback). ✓
- **short 1280×640**: 2 columns, panel doesn't scroll, dense nest lists scroll within their card. ✓

Confirmed visually with screenshots (clean 2×2 grid at xl). 131 homepage tests still pass (layout-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
