### PR TITLE
fix(duckdb): admin module delete handles legacy decimal MAC + clears all tables

### DIFF
--- a/duckdb-service/routes/modules.py
+++ b/duckdb-service/routes/modules.py
@@ -479,27 +479,47 @@ def set_display_name(module_id):
 
 @modules_bp.delete("/modules/<module_id>")
 def delete_module(module_id):
-    """Delete a module and all its related data (nests, progress, images)."""
+    """Delete a module and all its related data.
+
+    Matches BOTH the canonical 12-hex id and the legacy decimal uint64
+    MAC form. Some rows were stored as e.g. ``273227831496128`` instead
+    of canonical ``f87fcfd6cdc0`` (the decimal-MAC issue); the admin
+    delete button sends canonical hex, so a raw ``WHERE id = <hex>``
+    would 404 against those modules. We canonicalise the input and also
+    derive its decimal equivalent, matching either.
+
+    Also clears `module_heartbeats` and `measurements` — the previous
+    version deleted only nests/progress/images/config and left orphan
+    telemetry behind.
+    """
+    canonical, err = _canonicalize_or_400(module_id)
+    if err is not None:
+        return err
+    legacy_decimal = str(int(canonical, 16))  # same MAC as a uint64 string
+    ids = (canonical, legacy_decimal)
     with lock:
         con = get_conn()
         try:
-            # Check module exists
             existing = con.execute(
-                "SELECT id FROM module_configs WHERE id = ?", (module_id,)
+                "SELECT id FROM module_configs WHERE id IN (?, ?)", ids
             ).fetchone()
             if not existing:
                 return jsonify({"error": "Module not found"}), 404
 
-            # Delete in order: progress -> nests -> images -> module
+            # Reverse-FK order; both id forms; every table that references
+            # the module so nothing is orphaned.
             con.execute(
-                "DELETE FROM daily_progress WHERE nest_id IN (SELECT nest_id FROM nest_data WHERE module_id = ?)",
-                (module_id,),
+                "DELETE FROM daily_progress WHERE nest_id IN "
+                "(SELECT nest_id FROM nest_data WHERE module_id IN (?, ?))",
+                ids,
             )
-            con.execute("DELETE FROM nest_data WHERE module_id = ?", (module_id,))
-            con.execute("DELETE FROM image_uploads WHERE module_id = ?", (module_id,))
-            con.execute("DELETE FROM module_configs WHERE id = ?", (module_id,))
+            con.execute("DELETE FROM nest_data WHERE module_id IN (?, ?)", ids)
+            con.execute("DELETE FROM image_uploads WHERE module_id IN (?, ?)", ids)
+            con.execute("DELETE FROM module_heartbeats WHERE module_id IN (?, ?)", ids)
+            con.execute("DELETE FROM measurements WHERE module_mac IN (?, ?)", ids)
+            con.execute("DELETE FROM module_configs WHERE id IN (?, ?)", ids)
             con.commit()
-            return jsonify({"message": f"Module {module_id} deleted"}), 200
+            return jsonify({"message": f"Module {canonical} deleted"}), 200
         except Exception as e:
             con.rollback()
             return jsonify({"error": str(e)}), 500

--- a/duckdb-service/tests/test_module_endpoints.py
+++ b/duckdb-service/tests/test_module_endpoints.py
@@ -504,3 +504,90 @@ def test_activity_timeseries_excludes_other_modules(client, fresh_db):
     assert resp.status_code == 200
     body = resp.get_json()
     assert all(b["count"] == 0 for b in body["buckets"])
+
+
+# ---------- DELETE /modules/<id> ----------
+
+
+def _seed_heartbeat(fresh_db, module_id):
+    con = fresh_db.connection.get_conn()
+    try:
+        con.execute("INSERT INTO module_heartbeats (module_id) VALUES (?)", (module_id,))
+        con.commit()
+    finally:
+        con.close()
+
+
+def _seed_measurement(fresh_db, module_mac):
+    con = fresh_db.connection.get_conn()
+    try:
+        con.execute(
+            "INSERT INTO measurements (module_mac, ts, metric, value, source) "
+            "VALUES (?, '2024-06-01 00:00:00', 'battery_pct', 50.0, 'test')",
+            (module_mac,),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _count(fresh_db, sql, params):
+    con = fresh_db.connection.get_conn()
+    try:
+        return con.execute(sql, params).fetchone()[0]
+    finally:
+        con.close()
+
+
+def test_delete_module_clears_every_referencing_table(client, fresh_db):
+    """Delete must leave no orphan rows — including module_heartbeats and
+    measurements, which the pre-fix version did not touch."""
+    _seed_module(fresh_db, TEST_MAC_1)
+    _seed_nest(fresh_db, "nest-1", TEST_MAC_1)
+    _seed_progress(fresh_db, "prog-1", "nest-1")
+    _seed_image_upload(fresh_db, TEST_MAC_1, "x.jpg", "2024-06-01 12:00:00")
+    _seed_heartbeat(fresh_db, TEST_MAC_1)
+    _seed_measurement(fresh_db, TEST_MAC_1)
+
+    assert client.delete(f"/modules/{TEST_MAC_1}").status_code == 200
+
+    assert _count(fresh_db, "SELECT COUNT(*) FROM module_configs WHERE id=?", (TEST_MAC_1,)) == 0
+    assert _count(fresh_db, "SELECT COUNT(*) FROM nest_data WHERE module_id=?", (TEST_MAC_1,)) == 0
+    assert _count(fresh_db, "SELECT COUNT(*) FROM image_uploads WHERE module_id=?", (TEST_MAC_1,)) == 0
+    assert _count(fresh_db, "SELECT COUNT(*) FROM module_heartbeats WHERE module_id=?", (TEST_MAC_1,)) == 0
+    assert _count(fresh_db, "SELECT COUNT(*) FROM measurements WHERE module_mac=?", (TEST_MAC_1,)) == 0
+
+
+def test_delete_module_matches_legacy_decimal_mac(client, fresh_db):
+    """A module stored with its decimal uint64 MAC must be deletable via
+    the canonical-hex id the admin button sends — the f87f… 404 incident.
+    add_module rejects a decimal MAC, so seed the legacy row directly."""
+    decimal_id = "273227831496128"  # == 0xf87fcfd6cdc0
+    canonical = "f87fcfd6cdc0"
+    con = fresh_db.connection.get_conn()
+    try:
+        con.execute(
+            "INSERT INTO module_configs (id, name, lat, lng, first_online, "
+            "battery_level, image_count) VALUES (?, 'Legacy', 47.8, 9.6, "
+            "'2024-01-01', NULL, 0)",
+            (decimal_id,),
+        )
+        con.commit()
+    finally:
+        con.close()
+    _seed_heartbeat(fresh_db, decimal_id)
+    _seed_measurement(fresh_db, decimal_id)
+
+    # The admin UI sends the canonical hex form; it must match the decimal row.
+    assert client.delete(f"/modules/{canonical}").status_code == 200
+    assert _count(fresh_db, "SELECT COUNT(*) FROM module_configs WHERE id=?", (decimal_id,)) == 0
+    assert _count(fresh_db, "SELECT COUNT(*) FROM module_heartbeats WHERE module_id=?", (decimal_id,)) == 0
+    assert _count(fresh_db, "SELECT COUNT(*) FROM measurements WHERE module_mac=?", (decimal_id,)) == 0
+
+
+def test_delete_module_unknown_returns_404(client, fresh_db):
+    assert client.delete("/modules/aabbccddeeff").status_code == 404
+
+
+def test_delete_module_invalid_id_returns_400(client):
+    assert client.delete("/modules/not-a-mac").status_code == 400


### PR DESCRIPTION
## What & why

The admin page's **delete module** button 404'd and the module stayed. Root cause: a module registered with a **legacy decimal uint64 MAC** — e.g. `swift-berry-meise` was stored in `module_configs` as `273227831496128` (== `0xf87fcfd6cdc0`). The admin UI canonicalises that to hex for display and sends `f87fcfd6cdc0` to delete, but `delete_module` did a raw `WHERE id = 'f87fcfd6cdc0'` which never matched the decimal row → `404 Module not found`.

Secondary bug: `delete_module` only cleared `daily_progress`/`nest_data`/`image_uploads`/`module_configs`, leaving **orphan `module_heartbeats` and `measurements`** rows behind.

## Fix

`duckdb-service/routes/modules.py::delete_module`:
- Canonicalise the incoming id (`_canonicalize_or_400`, like its sibling routes), derive its decimal equivalent (`str(int(canonical, 16))`), and match **either** form.
- Delete across **every** referencing table, in reverse-FK order.

## Tests

`tests/test_module_endpoints.py`:
- `test_delete_module_clears_every_referencing_table` — no orphans left (incl. heartbeats + measurements).
- `test_delete_module_matches_legacy_decimal_mac` — deleting via canonical hex removes a decimal-stored row.
- `test_delete_module_unknown_returns_404`, `test_delete_module_invalid_id_returns_400`.

## Verification

Already deployed to the prod duckdb-service and used to remove the stuck legacy module: `DELETE /modules/f87fcfd6cdc0 → 200 {"message":"Module f87fcfd6cdc0 deleted"}`, with all its rows gone. Full duckdb suite green.

Note: this is a targeted fix for *deleting* legacy decimal-MAC modules. The deeper question of how decimal MACs get stored in the first place (the Python `ModuleId` rejects them, so the leak is via another path) is broader and left for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)