### PR TITLE
fix(wizard): show WPA2 AP password in setup Step 3

### DIFF
--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -1555,6 +1555,41 @@ about a WiFi or HTTP surface, grep for the actual API call
 before describing what the surface looks like to the network. Doc
 review needs to inspect the API, not just the surrounding prose.
 
+### Setup wizard Step 3 told users "open network — no password" while the AP is WPA2-protected
+
+**What happened.** The same wrong "open AP" claim as the `auth.md`
+incident above, but this time it shipped in the **user-facing setup
+wizard** (`homepage/.../Step3WiFi.tsx` via `step3.openNetwork` in both
+locales of `translations.ts`). The card showed the SSID
+`ESP32-Access-Point` and the caption "This is an open network — no
+password required.", but the firmware's `WiFi.softAP(HOST_SSID,
+HOST_PASSWORD, …)` in `host.cpp` advertises a WPA2 AP with PSK
+`esp-12345`. A field user followed the wizard, was prompted for a
+password the wizard insisted didn't exist, guessed `esp-1234` (one
+digit short), and got "unable to connect to this network." Fix: render
+the PSK as a second copy-able field next to the SSID and replace the
+caption with "this network is password-protected — enter the password
+above". Every doc (`hardware-notes.md`, `esp-flashing.md`,
+`troubleshooting.md`, `esp32cam.md`) already stated the password
+correctly; the wizard was the lone surface that didn't.
+
+**Why it happened.** The `auth.md` "open AP" fix corrected the _doc_
+but never swept the _product_. The two surfaces describe the same
+`WiFi.softAP` arguments, yet the lessons-learned remediation was scoped
+to prose review and stopped at `docs/`. The wizard string had no test
+asserting the rendered field matched `HOST_PASSWORD`, so jsdom unit
+tests and the build stayed green while the only string that mattered to
+a user in the field was wrong.
+
+**How to avoid it next time.** When a code/doc-drift fix corrects a
+claim that is _also_ surfaced in the UI, grep the frontend for the same
+claim in the same change — `host.cpp`'s `HOST_SSID`/`HOST_PASSWORD` are
+mirrored in `Step3WiFi.tsx`, and a constant in one must not silently
+diverge from a translation string in the other. The
+`tests/ui/tests/setup-wizard-happy-path.spec.ts` Playwright spec now pins
+`#ap-ssid`/`#ap-password` to the literal firmware values so a future
+divergence fails CI in the only layer that renders the production page.
+
 ### `lib/<name>/` includes diverge between PIO and arduino-cli (issue #36, PR #55)
 
 **What happened.** `bash ESP32-CAM/build.sh` (the arduino-cli release

--- a/homepage/src/__tests__/Step3WiFi.test.tsx
+++ b/homepage/src/__tests__/Step3WiFi.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LanguageProvider } from '../i18n/LanguageContext';
+import Step3WiFi from '../components/setup/Step3WiFi';
+
+// Step 3 of the setup wizard tells the user which WiFi network the module
+// advertises and how to join it. The firmware AP is WPA2-protected
+// (`WiFi.softAP(HOST_SSID, HOST_PASSWORD, …)` in ESP32-CAM/host.cpp), so the
+// card MUST show both the SSID and the PSK. A field user once couldn't connect
+// because the wizard claimed "open network — no password required" while the
+// firmware demanded `esp-12345`. These assertions pin the rendered strings to
+// the firmware values so that drift can't ship green again.
+describe('Step3WiFi AP credentials', () => {
+  // LanguageProvider reads the active locale from localStorage('lang'); clear
+  // it between cases so a locale set by one test can't leak into the next.
+  afterEach(() => localStorage.removeItem('lang'));
+
+  function renderStep() {
+    return render(
+      <LanguageProvider>
+        <Step3WiFi onNext={vi.fn()} onBack={vi.fn()} onSkip={vi.fn()} />
+      </LanguageProvider>,
+    );
+  }
+
+  it('renders the SSID the firmware advertises', () => {
+    renderStep();
+    expect(screen.getByText('ESP32-Access-Point')).toBeInTheDocument();
+  });
+
+  it('renders the WPA2 password (PSK) so the user can actually join the AP', () => {
+    renderStep();
+    // The literal HOST_PASSWORD from ESP32-CAM/host.cpp.
+    expect(screen.getByText('esp-12345')).toBeInTheDocument();
+  });
+
+  // The original bug — a caption claiming the AP is open — shipped in BOTH the
+  // en and de locales, so guard the absence of that claim in each. The PSK
+  // string is locale-independent, so it must still render either way.
+  it.each<[string, RegExp[]]>([
+    ['en', [/no password required/i, /open network/i]],
+    ['de', [/offenes Netzwerk/i, /kein Passwort/i]],
+  ])('does not claim the network is open (%s locale)', (lang, patterns) => {
+    localStorage.setItem('lang', lang);
+    renderStep();
+    for (const pattern of patterns) {
+      expect(screen.queryByText(pattern)).not.toBeInTheDocument();
+    }
+    expect(screen.getByText('esp-12345')).toBeInTheDocument();
+  });
+});

--- a/homepage/src/components/setup/Step3WiFi.tsx
+++ b/homepage/src/components/setup/Step3WiFi.tsx
@@ -8,10 +8,13 @@ interface Step3WiFiProps {
   onSkip: () => void;
 }
 
-// Must match `HOST_SSID` in `ESP32-CAM/host.cpp` (the captive-portal SSID
-// the firmware actually advertises). Drift between this and the firmware
-// would tell users to look for a network that doesn't exist.
+// Must match `HOST_SSID` / `HOST_PASSWORD` in `ESP32-CAM/host.cpp` (the
+// captive-portal SSID + WPA2 PSK the firmware actually advertises). Drift
+// here would tell users to look for a network that doesn't exist, or — as
+// happened in the field — that the AP is open when it is in fact
+// password-protected, so connection silently fails.
 const AP_SSID = 'ESP32-Access-Point';
+const AP_PASSWORD = 'esp-12345';
 
 export default function Step3WiFi({ onNext, onBack, onSkip }: Step3WiFiProps) {
   const { t } = useTranslation();
@@ -67,7 +70,24 @@ export default function Step3WiFi({ onNext, onBack, onSkip }: Step3WiFiProps) {
           </code>
           <CopyButton text={AP_SSID} label={t('step3.networkName')} />
         </div>
-        <p className="text-hf-xs text-hf-fg-mute mt-2">{t('step3.openNetwork')}</p>
+
+        <label
+          className="text-hf-xs text-hf-fg-mute uppercase tracking-wider font-medium mt-4 block"
+          htmlFor="ap-password"
+        >
+          {t('step3.networkPassword')}
+        </label>
+        <div
+          className="flex items-center justify-between mt-1 rounded-hf px-4 py-3"
+          style={{ background: 'var(--hf-line-soft)' }}
+        >
+          <code id="ap-password" className="text-hf-md font-mono font-bold text-hf-fg">
+            {AP_PASSWORD}
+          </code>
+          <CopyButton text={AP_PASSWORD} label={t('step3.networkPassword')} />
+        </div>
+
+        <p className="text-hf-xs text-hf-fg-mute mt-2">{t('step3.passwordNotice')}</p>
       </div>
 
       <aside

--- a/homepage/src/i18n/translations.ts
+++ b/homepage/src/i18n/translations.ts
@@ -234,7 +234,8 @@ const translations = {
       submit: 'Join the Waitlist',
       submitting: 'Sending…',
       successTitle: 'You’re on the list!',
-      successText: 'Thanks for signing up. We’ll be in touch as soon as Hive Modules are available.',
+      successText:
+        'Thanks for signing up. We’ll be in touch as soon as Hive Modules are available.',
       errorGeneric: 'Something went wrong. Please try again.',
       privacy: 'We’ll only use your email to notify you about Hive Module availability.',
     },
@@ -375,7 +376,9 @@ const translations = {
       title: 'Connect to Your Module',
       text: "Your module is now broadcasting its own WiFi network. Open your device's WiFi settings and connect to it.",
       networkName: 'Network Name',
-      openNetwork: 'This is an open network \u2014 no password required.',
+      networkPassword: 'Password',
+      passwordNotice:
+        'This network is password-protected \u2014 enter the password above exactly (including the dash) when your device prompts for it.',
       disconnectNotice:
         "Your internet connection will temporarily disconnect when you connect to the module's network. That's completely normal.",
       connected: "I'm Connected",
@@ -680,9 +683,11 @@ const translations = {
       submit: 'Auf die Warteliste',
       submitting: 'Wird gesendet\u2026',
       successTitle: 'Du bist auf der Liste!',
-      successText: 'Danke f\u00FCr deine Anmeldung. Wir melden uns, sobald die Hive-Module verf\u00FCgbar sind.',
+      successText:
+        'Danke f\u00FCr deine Anmeldung. Wir melden uns, sobald die Hive-Module verf\u00FCgbar sind.',
       errorGeneric: 'Etwas ist schiefgelaufen. Bitte versuche es erneut.',
-      privacy: 'Wir verwenden deine E-Mail nur, um dich \u00FCber die Verf\u00FCgbarkeit zu informieren.',
+      privacy:
+        'Wir verwenden deine E-Mail nur, um dich \u00FCber die Verf\u00FCgbarkeit zu informieren.',
     },
 
     // ---- Assembly Guide ----
@@ -821,7 +826,9 @@ const translations = {
       title: 'Mit deinem Modul verbinden',
       text: 'Dein Modul sendet jetzt sein eigenes WLAN-Netzwerk. \u00D6ffne deine Ger\u00E4te-WLAN-Einstellungen und verbinde dich damit.',
       networkName: 'Netzwerkname',
-      openNetwork: 'Dies ist ein offenes Netzwerk \u2014 kein Passwort n\u00F6tig.',
+      networkPassword: 'Passwort',
+      passwordNotice:
+        'Dieses Netzwerk ist passwortgesch\u00FCtzt \u2014 gib das Passwort oben genau so ein (mit dem Bindestrich), wenn dein Ger\u00E4t danach fragt.',
       disconnectNotice:
         'Deine Internetverbindung wird vor\u00FCbergehend unterbrochen, wenn du dich mit dem Modul-Netzwerk verbindest. Das ist v\u00F6llig normal.',
       connected: 'Ich bin verbunden',

--- a/tests/ui/tests/setup-wizard-happy-path.spec.ts
+++ b/tests/ui/tests/setup-wizard-happy-path.spec.ts
@@ -33,6 +33,14 @@ test.describe('setup wizard happy path', () => {
     // Step 3 - "Connect to Your Module". Skip-to-verification triggers
     // onSkip = () => goToStep(5).
     await expect(page.locator('#step3-title')).toBeVisible();
+
+    // The AP is WPA2-protected (HOST_PASSWORD in ESP32-CAM/host.cpp), so the
+    // card MUST surface both the SSID and the PSK. A field report showed the
+    // wizard once claimed "open network", so users couldn't connect. Pin the
+    // exact strings the firmware advertises against the production-built page.
+    await expect(page.locator('#ap-ssid')).toHaveText('ESP32-Access-Point');
+    await expect(page.locator('#ap-password')).toHaveText('esp-12345');
+
     await page
       .getByRole('button', {
         name: /Already configured.*skip to verification|Bereits konfiguriert/i,


### PR DESCRIPTION
## Problem

A field user couldn't connect to their module's WiFi AP. The setup wizard's **Step 3** told them it was an *"open network — no password required"*, but their device prompted for a password the wizard insisted didn't exist. They guessed `esp-1234` (one digit short) and got *"unable to connect to this network."*

The wizard text was simply wrong. The firmware's AP is genuinely **WPA2-protected**:

- `ESP32-CAM/host.cpp`: `HOST_SSID = "ESP32-Access-Point"`, `HOST_PASSWORD = "esp-12345"`
- `WiFi.softAP(HOST_SSID, HOST_PASSWORD, 1, 0)` advertises a WPA2 AP

Every doc (`hardware-notes.md`, `esp-flashing.md`, `troubleshooting.md`, `esp32cam.md`) already stated `esp-12345` correctly — the wizard was the lone surface that didn't. This is the same "open AP" drift that bit `docs/08-crosscutting-concepts/auth.md` once before; that fix swept the docs but never the product.

## Change

- **`Step3WiFi.tsx`** — added `AP_PASSWORD = 'esp-12345'` and a second copy-able card row (`#ap-password`) next to the SSID; replaced the `openNetwork` caption with `passwordNotice` ("this network is password-protected — enter the password above exactly, including the dash").
- **`translations.ts`** — replaced the `openNetwork` key with `networkPassword` + `passwordNotice` in **both `en` and `de`**.
- **`Step3WiFi.test.tsx`** (new) — jsdom render test asserting the SSID + PSK render and the "open network" claim is gone, in both locales.
- **`setup-wizard-happy-path.spec.ts`** — Playwright assertion pinning `#ap-ssid` / `#ap-password` to the literal firmware values (the production-render layer the field bug lived in).
- **`docs/11-risks-and-technical-debt`** — lessons-learned entry.

## Testing

- `npm run build` (tsc) clean; homepage vitest suite green (135 tests, incl. the new locale-aware render test).
- `make check-citations` clean.
- Senior-reviewer pass; both findings addressed (stale doc path; locale-aware negative assertion).
- Playwright spec assertion added but not run locally (needs `make test-ui` full stack) — will run in CI.

## Notes

- No firmware change and no reflash needed — boards already advertise the WPA2 AP; the wizard just never showed the password.
- The frontend change is already deployed to the live site; this PR lands it in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)