### PR TITLE
feat(esp): simplify captive portal to Wi-Fi-credentials-only

### DIFF
--- a/.claude/skills/esp32-onboarding/SKILL.md
+++ b/.claude/skills/esp32-onboarding/SKILL.md
@@ -63,6 +63,20 @@ Find the COM port:
 - Windows: Device Manager → Ports → "USB-SERIAL CH340 (COMx)"
 - Linux/Mac: `/dev/ttyUSB0` or `/dev/cu.usbserial-*`
 
+**Targeting a local dev stack?** The server URLs are baked in at build time (the captive portal no longer asks for them). For a production build, skip this — the firmware defaults to `https://highfive.schutera.com/...`. To point the module at your LAN `docker compose` stack, write the host's LAN IP (host only — no scheme, no port, no path) to the gitignored `ESP32-CAM/DEV_SERVER_HOST` **before** flashing, or export `DEV_SERVER_HOST`:
+
+```bash
+# Linux/Mac — from repo root
+printf '%s' "192.168.1.50" > ESP32-CAM/DEV_SERVER_HOST
+```
+
+```powershell
+# Windows / PowerShell — from repo root
+"192.168.1.50" | Out-File -NoNewline -Encoding ascii ESP32-CAM\DEV_SERVER_HOST
+```
+
+The build (`build.sh` / `extra_scripts.py`) injects `http://<host>:8002/new_module` (duckdb-service) and `http://<host>:8000/upload` (image-service). Same pattern as `GEO_API_KEY`. See [esp-flashing.md → "Point a dev module at a local stack"](../../../docs/07-deployment-view/esp-flashing.md).
+
 Enter flash mode (ESP32-CAM-MB):
 
 1. Hold **IO0** (BOOT) button
@@ -121,17 +135,14 @@ Check `esp_log.txt`. A healthy unconfigured board shows:
 
 1. Connect to Wi-Fi: **`ESP32-Access-Point`** / password **`esp-12345`**
 2. Open **http://192.168.4.1**
-3. Fill in the form:
+3. Fill in the form — **Wi-Fi credentials only**:
 
-| Field                   | Value                                                                     |
-| ----------------------- | ------------------------------------------------------------------------- |
-| Module Name             | Any label, e.g. `hive-01`                                                 |
-| Wi-Fi SSID              | Your **2.4 GHz** network name — copy-paste, don't retype (case-sensitive) |
-| Wi-Fi Password          | Your network password                                                     |
-| Initialization Base URL | `http://<LAN-IP>:8002`                                                    |
-| Initialization Endpoint | `/new_module`                                                             |
-| Upload Base URL         | `http://<LAN-IP>:8000`                                                    |
-| Upload Endpoint         | `/upload`                                                                 |
+| Field          | Value                                                                     |
+| -------------- | ------------------------------------------------------------------------- |
+| Wi-Fi SSID     | Your **2.4 GHz** network name — copy-paste, don't retype (case-sensitive) |
+| Wi-Fi Password | Your network password                                                     |
+
+There are no other fields. Module name, server URLs, and camera settings are assigned under the hood (see Phase 3 — server URLs are baked in at build time, not entered here). See [ADR-018](../../../docs/09-architecture-decisions/adr-018-captive-portal-wifi-only.md).
 
 4. Click **Save Configuration** — you should see "Configuration saved successfully."
 
@@ -141,9 +152,9 @@ The board reboots and connects to your Wi-Fi. The access point disappears.
 
 - ESP32 is **2.4 GHz only** — router must have a 2.4 GHz band available
 - The ESP32 and the server must be on the **same LAN** — not one on a phone hotspot and the other on the home router
-- Use the server's **LAN IP**, not `localhost`
+- For a dev module, the server's **LAN IP** (not `localhost`) goes into `DEV_SERVER_HOST` **before flashing** (Phase 3), not into the form — there is no URL field
 
-**Factory reset** (to redo config): in AP mode, visit `http://192.168.4.1` → expand **Factory reset (advanced)** → tick the confirm box → submit. The module reboots and reopens the access point. From STA mode without a serial cable, cause three consecutive failed WiFi joins to trigger the auto-AP-fallback first.
+**Reconfigure = re-flash.** There is no factory-reset button. Re-flashing erases the saved config (full chip erase, `eraseAll: true` in `homepage/src/components/setup/flashEsp.ts`'s `flashEsp`), so the module boots straight back into this Wi-Fi-only setup page. To change the server a module talks to, set `DEV_SERVER_HOST`, re-build, and re-flash (Phase 3). The "moved to a new network" case needs no re-flash: cause three consecutive failed Wi-Fi joins (e.g. save wrong credentials) and the module auto-reopens the access point after ~90 s (`WIFI_FAIL_AP_FALLBACK_THRESH` in `ESP32-CAM/ESP32-CAM.ino`).
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,9 @@ cython_debug/
 # Secrets
 secrets.h
 ESP32-CAM/GEO_API_KEY
+# Dev-only override: LAN host/IP that retargets the firmware's server URLs
+# away from production (see firmware_defaults.h / build.sh). Never committed.
+ESP32-CAM/DEV_SERVER_HOST
 
 # Configuration files - server-specific
 .env

--- a/ESP32-CAM/ESP32-CAM.ino
+++ b/ESP32-CAM/ESP32-CAM.ino
@@ -237,11 +237,13 @@ void setup() {
   // to live here. It was unreachable on AI Thinker ESP32-CAM-MB because
   // GPIO0 is a strap pin — the ROM samples it at the moment EN releases,
   // so holding it LOW enters UART download mode and this firmware never
-  // runs. Removed in #40. The supported reset paths are:
-  //   1. The 3-WiFi-fail auto-fallback below (re-opens AP).
-  //   2. POST /factory_reset on the captive portal (host.cpp).
+  // runs. Removed in #40. The captive-portal factory-reset button was later
+  // removed too; the supported reset/reconfigure paths are now:
+  //   1. The 3-WiFi-fail auto-fallback below (re-opens the setup AP).
+  //   2. Re-flash via the homepage wizard — the web installer erases NVS +
+  //      SPIFFS, so the module boots back into the Wi-Fi setup page.
   //   3. `pio run -t erase` over a serial cable.
-  // See docs/troubleshooting.md "Factory reset" for details.
+  // See docs/07-deployment-view/esp-flashing.md "Reconfiguration (re-flash)".
 
   /*
     ESP opens WiFi access point to receive the configuration from user input
@@ -252,7 +254,8 @@ void setup() {
           ===== http://192.168.4.1 ===== -> ESP softAP() endpoint
           ==============================
 
-    to type in WiFi credentials, endpoint URL and camera settings
+    to type in your WiFi credentials (the only thing the page asks for —
+    module name, server URLs and camera settings are set under the hood)
   */
   Serial.println("[ESP] OPENING ACCESS POINT");
   Serial.println("------ Connect on http://192.168.4.1 to configure ------");
@@ -263,9 +266,10 @@ void setup() {
     setupAccessPoint();
   } else {
     // Auto-fallback: if previous boots have repeatedly failed to join the
-    // saved network, clear the configured flag so the next boot re-opens
-    // the captive portal. Same NVS mutation as POST /factory_reset on the
-    // captive portal; this path triggers automatically without user input.
+    // saved network, clear the NVS `configured` flag so the next boot
+    // re-opens the captive portal. This triggers automatically without user
+    // input — the supported recovery path when a module is moved to a new
+    // network and the old SSID is gone.
     uint8_t wifiFails = getWifiFailCount();
     if (wifiFails >= WIFI_FAIL_AP_FALLBACK_THRESH) {
       Serial.printf("-- %u consecutive WiFi join failures — re-entering AP mode\n",
@@ -276,9 +280,9 @@ void setup() {
       ESP.restart();
     }
     Serial.println("-- ESP already configured. To reconfigure:");
-    Serial.println("   (1) Cause 3 consecutive WiFi-join failures (e.g. save wrong credentials) — board auto-reopens AP at http://192.168.4.1.");
-    Serial.println("   (2) Once at the captive portal, expand 'Factory reset (advanced)' and submit.");
-    Serial.println("   (3) Or via serial cable: cd ESP32-CAM && pio run -t erase && pio run -t upload");
+    Serial.println("   (1) Re-flash via the homepage wizard Step 2 — flashing erases the saved config and reopens the WiFi setup page at http://192.168.4.1.");
+    Serial.println("   (2) Over a serial cable: cd ESP32-CAM && pio run -t erase && pio run -t upload");
+    Serial.println("   (3) Or cause 3 consecutive WiFi-join failures (e.g. move to a new network) — the board auto-reopens its setup AP at http://192.168.4.1.");
   }
 
   Serial.println("[ESP] INITIALIZING ESP");

--- a/ESP32-CAM/build.sh
+++ b/ESP32-CAM/build.sh
@@ -71,12 +71,36 @@ if [ -z "${GEO_API_KEY}" ] && [ -f "${SKETCH_DIR}/GEO_API_KEY" ]; then
   GEO_API_KEY="$(tr -d '[:space:]' < "${SKETCH_DIR}/GEO_API_KEY")"
 fi
 
+# DEV_SERVER_HOST (optional): point a dev module at a LAN stack instead of the
+# production backend baked into firmware_defaults.h. Sourced from env var
+# first, then a .gitignored file — same pattern as GEO_API_KEY above. When set,
+# compose the init/upload URLs from the LAN-dev host ports (8002 = duckdb-
+# service, 8000 = image-service) and inject them as -DHF_INIT_URL_DEFAULT /
+# -DHF_UPLOAD_URL_DEFAULT, overriding the production #ifndef defaults in
+# firmware_defaults.h. Absent => no flags, production URLs apply. The `\"`
+# escapes produce a single layer of C-string quote bytes, matching the
+# GEO_API_KEY/FIRMWARE_VERSION quoting; extra_scripts.py mirrors this via
+# env.StringifyMacro. See docs/07-deployment-view/esp-flashing.md.
+DEV_SERVER_HOST="$(printf '%s' "${DEV_SERVER_HOST:-}" | tr -d '[:space:]')"
+if [ -z "${DEV_SERVER_HOST}" ] && [ -f "${SKETCH_DIR}/DEV_SERVER_HOST" ]; then
+  DEV_SERVER_HOST="$(tr -d '[:space:]' < "${SKETCH_DIR}/DEV_SERVER_HOST")"
+fi
+DEV_URL_FLAGS=""
+if [ -n "${DEV_SERVER_HOST}" ]; then
+  DEV_URL_FLAGS=" -DHF_INIT_URL_DEFAULT=\"http://${DEV_SERVER_HOST}:8002/new_module\" -DHF_UPLOAD_URL_DEFAULT=\"http://${DEV_SERVER_HOST}:8000/upload\""
+fi
+
 echo "Compiling ESP32-CAM firmware..."
 echo "  FQBN:     ${FQBN}"
 echo "  Sketch:   ${SKETCH_DIR}"
 echo "  Output:   ${BUILD_DIR}"
 echo "  Version:  ${VERSION}"
 echo "  Sequence: ${SEQUENCE}"
+if [ -n "${DEV_SERVER_HOST}" ]; then
+  echo "  DevHost: ${DEV_SERVER_HOST} (init :8002, upload :8000 — LAN dev override)"
+else
+  echo "  DevHost: <unset> (production URLs baked in)"
+fi
 if [ -n "${GEO_API_KEY}" ]; then
   echo "  GeoKey:  set (len=${#GEO_API_KEY})"
 else
@@ -107,7 +131,7 @@ arduino-cli compile \
   --fqbn "${FQBN}" \
   --output-dir "${BUILD_DIR}" \
   --libraries "${SKETCH_DIR}/lib" \
-  --build-property "build.extra_flags=-DFIRMWARE_VERSION=\"${VERSION}\" -DGEO_API_KEY=\"${GEO_API_KEY}\" -DFIRMWARE_SEQUENCE=${SEQUENCE}" \
+  --build-property "build.extra_flags=-DFIRMWARE_VERSION=\"${VERSION}\" -DGEO_API_KEY=\"${GEO_API_KEY}\" -DFIRMWARE_SEQUENCE=${SEQUENCE}${DEV_URL_FLAGS}" \
   --build-property "build.partitions=min_spiffs" \
   "${SKETCH_DIR}"
 

--- a/ESP32-CAM/esp_init.cpp
+++ b/ESP32-CAM/esp_init.cpp
@@ -469,8 +469,22 @@ bool loadConfig(esp_config_t *esp_config) {
   const bool urlMigrated =
       (uploadMigrated != uploadFromDisk) || (initMigrated != initFromDisk);
 
-  strlcpy(esp_config->UPLOAD_URL, uploadMigrated.c_str(), sizeof(esp_config->UPLOAD_URL));
-  strlcpy(esp_config->INIT_URL,   initMigrated.c_str(),   sizeof(esp_config->INIT_URL));
+  // Server URLs are no longer operator-entered — the captive portal is
+  // Wi-Fi-credentials-only, so a config saved by the simplified form carries
+  // no INIT_URL/UPLOAD_URL. Fall back to the compile-time defaults
+  // (production by default; a LAN-dev override baked in via the gitignored
+  // DEV_SERVER_HOST build file). See lib/firmware_defaults/firmware_defaults.h.
+  // Modules still holding URLs from an older config keep them (migrated to
+  // https above), so existing fleets are unaffected. The substitution is
+  // RAM-only — we do NOT persist the default to SPIFFS, so a rebuild for a
+  // different target retargets cleanly without an erase.
+  const std::string uploadResolved =
+      uploadMigrated.empty() ? std::string(hf::defaults::kUploadUrlDefault) : uploadMigrated;
+  const std::string initResolved =
+      initMigrated.empty() ? std::string(hf::defaults::kInitUrlDefault) : initMigrated;
+
+  strlcpy(esp_config->UPLOAD_URL, uploadResolved.c_str(), sizeof(esp_config->UPLOAD_URL));
+  strlcpy(esp_config->INIT_URL,   initResolved.c_str(),   sizeof(esp_config->INIT_URL));
   strlcpy(
     esp_config->email,
     esp_config_doc["NETWORK"]["EMAIL"] | "",

--- a/ESP32-CAM/esp_init.h
+++ b/ESP32-CAM/esp_init.h
@@ -74,16 +74,16 @@ void setESPConfigured(bool value);
 /* Settle delay between mutating NVS (e.g. setESPConfigured(false)) and
    ESP.restart(), so the flash write commits and the WiFi/HTTP stack can
    finish flushing FINs. Used by the auto-AP-fallback path in
-   ESP32-CAM.ino's setup() and by the /factory_reset endpoint in
-   host.cpp. */
+   ESP32-CAM.ino's setup(). (The captive-portal /factory_reset endpoint that
+   also used this was removed; reconfiguring is now done by re-flashing.) */
 #define FACTORY_RESET_SETTLE_MS 500UL
 
 /* Persisted counter of consecutive WiFi-join timeouts. Cleared on a
    successful join; bumped from setupWifiConnection() each time the 30 s
    begin() loop times out. Used at boot to decide whether to drop back
-   into AP-config mode automatically — the user can also trigger the
-   same NVS mutation by hand via the captive portal's POST /factory_reset
-   endpoint once the AP has reopened.
+   into AP-config mode automatically — the user can also force the AP to
+   reopen by re-flashing the firmware (the web installer erases the saved
+   config).
 
    Storage: NVS namespace "config", key "wifi_fails" (uint8). */
 uint8_t getWifiFailCount();

--- a/ESP32-CAM/extra_scripts.py
+++ b/ESP32-CAM/extra_scripts.py
@@ -100,14 +100,35 @@ geo_key = (
     or (_strip_all_whitespace(geo_key_file.read_text(encoding="utf-8")) if geo_key_file.exists() else "")
 )
 
+# DEV_SERVER_HOST (optional): mirror build.sh. When set (env var first, then a
+# .gitignored ESP32-CAM/DEV_SERVER_HOST file), override the production server
+# URLs baked into firmware_defaults.h with a LAN-dev stack so a `pio run`
+# binary talks to the developer's machine. Absent => no defines, so the
+# production #ifndef defaults apply. The LAN-dev host ports are 8002 (duckdb-
+# service) and 8000 (image-service); the wire endpoints (`new_module`,
+# `upload`) match the production paths.
+dev_host_file = project_dir / "DEV_SERVER_HOST"
+dev_host = (
+    _strip_all_whitespace(os.environ.get("DEV_SERVER_HOST") or "")
+    or (_strip_all_whitespace(dev_host_file.read_text(encoding="utf-8")) if dev_host_file.exists() else "")
+)
+url_defines = []
+if dev_host:
+    url_defines = [
+        ("HF_INIT_URL_DEFAULT",   env.StringifyMacro(f"http://{dev_host}:8002/new_module")),   # noqa: F821
+        ("HF_UPLOAD_URL_DEFAULT", env.StringifyMacro(f"http://{dev_host}:8000/upload")),        # noqa: F821
+    ]
+
 env.Append(  # noqa: F821
     CPPDEFINES=[
         ("FIRMWARE_VERSION",  env.StringifyMacro(version)),       # noqa: F821
         ("FIRMWARE_SEQUENCE", str(sequence)),
         ("GEO_API_KEY",       env.StringifyMacro(geo_key)),       # noqa: F821
+        *url_defines,
     ]
 )
 
 print(f"[extra_scripts] FIRMWARE_VERSION={version}")
 print(f"[extra_scripts] FIRMWARE_SEQUENCE={sequence}")
 print(f"[extra_scripts] GEO_API_KEY len={len(geo_key)}")
+print(f"[extra_scripts] DEV_SERVER_HOST={dev_host or '<unset> (production URLs)'}")

--- a/ESP32-CAM/host.cpp
+++ b/ESP32-CAM/host.cpp
@@ -4,8 +4,7 @@
 #include <ArduinoJson.h>
 #include <esp_task_wdt.h>
 #include "esp_init.h"   // setESPConfigured
-#include "firmware_defaults.h" // hf::defaults::k*FormFallback (issue #66)
-#include "form_query.h" // hf::urlDecode, hf::getParam, hf::resolveKeepCurrentField, hf::splitUrlForForm, hf::joinUrlFromForm (host-testable)
+#include "form_query.h" // hf::urlDecode, hf::getParam, hf::resolveKeepCurrentField (host-testable)
 #include "led.h"        // ledTick during the AP server loop
 #include <string>
 
@@ -18,15 +17,14 @@ String sessionToken;
 
 String header;
 
-String cfg_module_name = "";
-String cfg_ssid           = "";
-String cfg_password       = "";
-String cfg_upload_url     = "";
-String cfg_init_url       = "";
-String cfg_resolution     = hf::defaults::kResolutionFormFallback;
-int    cfg_vflip          = hf::defaults::kVerticalFlipFormFallback;
-int    cfg_brightness     = hf::defaults::kBrightnessFormFallback;
-int    cfg_saturation     = hf::defaults::kSaturationFormFallback;
+// The captive portal is Wi-Fi-credentials-only (PR: simplify ESP config to
+// SSID+password). Module name, server URLs and camera settings are no longer
+// operator-editable — they are derived under the hood at boot by
+// esp_init.cpp's loadConfig (MAC-derived name, compile-time URL defaults from
+// firmware_defaults.h, production camera fallbacks). So only the two Wi-Fi
+// fields have a RAM shadow here.
+String cfg_ssid     = "";
+String cfg_password = "";
 
 
 /*
@@ -90,36 +88,15 @@ void loadConfig() {
     return;
   }
 
-  cfg_module_name = doc["NETWORK"]["MODULE_NAME"] | "";
-  cfg_ssid        = doc["NETWORK"]["SSID"]           | "";
-  cfg_password    = doc["NETWORK"]["PASSWORD"]       | "";
-  cfg_upload_url  = doc["NETWORK"]["UPLOAD_URL"]     | "";
-  cfg_init_url    = doc["NETWORK"]["INIT_URL"]       | "";
-
-  // Mirror the legacy-http migration esp_init.cpp::loadConfig applies
-  // on the main-firmware boot path. host.cpp::loadConfig runs on the
-  // captive-portal entry, which is after WiFi-auth has failed three
-  // times (auto-AP fallback) or on an explicit factory reset — in the
-  // common case esp_init.cpp will have already migrated SPIFFS, so
-  // this is a defensive in-memory rewrite. The captive portal does
-  // NOT re-save on read; the operator must click Save to persist.
-  // See lib/firmware_defaults/firmware_defaults.h for the dual-reader
-  // contract this honours, and rewriteLegacyHighfiveUrl in
-  // lib/form_query/ for the prefix-match rule. Issue #79.
-  cfg_upload_url = String(hf::rewriteLegacyHighfiveUrl(std::string(cfg_upload_url.c_str())).c_str());
-  cfg_init_url   = String(hf::rewriteLegacyHighfiveUrl(std::string(cfg_init_url.c_str())).c_str());
-
-  // Form-prefill fallbacks. Asymmetric on purpose with the production
-  // reader in `esp_init.cpp`'s `loadConfig` (form prefills the operator-
-  // facing default; the production side picks the conservative "do
-  // nothing surprising" value when the key is missing). Each pair lives
-  // in `lib/firmware_defaults/firmware_defaults.h` as a named constant
-  // so the asymmetry survives future "deduplicate the literals"
-  // refactors — see chapter-11 "Dual-reader asymmetry" for the lesson.
-  cfg_resolution  = doc["CAMERA"]["RESOLUTION"]     | hf::defaults::kResolutionFormFallback;
-  cfg_vflip       = doc["CAMERA"]["VERTICAL_FLIP"]  | hf::defaults::kVerticalFlipFormFallback;
-  cfg_brightness  = doc["CAMERA"]["BRIGHTNESS"]     | hf::defaults::kBrightnessFormFallback;
-  cfg_saturation  = doc["CAMERA"]["SATURATION"]    | hf::defaults::kSaturationFormFallback;
+  // Wi-Fi-credentials-only captive portal: prefill only the SSID (so a
+  // reconfiguring operator sees their current network). The password is
+  // never echoed back into the form (#46) but we load it so the "leave
+  // blank to keep current" contract in `/save` can fall through to it.
+  // Module name, server URLs and camera settings are not operator-editable
+  // here — esp_init.cpp's loadConfig owns those defaults — so they are not
+  // read.
+  cfg_ssid     = doc["NETWORK"]["SSID"]     | "";
+  cfg_password = doc["NETWORK"]["PASSWORD"] | "";
 }
 
 /*
@@ -131,18 +108,14 @@ void saveConfig() {
   StaticJsonDocument<1024> doc;
 
   JsonObject net  = doc.createNestedObject("NETWORK");
-  JsonObject cam  = doc.createNestedObject("CAMERA");
 
-  net["MODULE_NAME"] = cfg_module_name;
+  // Only Wi-Fi credentials are persisted. Module name, server URLs and
+  // camera settings are intentionally absent from /config.json: esp_init.cpp's
+  // loadConfig derives them under the hood (MAC-derived name, compile-time
+  // URL defaults from firmware_defaults.h, production camera fallbacks) when
+  // the keys are missing, so a Wi-Fi-only config is complete.
   net["SSID"]        = cfg_ssid;
   net["PASSWORD"]    = cfg_password;
-  net["UPLOAD_URL"]  = cfg_upload_url;
-  net["INIT_URL"]    = cfg_init_url;
-
-  cam["RESOLUTION"]             = cfg_resolution;
-  cam["VERTICAL_FLIP"]          = cfg_vflip;
-  cam["BRIGHTNESS"]             = cfg_brightness;
-  cam["SATURATION"]             = cfg_saturation;
 
   File f = SPIFFS.open("/config.json", "w");
   if (!f) {
@@ -157,7 +130,8 @@ void saveConfig() {
   // setup that keeps the NVS `configured` flag false, so next boot re-enters
   // the captive portal; the captive-portal reader (`host.cpp`'s own
   // `loadConfig`) will trip over the empty file once, log "Failed to parse
-  // config.json", and fall back to the compiled-in `cfg_*` defaults. On
+  // config.json", and leave `cfg_ssid`/`cfg_password` at their initial empty
+  // strings — the form simply renders as first-time setup. On
   // re-configuration the flag persists `true` from an earlier successful
   // save; next boot calls `esp_init.cpp`'s `loadConfig`, `deserializeJson`
   // returns a parse error on the empty file, `loadConfig` logs "JSON parse
@@ -186,43 +160,10 @@ void saveConfig() {
   -------- HTML CONFIG FORM --------
   ----------------------------------
 */
-// `errorMessage` MUST be a compile-time-controlled string. It is
-// rendered raw into the HTML response with no escape; a future
-// contributor passing operator-tainted data here (e.g. echoing the
-// rejected port value back) opens an XSS hole. Keep it to constant
-// strings populated by the /save handler's failure paths.
-void sendConfigForm(WiFiClient &client, bool saved = false, const char* errorMessage = nullptr) {
-  // Three-fields-per-URL pre-fill (issue #79). Logic lives in
-  // hf::splitUrlForForm (lib/form_query/) so test_native_form_query
-  // pins the split shape. Port defaults to the LAN-dev convention
-  // (8002 for init, 8000 for upload) ONLY when no URL is saved —
-  // first-boot. On reconfigure the stored URL's port (which may be
-  // empty for production https://highfive.schutera.com) wins so the
-  // operator doesn't see a phantom "8002" appear on a production
-  // module. Endpoint defaults likewise — first-boot prefills the
-  // wire-protocol constants (`upload` / `new_module`) pinned by
-  // `image-service/app.py::upload_image` and
-  // `duckdb-service/routes/modules.py::add_module`.
-  hf::FormUrlParts uploadParts = hf::splitUrlForForm(std::string(cfg_upload_url.c_str()));
-  hf::FormUrlParts initParts   = hf::splitUrlForForm(std::string(cfg_init_url.c_str()));
-
-  String uploadBase     = String(uploadParts.base.c_str());
-  String uploadPort     = (cfg_upload_url.length() == 0)
-                              ? "8000"
-                              : String(uploadParts.port.c_str());
-  String uploadEndpoint = uploadParts.endpoint.empty()
-                              ? "upload"
-                              : String(uploadParts.endpoint.c_str());
-
-  String initBase       = String(initParts.base.c_str());
-  String initPort       = (cfg_init_url.length() == 0)
-                              ? "8002"
-                              : String(initParts.port.c_str());
-  String initEndpoint   = initParts.endpoint.empty()
-                              ? "new_module"
-                              : String(initParts.endpoint.c_str());
-
-
+// Wi-Fi-credentials-only captive portal. The page asks for nothing but the
+// home Wi-Fi SSID + password; module name, server URLs and camera settings
+// are derived under the hood (see saveConfig / esp_init.cpp's loadConfig).
+void sendConfigForm(WiFiClient &client, bool saved = false) {
   client.println("HTTP/1.1 200 OK");
   client.println("Content-type:text/html");
   client.println("Access-Control-Allow-Origin: *");
@@ -281,34 +222,23 @@ void sendConfigForm(WiFiClient &client, bool saved = false, const char* errorMes
   );
 
   /* ===== VALIDATION SCRIPT ===== */
+  // Only the SSID is required. The password input is tagged
+  // data-keep-current-on-empty when a password is already saved, so an empty
+  // submission is allowed (the /save handler keeps the current password via
+  // hf::resolveKeepCurrentField). The hidden session field is skipped.
   client.println(
   "<script>"
   "function validateForm(event){"
   "  event.preventDefault();"
   "  let valid=true;"
-  "  const fields=document.querySelectorAll('input, select');"
+  "  const fields=document.querySelectorAll('input');"
   "  fields.forEach(f=>{"
+  "    if(f.type==='hidden'){return;}"
   "    if(f.dataset.keepCurrentOnEmpty==='1' && f.value===''){"
   "      f.classList.remove('error-field');"
   "      return;"
   "    }"
-  // data-keep-empty (issue #79) — port fields are legitimately
-  // empty when the URL uses an implicit scheme-default port
-  // (e.g. 443 for https). Numeric range is enforced by the
-  // input's min/max plus a defensive parseInt check below.
-  "    if(f.dataset.keepEmpty==='1' && f.value===''){"
-  "      f.classList.remove('error-field');"
-  "      return;"
-  "    }"
-  "    if(f.type==='number' && f.value!==''){"
-  "      const n=parseInt(f.value,10);"
-  "      if(isNaN(n)||n<(parseInt(f.min,10)||0)||n>(parseInt(f.max,10)||0x7fffffff)){"
-  "        f.classList.add('error-field');"
-  "        valid=false;"
-  "        return;"
-  "      }"
-  "    }"
-  "    if(f.type!=='hidden' && f.value.trim()===''){"
+  "    if(f.value.trim()===''){"
   "      f.classList.add('error-field');"
   "      valid=false;"
   "    }else{"
@@ -328,47 +258,23 @@ void sendConfigForm(WiFiClient &client, bool saved = false, const char* errorMes
 
   client.println("</head><body>");
   client.println("<div class=\"container\"><div class=\"card\">");
-  client.println("<h1>ESP32 Module Configuration</h1>");
+  client.println("<h1>Connect your module to WiFi</h1>");
 
   if (saved) {
-    client.println("<div class=\"message\"><strong>Configuration saved successfully.</strong></div>");
-  }
-  // Server-side reject banner (issue #79). Used when /save rejects
-  // a submission for a reason the JS validator would have caught
-  // (port out of range, port non-numeric) but the JS path was
-  // bypassed via curl or a JS-disabled browser. Without this,
-  // operators see the form re-render with their previous values
-  // and no indication that anything went wrong — the same silent-
-  // failure shape chapter-11 already flagged for the setup wizard.
-  if (errorMessage != nullptr) {
-    client.print("<div class=\"message\" style=\"background:#fee2e2;color:#991b1b;border:1px solid #fecaca;\"><strong>");
-    client.print(errorMessage);
-    client.println("</strong></div>");
+    client.println("<div class=\"message\"><strong>Configuration saved successfully.</strong> Your module is connecting to your WiFi now.</div>");
   }
 
   client.println("<form action=\"/save\" method=\"POST\" autocomplete=\"off\" onsubmit=\"validateForm(event)\">");
   client.println("<input type=\"hidden\" name=\"session\" value=\"" + sessionToken + "\">");
 
-  /* ===== GENERAL ===== */
+  /* ===== WIFI ===== */
   client.println("<div class=\"section\">");
-  client.println("<h2>General</h2>");
-  client.println("<div class=\"section-desc\">Basic identification settings for this device.</div>");
-
-  client.println("<div class=\"field\">");
-  client.println("<label>Module Name</label>");
-  client.println("<input type=\"text\" name=\"module_name\" value=\"" + cfg_module_name + "\">");
-  client.println("<div class=\"description\">You can name the module however you want.</div>");
-  client.println("</div>");
-  client.println("</div>");
-
-  /* ===== NETWORK ===== */
-  client.println("<div class=\"section\">");
-  client.println("<h2>Network</h2>");
-  client.println("<div class=\"section-desc\">WiFi credentials and communication endpoints.</div>");
+  client.println("<div class=\"section-desc\">Enter your home WiFi name and password. That's all — your module sets everything else up automatically.</div>");
 
   client.println("<div class=\"field\">");
   client.println("<label>WiFi SSID</label>");
   client.println("<input type=\"text\" name=\"ssid\" value=\"" + cfg_ssid + "\">");
+  client.println("<div class=\"description\">Your WiFi must be 2.4 GHz — the module cannot use 5 GHz networks.</div>");
   client.println("</div>");
 
   client.println("<div class=\"field\">");
@@ -390,100 +296,17 @@ void sendConfigForm(WiFiClient &client, bool saved = false, const char* errorMes
   client.println("<input type=\"password\" name=\"password\"" + pwKeepAttr + " value=\"\" placeholder=\"" + pwHint + "\">");
   client.println("</div>");
 
-  // Three fields per URL since #79: base, port, endpoint. Port is
-  // its own input so production (`https://highfive.schutera.com`,
-  // implicit :443) and LAN dev (`http://10.0.0.5:8002`) share the
-  // same shape — the operator only types numbers in one place. Flex
-  // sizes intentionally non-uniform: base is the widest input, port
-  // is the narrowest. Empty port is permitted (data-keep-empty="1")
-  // so production submissions don't fail validation.
-  client.println("<div class=\"row\">");
-  client.println("<div class=\"field\" style=\"flex:3\">");
-  client.println("<label>Initialization Base URL</label>");
-  client.println("<input type=\"text\" name=\"init_base\" value=\"" + initBase + "\">");
-  client.println("</div>");
-  client.println("<div class=\"field\" style=\"flex:1\">");
-  client.println("<label>Port</label>");
-  client.println("<input type=\"number\" name=\"init_port\" min=\"1\" max=\"65535\" data-keep-empty=\"1\" value=\"" + initPort + "\">");
-  client.println("</div>");
-  client.println("<div class=\"field\" style=\"flex:1\">");
-  client.println("<label>Endpoint</label>");
-  client.println("<input type=\"text\" name=\"init_endpoint\" value=\"" + initEndpoint + "\">");
-  client.println("</div>");
-  client.println("</div>");
-
-  client.println("<div class=\"row\">");
-  client.println("<div class=\"field\" style=\"flex:3\">");
-  client.println("<label>Upload Base URL</label>");
-  client.println("<input type=\"text\" name=\"upload_base\" value=\"" + uploadBase + "\">");
-  client.println("</div>");
-  client.println("<div class=\"field\" style=\"flex:1\">");
-  client.println("<label>Port</label>");
-  client.println("<input type=\"number\" name=\"upload_port\" min=\"1\" max=\"65535\" data-keep-empty=\"1\" value=\"" + uploadPort + "\">");
-  client.println("</div>");
-  client.println("<div class=\"field\" style=\"flex:1\">");
-  client.println("<label>Endpoint</label>");
-  client.println("<input type=\"text\" name=\"upload_endpoint\" value=\"" + uploadEndpoint + "\">");
-  client.println("</div>");
-  client.println("</div>");
-  client.println("</div>");
-
-  /* ===== CAMERA ===== */
-  client.println("<div class=\"section\">");
-  client.println("<h2>Camera</h2>");
-  client.println("<div class=\"section-desc\">Image capture and quality settings.</div>");
-
-  client.println("<div class=\"field\">");
-  client.println("<label>Resolution</label>");
-  client.println("<select name=\"res\">");
-  client.println("<option value=\"qvga\""  + String(cfg_resolution.equalsIgnoreCase("qvga")  ? " selected" : "") + ">QVGA - 320x240</option>");
-  client.println("<option value=\"vga\""   + String(cfg_resolution.equalsIgnoreCase("vga")   ? " selected" : "") + ">VGA - 640x480</option>");
-  client.println("<option value=\"qxga\""  + String(cfg_resolution.equalsIgnoreCase("qxga")  ? " selected" : "") + ">QXGA - 800x600</option>");
-  client.println("<option value=\"sxga\""  + String(cfg_resolution.equalsIgnoreCase("sxga")  ? " selected" : "") + ">SXGA - 1280x1024</option>");
-  client.println("<option value=\"uxga\""  + String(cfg_resolution.equalsIgnoreCase("uxga")  ? " selected" : "") + ">UXGA - 1600x1200</option>");
-  client.println("</select>");
-  client.println("</div>");
-
-  client.println("<div class=\"field\">");
-  client.println("<label>Vertical Flip (0 or 1)</label>");
-  client.println("<input type=\"number\" name=\"vflip\" min=\"0\" max=\"1\" value=\"" + String(cfg_vflip) + "\">");
-  client.println("</div>");
-
-  client.println("<div class=\"field\">");
-  client.println("<label>Brightness</label>");
-  client.println("<input type=\"number\" name=\"bright\" value=\"" + String(cfg_brightness) + "\">");
-  client.println("</div>");
-
-  client.println("<div class=\"field\">");
-  client.println("<label>Saturation</label>");
-  client.println("<input type=\"number\" name=\"sat\" value=\"" + String(cfg_saturation) + "\">");
-  client.println("</div>");
-
-  client.println("</div>");
+  client.println("</div>");  // end WIFI section
 
   client.println("<button type=\"submit\">Save Configuration</button>");
-  client.println("<div id=\"errorText\" class=\"error-message\">Enter missing details before saving configuration.</div>");
+  client.println("<div id=\"errorText\" class=\"error-message\">Enter your WiFi name before saving.</div>");
 
   client.println("</form>");
 
-  // Factory reset is a separate form so the main Save button can't
-  // accidentally trigger it. Collapsed inside <details> by default.
-  // Issue #40: replaces the old "hold IO0 at boot" path which never
-  // actually worked because GPIO0 is a strap pin.
-  client.println("<form action=\"/factory_reset\" method=\"POST\" autocomplete=\"off\">");
-  client.println("<input type=\"hidden\" name=\"session\" value=\"" + sessionToken + "\">");
-  client.println("<details class=\"section\">");
-  // <summary> is the screen-reader heading for the disclosure widget;
-  // wrapping <h2> inside it would announce the label twice.
-  client.println("<summary class=\"summary-as-h2\">Factory reset (advanced)</summary>");
-  client.println("<div class=\"section-desc\">Reboots the module back into this configuration portal so you can re-enter or edit the saved settings. Your previous values prefill the form for editing. Use this when moving the module to a new WiFi network or when login credentials changed.</div>");
-  client.println("<div class=\"field\">");
-  client.println("<label><input type=\"checkbox\" name=\"confirm\" value=\"yes\" required> I understand this reboots the module and reopens the configuration portal.</label>");
-  client.println("</div>");
-  client.println("<button type=\"submit\">Factory reset</button>");
-  client.println("</details>");
-  client.println("</form>");
-
+  // No factory-reset control: reconfiguring is done by re-flashing (which
+  // erases the saved config and reopens this page), and the firmware also
+  // auto-reopens this access point after WIFI_FAIL_AP_FALLBACK_THRESH failed
+  // joins. See docs/07-deployment-view/esp-flashing.md.
   client.println("</div></div></body></html>");
   client.println();
 }
@@ -566,97 +389,24 @@ void runAccessPoint() {
                   // Only treat as valid if session token matches
                   String sessionParam = getParam(query, "session");
                   if (sessionParam == sessionToken) {
-                    cfg_module_name = getParam(query, "module_name");
-
-                    cfg_ssid        = getParam(query, "ssid");
+                    cfg_ssid     = getParam(query, "ssid");
                     // Empty submission means "keep current password" (#46): the
-                    // form no longer pre-fills the field, so a user editing only
-                    // the SSID would otherwise wipe their saved credential. The
-                    // HTML half (`pwKeepAttr` in `sendConfigForm` above) tags
-                    // the password input with `data-keep-current-on-empty="1"`
-                    // and the JS validator (also rendered by `sendConfigForm`)
-                    // skips validation when empty; this assignment honours the
-                    // same shape on the server. Logic lives in
+                    // form never pre-fills the field, so a user editing only the
+                    // SSID would otherwise wipe their saved credential. The HTML
+                    // half (`pwKeepAttr` in `sendConfigForm` above) tags the
+                    // password input with `data-keep-current-on-empty="1"` and the
+                    // JS validator skips validation when empty; this assignment
+                    // honours the same shape on the server. Logic lives in
                     // `hf::resolveKeepCurrentField` (lib/form_query/) — host-
-                    // testable as of #57; whitespace-trim and blank-keep
-                    // semantics are pinned by 5 Unity tests in
-                    // test/test_native_form_query/.
+                    // testable as of #57; whitespace-trim and blank-keep semantics
+                    // are pinned by 5 Unity tests in test/test_native_form_query/.
                     cfg_password = resolveKeepCurrentField(getParam(query, "password"), cfg_password);
 
-                    // Three-fields-per-URL form (issue #79). Read base, port,
-                    // endpoint; trim each; recombine via hf::joinUrlFromForm so
-                    // the slash-normalisation + scheme-default-port-stripping
-                    // is pinned by test_native_form_query rather than inlined
-                    // here. Empty port submissions are normal (production
-                    // https://highfive.schutera.com on implicit :443) — the
-                    // joiner omits ":port" for empty values.
-                    String uploadBase     = getParam(query, "upload_base");
-                    String uploadPort     = getParam(query, "upload_port");
-                    String uploadEndpoint = getParam(query, "upload_endpoint");
-
-                    String initBase       = getParam(query, "init_base");
-                    String initPort       = getParam(query, "init_port");
-                    String initEndpoint   = getParam(query, "init_endpoint");
-
-                    uploadBase.trim();
-                    uploadPort.trim();
-                    uploadEndpoint.trim();
-                    initBase.trim();
-                    initPort.trim();
-                    initEndpoint.trim();
-
-                    // Server-side port validation (issue #79). The JS
-                    // validator in `sendConfigForm` enforces the same
-                    // rule, but a curl / JS-disabled submission would
-                    // otherwise persist `init_port=99999` or
-                    // `init_port=abc` to SPIFFS and brick the next
-                    // boot's URL parse. On any invalid port we
-                    // re-render the form WITHOUT setting "saved" AND
-                    // surface an error banner so the operator sees
-                    // their submission did not stick — silent reject
-                    // is the same shape as the setup-wizard silent-
-                    // success bugs chapter-11 already flagged. Logic
-                    // + 10 unit tests live in `hf::isValidPortString`
-                    // (lib/form_query/).
-                    const bool uploadPortValid = hf::isValidPortString(std::string(uploadPort.c_str()));
-                    const bool initPortValid   = hf::isValidPortString(std::string(initPort.c_str()));
-                    if (!uploadPortValid || !initPortValid) {
-                      const char* which =
-                          (!uploadPortValid && !initPortValid) ? "Upload Port and Initialization Port"
-                          : (!uploadPortValid)                 ? "Upload Port"
-                                                               : "Initialization Port";
-                      Serial.printf("[host] /save rejected: invalid port (upload_ok=%d init_ok=%d)\n",
-                                    (int)uploadPortValid, (int)initPortValid);
-                      // Reuse one buffer for the banner text — Arduino String
-                      // would heap-fragment on a re-onboarding loop.
-                      char banner[96];
-                      snprintf(banner, sizeof(banner),
-                               "%s must be empty or a number between 1 and 65535.",
-                               which);
-                      sendConfigForm(client, false, banner);
-                      break;
-                    }
-
-                    cfg_upload_url = String(
-                        hf::joinUrlFromForm(
-                            std::string(uploadBase.c_str()),
-                            std::string(uploadPort.c_str()),
-                            std::string(uploadEndpoint.c_str())
-                        ).c_str()
-                    );
-                    cfg_init_url = String(
-                        hf::joinUrlFromForm(
-                            std::string(initBase.c_str()),
-                            std::string(initPort.c_str()),
-                            std::string(initEndpoint.c_str())
-                        ).c_str()
-                    );
-
-                    cfg_resolution  = getParam(query, "res");
-                    cfg_vflip       = getParam(query, "vflip").toInt();
-                    cfg_brightness  = getParam(query, "bright").toInt();
-                    cfg_saturation  = getParam(query, "sat").toInt();
-
+                    // Wi-Fi-credentials-only: module name, server URLs and camera
+                    // settings are no longer operator-entered. Any such fields a
+                    // legacy client still POSTs are ignored here; the firmware
+                    // derives them under the hood at boot (esp_init.cpp's
+                    // loadConfig).
                     saveConfig();
                     sendConfigForm(client, true);
                     server_running = 0;
@@ -667,57 +417,6 @@ void runAccessPoint() {
                 } else {
                   // /save but no params: show form
                   sendConfigForm(client, false);
-                }
-
-              } else if (fullPath.startsWith("/factory_reset")) {
-                // POST-only endpoint that wipes the NVS configured flag
-                // and reboots straight into AP mode. Issue #40 option A —
-                // replaces the broken GPIO0-hold path that never worked
-                // because GPIO0 is a strap pin on the AI Thinker board.
-                String query;
-                if (isPost) {
-                  query = body;
-                }
-
-                String sessionParam = getParam(query, "session");
-                String confirmParam = getParam(query, "confirm");
-                if (!isPost || sessionParam != sessionToken || confirmParam != "yes") {
-                  // Bad request. Render the form without leaking which check failed
-                  // to the client, but log the reason locally so a developer at the
-                  // serial monitor can see why their curl test isn't working.
-                  Serial.printf("[host] /factory_reset rejected: isPost=%d sessionOk=%d confirmOk=%d\n",
-                                (int)isPost,
-                                (int)(sessionParam == sessionToken),
-                                (int)(confirmParam == "yes"));
-                  sendConfigForm(client, false);
-                } else {
-                  Serial.println("[host] Factory reset requested via captive portal");
-                  // Tiny inline response page; the restart cuts the socket within ms.
-                  // The 60 s meta-refresh is a best-effort nudge — meta-refresh has
-                  // no event hook for "SSID has come back", just a fixed timer, and
-                  // an iOS/Android SSID switch round-trip can be 30+ s. If the user
-                  // is still off-network when the timer fires, the page errors and
-                  // the copy below tells them to reload manually. Better than
-                  // pretending the browser knows when the AP is back.
-                  client.println("HTTP/1.1 200 OK");
-                  client.println("Content-type:text/html");
-                  client.println("Connection: close");
-                  client.println();
-                  client.println("<!doctype html><html><head>");
-                  client.println("<meta http-equiv=\"refresh\" content=\"60; url=http://192.168.4.1/\">");
-                  client.println("</head><body>");
-                  client.println("<h1>Factory reset</h1>");
-                  client.println("<p>The module is rebooting and will reopen the WiFi access point in a moment. Reconnect your phone to <code>ESP32-Access-Point</code>, then either wait up to 60 seconds for this page to refresh on its own, or reload it manually.</p>");
-                  client.println("</body></html>");
-                  // WiFiClient::flush() on Arduino-ESP32 is best-effort — it
-                  // doesn't guarantee bytes have actually left the radio. The
-                  // 500 ms FACTORY_RESET_SETTLE_MS below is what gives the TCP
-                  // stack a fighting chance to drain before ESP.restart().
-                  client.flush();
-
-                  setESPConfigured(false);
-                  delay(FACTORY_RESET_SETTLE_MS);  // give the kernel time to flush the TCP FIN
-                  ESP.restart();
                 }
 
               } else {

--- a/ESP32-CAM/lib/firmware_defaults/firmware_defaults.h
+++ b/ESP32-CAM/lib/firmware_defaults/firmware_defaults.h
@@ -59,5 +59,32 @@ constexpr int kBrightnessProductionFallback = 1;
 constexpr int kSaturationFormFallback       = 0;
 constexpr int kSaturationProductionFallback = -1;
 
+// ----- SERVER URLs --------------------------------------------------------
+// The captive portal is Wi-Fi-credentials-only: the operator never types a
+// server URL. esp_init.cpp's `loadConfig` applies these compile-time defaults
+// whenever the saved /config.json has no (or empty) INIT_URL / UPLOAD_URL, so
+// a module configured with just SSID+password still reaches the backend.
+//
+// Production (the #ifndef fallback) points at the TLS origin nginx serves on
+// :443 with path routing. Developers targeting a LAN stack override both at
+// build time by writing a gitignored ESP32-CAM/DEV_SERVER_HOST file (a bare
+// host/IP, e.g. 192.168.1.50) or exporting DEV_SERVER_HOST; build.sh and
+// extra_scripts.py compose http://<host>:8002/new_module and
+// http://<host>:8000/upload (the LAN-dev host ports for duckdb-service and
+// image-service) and inject them as -DHF_INIT_URL_DEFAULT /
+// -DHF_UPLOAD_URL_DEFAULT. This mirrors the GEO_API_KEY build-injection
+// pattern. The wire endpoints (`new_module`, `upload`) are pinned by
+// duckdb-service/routes/modules.py::add_module and
+// image-service/app.py::upload_image.
+#ifndef HF_INIT_URL_DEFAULT
+#define HF_INIT_URL_DEFAULT "https://highfive.schutera.com/new_module"
+#endif
+#ifndef HF_UPLOAD_URL_DEFAULT
+#define HF_UPLOAD_URL_DEFAULT "https://highfive.schutera.com/upload"
+#endif
+
+constexpr const char* kInitUrlDefault   = HF_INIT_URL_DEFAULT;
+constexpr const char* kUploadUrlDefault = HF_UPLOAD_URL_DEFAULT;
+
 }  // namespace defaults
 }  // namespace hf

--- a/docs/05-building-block-view/esp32cam.md
+++ b/docs/05-building-block-view/esp32cam.md
@@ -4,7 +4,7 @@ C++17 firmware on the AI-Thinker ESP32-CAM, built with PlatformIO
 against the Arduino framework. One module = one deployed unit. After
 configuration, the device runs fully unattended.
 
-For procedural setup (flashing, Wi-Fi config, factory reset) see
+For procedural setup (flashing, Wi-Fi config, reconfigure) see
 [07-deployment-view/esp-flashing.md](../07-deployment-view/esp-flashing.md).
 For the reliability layers (watchdogs, recovery) see
 [06-runtime-view/esp-reliability.md](../06-runtime-view/esp-reliability.md).
@@ -62,17 +62,20 @@ The host-testable split is documented in
 ## Configuration model
 
 The first boot opens an access point named `ESP32-Access-Point`
-(password `esp-12345`), serves a config form at
-`http://192.168.4.1`, and persists the user's input to NVS. On
-subsequent boots the device reads NVS and goes straight to the upload
-loop. The captive portal reopens automatically after three
-consecutive WiFi-join failures (auto-AP-fallback) so a typo'd
-password is recoverable in-band. From a reachable AP, factory reset
-is exposed via the captive portal at `http://192.168.4.1` (collapsed
-"Factory reset (advanced)" section), which calls `POST /factory_reset`
-and reboots into AP mode. For STA-locked boards (joined a working
-SSID, want to move to a different one), the cable path is
-`pio run -t erase` over serial.
+(password `esp-12345`), serves a Wi-Fi-only config form at
+`http://192.168.4.1`, and persists the user's input to SPIFFS
+`/config.json`; the `configured` flag that gates AP mode lives in NVS
+(`ESP32-CAM/host.cpp`'s `saveConfig`). On subsequent boots the device
+reads `configured` from NVS, loads `/config.json`, and goes straight
+to the upload loop. The captive portal reopens automatically after
+three consecutive WiFi-join failures (auto-AP-fallback,
+`ESP32-CAM/ESP32-CAM.ino`'s `WIFI_FAIL_AP_FALLBACK_THRESH`) so a
+typo'd password is recoverable in-band. There is no in-firmware
+factory-reset route — reconfiguring (new SSID, changed password, or a
+full wipe) is done by **re-flashing**: the homepage flasher erases the
+whole chip (`homepage/src/components/setup/flashEsp.ts`'s `flashEsp`
+sets `eraseAll: true`), which clears both the NVS `configured` flag and
+`/config.json`, so the next boot re-enters AP-config mode.
 
 See [esp-flashing.md](../07-deployment-view/esp-flashing.md) for the
 full setup walkthrough.

--- a/docs/05-building-block-view/homepage.md
+++ b/docs/05-building-block-view/homepage.md
@@ -118,26 +118,25 @@ Handles ESP32 firmware flashing directly in the browser using
 
 ### SetupGuide (`/setup-guide`)
 
-Three-step configuration guide shown after flashing:
+Configuration guide shown after flashing:
 
 - **Step 1: WiFi Configuration** — connect to `ESP32-Access-Point`,
-  open `192.168.4.1`, enter home WiFi credentials
+  open `192.168.4.1`, enter home WiFi credentials. That is all the page
+  asks for — module name, server URLs and camera settings are derived
+  under the hood (see [ADR-018](../09-architecture-decisions/adr-018-captive-portal-wifi-only.md))
 - **Step 2: Module Deployment** — placement guidelines (south-facing,
   weather protection, 1–2 m height, camera alignment)
-- **Step 3: Backend Configuration** — set Initialization Base URL
-  (port `8002`, endpoint `/new_module`) and Upload Base URL
-  (port `8000`, endpoint `/upload`)
 
 **Interactive Troubleshooting** — accordion section with six common issues:
 
-| Issue                           | Solution                                                                                                                                         |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Access point does not appear    | Power cycle the module and retry                                                                                                                 |
-| `192.168.4.1` does not open     | Ensure connected to `ESP32-Access-Point`, navigate manually                                                                                      |
-| ESP32 not detected in installer | Use a data USB cable, use Chrome or Edge                                                                                                         |
-| Module not on dashboard         | Check port `8002` and `/new_module` endpoint                                                                                                     |
-| No image uploads                | Check port `8000` and `/upload` endpoint                                                                                                         |
-| Need to reconfigure             | Open `http://192.168.4.1` → expand "Factory reset (advanced)" → confirm → submit. The module auto-reopens this portal after 3 failed WiFi joins. |
+| Issue                           | Solution                                                                                                                                                                                                     |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Access point does not appear    | Power cycle the module and retry                                                                                                                                                                             |
+| `192.168.4.1` does not open     | Ensure connected to `ESP32-Access-Point`, navigate manually                                                                                                                                                  |
+| ESP32 not detected in installer | Use a data USB cable, use Chrome or Edge                                                                                                                                                                     |
+| Module not on dashboard         | Check port `8002` and `/new_module` endpoint                                                                                                                                                                 |
+| No image uploads                | Check port `8000` and `/upload` endpoint                                                                                                                                                                     |
+| Need to reconfigure             | Re-flash via the wizard (Step 2) — flashing erases the saved config, so the module reopens its Wi-Fi setup page at `http://192.168.4.1`. The module also auto-reopens this portal after 3 failed WiFi joins. |
 
 <br>
 

--- a/docs/06-runtime-view/image-upload-flow.md
+++ b/docs/06-runtime-view/image-upload-flow.md
@@ -79,6 +79,20 @@ sequenceDiagram
    reason, last HTTP codes, the last ~2 KB of the on-device circular
    log buffer.
 
+   > **Onboarding precondition.** Before any of this runs, the module
+   > must be onboarded once. The captive portal at `http://192.168.4.1`
+   > (setup/AP mode) now asks the operator for **Wi-Fi SSID and password
+   > only** — everything else is assigned under the hood: the module
+   > name is derived from the MAC (`ESP32-CAM/esp_init.cpp`'s
+   > `generateModuleName`), the `INIT_URL` / `UPLOAD_URL` come from the
+   > build-time defaults applied in `ESP32-CAM/esp_init.cpp`'s
+   > `loadConfig`, and camera settings come from
+   > `ESP32-CAM/lib/firmware_defaults/firmware_defaults.h`. Reconfigure
+   > is by re-flash (which erases the saved config). See
+   > [ADR-018](../09-architecture-decisions/adr-018-captive-portal-wifi-only.md)
+   > and the
+   > [onboarding guide](../07-deployment-view/esp-flashing.md).
+
 1. **Upload.** Device sends multipart `POST /upload` to
    `image-service` with form fields `image` (the JPEG), `mac` (the
    module identifier), `battery` (0–100), and optional `logs`

--- a/docs/07-deployment-view/esp-flashing.md
+++ b/docs/07-deployment-view/esp-flashing.md
@@ -21,7 +21,7 @@ Check all four services are healthy (substitute your machine's LAN IP):
 | `http://<LAN-IP>:8000/health`     | `ok`              |
 | `http://<LAN-IP>:8002/health`     | `ok`              |
 
-> **Find your LAN IP:** `ipconfig` on Windows (look for the WLAN or Ethernet adapter), `ip addr` on Linux/Mac. Use this IP — not `localhost` — when configuring the module, because the ESP32 is a separate device on the network.
+> **Find your LAN IP:** `ipconfig` on Windows (look for the WLAN or Ethernet adapter), `ip addr` on Linux/Mac. For a dev module you write this IP — not `localhost` — into `DEV_SERVER_HOST` before building (see "Point a dev module at a local stack"), because the ESP32 is a separate device on the network and `localhost` would resolve to the module itself.
 
 > **Windows Firewall:** ports 8000 and 8002 must accept inbound TCP connections from LAN devices. If modules register on the network but never appear on the dashboard, run this once in an **admin** PowerShell:
 >
@@ -105,6 +105,54 @@ The maintainer issues the key from the project's Google Cloud
 Console (restricted to the Geolocation API). Ask in the issue
 tracker if you need access for a personal fork.
 
+### Point a dev module at a local stack (`DEV_SERVER_HOST`)
+
+> **Skip this for production builds.** Without it, the firmware bakes
+> in the production server URLs (`https://highfive.schutera.com/new_module`
+> for registration and `https://highfive.schutera.com/upload` for image
+> upload) — the `#ifndef` defaults in
+> [`ESP32-CAM/lib/firmware_defaults/firmware_defaults.h`](../../ESP32-CAM/lib/firmware_defaults/firmware_defaults.h).
+> The captive portal no longer has URL fields (see "Configuring a
+> module" below), so a dev module that should talk to your LAN stack
+> must be told at **build time**.
+
+The server URLs are build-time injected, exactly like the Geolocation
+key above. Write the LAN host or IP of the machine running
+`docker compose` to the gitignored `ESP32-CAM/DEV_SERVER_HOST` file —
+host only, no scheme, no port, no path:
+
+```powershell
+# Windows / PowerShell — from repo root
+"192.168.1.50" | Out-File -NoNewline -Encoding ascii ESP32-CAM\DEV_SERVER_HOST
+```
+
+```bash
+# Linux / macOS — from repo root
+printf '%s' "192.168.1.50" > ESP32-CAM/DEV_SERVER_HOST
+```
+
+Or set the env var in the shell where you run `pio` / `build.sh`:
+
+```bash
+export DEV_SERVER_HOST="192.168.1.50"
+```
+
+The build (`ESP32-CAM/build.sh` and `ESP32-CAM/extra_scripts.py`) then
+composes and injects
+`-DHF_INIT_URL_DEFAULT="http://<host>:8002/new_module"` and
+`-DHF_UPLOAD_URL_DEFAULT="http://<host>:8000/upload"` — port `8002` is
+the duckdb-service host port, `8000` is the image-service host port (see
+the service map in the root `CLAUDE.md`). When the file/env is absent
+the firmware falls back to the production `#ifndef` defaults in
+`firmware_defaults.h`. The under-the-hood URL fallback (used when the
+saved `/config.json` has no `INIT_URL` / `UPLOAD_URL` — i.e. on every
+fresh setup) is applied by `ESP32-CAM/esp_init.cpp`'s `loadConfig`.
+
+This is plain HTTP on purpose: dev-box services do not terminate TLS,
+so the LAN URLs stay `http://` while production stays `https://`. The
+rationale for moving URLs off the form and into the build is
+[ADR-018](../09-architecture-decisions/adr-018-captive-portal-wifi-only.md).
+
 ### Flash
 
 ```bash
@@ -137,34 +185,31 @@ Navigate to **http://192.168.4.1**
 
 ### 3. Fill in the configuration form
 
-| Field                   | LAN dev value                                                         | Production value                       |
-| ----------------------- | --------------------------------------------------------------------- | -------------------------------------- |
-| Module Name             | Any label, e.g. `hive-01`                                             | Any label, e.g. `hive-01`              |
-| Wi-Fi SSID              | Your 2.4 GHz network name (case-sensitive — copy-paste, don't retype) | Same                                   |
-| Wi-Fi Password          | Your network password                                                 | Same                                   |
-| Initialization Base URL | `http://<LAN-IP>`                                                     | `https://highfive.schutera.com`        |
-| Initialization Port     | `8002`                                                                | (leave empty — implicit 443 for HTTPS) |
-| Initialization Endpoint | `new_module`                                                          | `new_module`                           |
-| Upload Base URL         | `http://<LAN-IP>`                                                     | `https://highfive.schutera.com`        |
-| Upload Port             | `8000`                                                                | (leave empty)                          |
-| Upload Endpoint         | `upload`                                                              | `upload`                               |
+The captive portal asks for **Wi-Fi credentials only** — SSID and
+password. Everything else (module name, server URLs, camera settings)
+is assigned under the hood, so there is nothing else to type
+([ADR-018](../09-architecture-decisions/adr-018-captive-portal-wifi-only.md)).
 
-The captive-portal form splits each URL into three inputs since #79
-([ADR-010](../09-architecture-decisions/adr-010-esp-firmware-tls-trust-model.md)):
-**Base URL** (scheme + host, no port, no trailing slash), **Port**
-(numeric, empty means the scheme default — 80 for http, 443 for https),
-and **Endpoint** (path with no leading slash). The port-as-separate-field
-shape exists so a production module on `https://highfive.schutera.com`
-and a LAN-dev module on `http://10.0.0.5:8002` use the same form
-without the operator having to retype the protocol-and-colon-and-port
-substring.
+| Field          | Value                                                                 |
+| -------------- | --------------------------------------------------------------------- |
+| Wi-Fi SSID     | Your 2.4 GHz network name (case-sensitive — copy-paste, don't retype) |
+| Wi-Fi Password | Your network password                                                 |
 
-> **Modules onboarded before firmware version `mason`** will auto-migrate
-> their saved URL from `http://highfive.schutera.com/...` to
-> `https://highfive.schutera.com/...` on the first boot after the OTA.
-> The migration is idempotent and re-saves SPIFFS once. LAN-dev URLs
-> (`http://10.0.0.5:8002/...`) are not touched — they keep using plain
-> HTTP because there is no TLS endpoint on the dev box.
+Under the hood, after you save:
+
+- **Module name** is auto-derived from the MAC
+  (`ESP32-CAM/esp_init.cpp`'s `generateModuleName` →
+  `hf::moduleNameFromMac`) — no field, no typos, no same-batch
+  collisions.
+- **Server URLs** are the compiled-in defaults: production
+  (`https://highfive.schutera.com/...`) unless this firmware was built
+  with `DEV_SERVER_HOST` set, in which case the LAN
+  `http://<host>:8002/new_module` and `http://<host>:8000/upload` are
+  used (see "Point a dev module at a local stack" above). To change the
+  server a module talks to, re-build with the right `DEV_SERVER_HOST`
+  and re-flash — there is no URL field on the form.
+- **Camera settings** come from the production fallbacks in
+  `ESP32-CAM/lib/firmware_defaults/firmware_defaults.h`.
 
 > **2.4 GHz only.** The ESP32 does not support 5 GHz. If your router shows a single SSID for both bands (band steering), the ESP32 should be assigned to 2.4 GHz automatically — but if it fails to connect, check your router's band-steering settings.
 
@@ -228,14 +273,39 @@ Then open `esp_log.txt` to read the boot log.
 
 ---
 
-## Reconfiguration (factory reset)
+## Reconfiguration (re-flash)
 
-To clear the saved configuration and re-enter setup mode:
+**Reconfigure by re-flashing.** There is no factory-reset button. The
+web-installer flash performs a full chip erase (`eraseAll: true` in
+[`homepage/src/components/setup/flashEsp.ts`](../../homepage/src/components/setup/flashEsp.ts)'s
+`flashEsp`), which wipes the NVS `configured` flag and the SPIFFS
+`/config.json`. So after **any** (re)flash — web installer or
+`pio run -t upload` — the module boots straight into its Wi-Fi setup
+page (`ESP32-Access-Point`); re-enter Wi-Fi credentials there. To point
+a module at a different server, set `DEV_SERVER_HOST` (or build the
+production default), re-build, and re-flash — the URLs are baked in, not
+on the form.
 
-- **From AP mode** (`ESP32-Access-Point` visible): connect to it, open <http://192.168.4.1>, expand **Factory reset (advanced)**, tick the confirmation checkbox, and click **Factory reset**. The module reboots and reopens the AP.
-- **From STA mode** (joined WiFi): cause three consecutive failed joins to trigger the auto-AP-fallback, then follow the AP-mode steps. The least disruptive way: reconnect to `ESP32-Access-Point`, open `http://192.168.4.1`, and save intentionally wrong WiFi credentials — the board will fail three times (~90 s total) and reopen the AP automatically. Or, with a serial cable: `pio run -t erase && pio run -t upload`.
+> **Already in AP mode and just want to re-enter Wi-Fi?** You don't have
+> to re-flash for that — connect to `ESP32-Access-Point`, open
+> <http://192.168.4.1>, and save the correct credentials. Re-flash is
+> the path when you need to **clear** a saved config (wrong Wi-Fi that
+> the board keeps retrying, or a server-URL change).
 
-> The legacy "hold IO0 for 5 seconds" procedure was removed in #40 — GPIO0 is a strap pin, the procedure was unreachable on AI Thinker ESP32-CAM-MB boards. See chapter 11 "Lessons learned" for the post-mortem.
+The "moved to a new network" case needs no re-flash: the module
+auto-reopens its setup access point after `WIFI_FAIL_AP_FALLBACK_THRESH`
+consecutive failed Wi-Fi joins
+(`ESP32-CAM/ESP32-CAM.ino`). The least disruptive way to force that from
+STA mode without a serial cable: reconnect to `ESP32-Access-Point`, open
+`http://192.168.4.1`, and save intentionally wrong Wi-Fi credentials —
+the board fails the threshold number of joins (~90 s total) and reopens
+the AP automatically.
+
+> The captive-portal **Factory reset** route was removed in
+> [ADR-018](../09-architecture-decisions/adr-018-captive-portal-wifi-only.md):
+> re-flash now erases config as a side effect, so the form button was
+> dead weight. The earlier "hold IO0 for 5 seconds" procedure was already removed in #40 (unreachable on the AI Thinker ESP32-CAM-MB — GPIO0 is a strap pin).
+> See chapter 11 "Lessons learned" for both post-mortems.
 
 ---
 
@@ -368,9 +438,10 @@ the `min_spiffs` partition tables put SPIFFS at different offsets, so
 the firmware's `SPIFFS.begin(true)` auto-formats on the mismatch.
 Result: `/config.json` is wiped, the module boots into AP mode after
 the migration flash, and the operator has to re-onboard via the
-captive portal (Wi-Fi SSID/password, server URLs). Plan for this on
-deployed modules — schedule the migration during an onboarding visit
-rather than from a remote office.
+captive portal (Wi-Fi SSID/password only — server URLs are baked in at
+build time, see ADR-018). Plan for this on deployed modules — schedule
+the migration during an onboarding visit rather than from a remote
+office.
 
 After that one-time USB flash, every subsequent update can be OTA.
 Symptom of trying to OTA-push to an un-migrated module: the upload

--- a/docs/08-crosscutting-concepts/README.md
+++ b/docs/08-crosscutting-concepts/README.md
@@ -3,9 +3,9 @@
 Concerns that span multiple services. Don't fit neatly into one
 building block, so they live here.
 
-| Topic | Document |
-|-------|----------|
-| **Authentication & authorisation** — API key, admin gate, dev fallback, third-party API keys (Geolocation) | [auth.md](auth.md) |
-| **API contracts** — `@highfive/contracts` workspace, field-name drift, mitigations | [api-contracts.md](api-contracts.md) |
-| **ESP32-CAM hardware notes** — AP credentials, browser, Wi-Fi band, firewall, factory reset | [hardware-notes.md](hardware-notes.md) |
-| **Measurement retention** — when to revisit the "keep forever" default for `measurements` rows | [measurement-retention.md](measurement-retention.md) |
+| Topic                                                                                                      | Document                                             |
+| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| **Authentication & authorisation** — API key, admin gate, dev fallback, third-party API keys (Geolocation) | [auth.md](auth.md)                                   |
+| **API contracts** — `@highfive/contracts` workspace, field-name drift, mitigations                         | [api-contracts.md](api-contracts.md)                 |
+| **ESP32-CAM hardware notes** — AP credentials, browser, Wi-Fi band, firewall, reconfigure/reset            | [hardware-notes.md](hardware-notes.md)               |
+| **Measurement retention** — when to revisit the "keep forever" default for `measurements` rows             | [measurement-retention.md](measurement-retention.md) |

--- a/docs/08-crosscutting-concepts/auth.md
+++ b/docs/08-crosscutting-concepts/auth.md
@@ -231,7 +231,8 @@ keeps onboarding to one secret while preserving the gating semantics.
 - `GET /api/health` — public liveness check.
 - `image-service /upload` — accepts uploads from any client that
   knows the URL. Authentication for ESP modules is "you must be on
-  the LAN" (the Init/Upload base URL is the host's LAN IP). Not
+  the LAN" (the module's upload URL is the host's LAN IP in a dev
+  build, or the production origin otherwise). Not
   defence-in-depth; a compromised LAN device can spoof uploads.
   Acceptable for the current threat model (single-tenant, hobbyist
   deployment); revisit if multi-tenancy is added.

--- a/docs/08-crosscutting-concepts/hardware-notes.md
+++ b/docs/08-crosscutting-concepts/hardware-notes.md
@@ -35,10 +35,15 @@ message — the form just looks like nothing happened.
 
 ## Server URLs
 
-The Init/Upload base URLs in the config form must use the host
-machine's **LAN IP** (e.g. `192.168.178.25`), **not** `localhost`.
-The ESP32 is a separate device on the network — `localhost` resolves
-to the ESP32 itself.
+Operators no longer enter server URLs — the config form is Wi-Fi-only and
+production modules reach `https://highfive.schutera.com` baked in at build
+time. **Developers** targeting a local stack set the host machine's **LAN
+IP** (e.g. `192.168.178.25`), **not** `localhost`, in the gitignored
+`ESP32-CAM/DEV_SERVER_HOST` build file (see
+[esp-flashing.md](../07-deployment-view/esp-flashing.md) and
+[ADR-018](../09-architecture-decisions/adr-018-captive-portal-wifi-only.md)).
+`localhost` would resolve to the ESP32 itself — it is a separate device on
+the network.
 
 The ESP32 and the server must be on the **same LAN**. A common
 mistake is configuring the module to join a phone hotspot while the
@@ -55,13 +60,19 @@ New-NetFirewallRule -DisplayName "HiveHive image-service (8000)" -Direction Inbo
 New-NetFirewallRule -DisplayName "HiveHive duckdb-service (8002)" -Direction Inbound -Protocol TCP -LocalPort 8002 -Action Allow -Profile Any
 ```
 
-## Factory reset
+## Reconfigure or reset a module
 
-Use the captive portal at <http://192.168.4.1> ("Factory reset
-(advanced)" → confirm → submit) when the module is in AP mode. From
-STA mode, either cause three consecutive failed WiFi joins (the
-firmware auto-falls back to AP after that) or use `pio run -t erase`
-over a serial cable.
+There is no in-firmware factory-reset control — the captive portal is
+Wi-Fi-only. To reconfigure (new SSID, changed password, or a full
+wipe), **re-flash** the module: flashing does a full chip erase, which
+clears the saved config (the NVS `configured` flag and SPIFFS
+`/config.json`), so the module reopens its Wi-Fi setup page at
+<http://192.168.4.1> on the next boot. Re-flash via the homepage setup
+wizard (Step 2) or the standalone web installer.
+
+If you only need to move the module to a different network you can skip
+the re-flash: cause three consecutive failed WiFi joins and the
+firmware auto-falls back to AP mode on its own.
 
 > The IO0-hold procedure listed in older revisions was unreachable on
 > AI Thinker ESP32-CAM-MB — GPIO0 is a strap pin, holding it LOW at

--- a/docs/09-architecture-decisions/README.md
+++ b/docs/09-architecture-decisions/README.md
@@ -26,6 +26,7 @@ and link backwards.
 | [015](adr-015-weather-correlation.md)                       | Activity-vs-weather chart — Open-Meteo browser-direct + Recharts                | Accepted |
 | [016](adr-016-per-module-measurements-store.md)             | Per-module time-series store is one wide `measurements` table                   | Accepted |
 | [017](adr-017-external-weather-source.md)                   | Server-side weather worker fetches Open-Meteo into the measurements store       | Accepted |
+| [018](adr-018-captive-portal-wifi-only.md)                  | Captive portal is Wi-Fi-only; identity / URLs / camera defaulted in firmware    | Accepted |
 
 ## When to create an ADR
 

--- a/docs/09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md
+++ b/docs/09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md
@@ -197,9 +197,11 @@ watchdog feed.
      the counter entirely and the slot reboots forever with no
      recovery. Use `abort()` or `esp_system_abort()` instead — the
      panic handler produces `reset_reason=ESP_RST_PANIC`, which the
-     gate counts. The six existing `ESP.restart()` sites in the
+     gate counts. The five existing `ESP.restart()` sites in the
      firmware (per `git grep "ESP\.restart()" ESP32-CAM/`) are all
-     intentional clean reboots, none of which violate this invariant:
+     intentional clean reboots, none of which violate this invariant
+     (a sixth — the captive-portal `/factory_reset` handler — was
+     later removed when reconfigure moved to re-flash; see ADR-018):
      - `ESP32-CAM/esp_init.cpp`'s `setupWifiConnection` — WiFi-join
        timeout, intentional retry.
      - `ESP32-CAM/ESP32-CAM.ino`'s `setup()` AP-fallback branch —
@@ -209,8 +211,6 @@ watchdog feed.
      - `ESP32-CAM/ESP32-CAM.ino`'s `loop()` upload circuit-breaker —
        fires only after setup() already completed (mark-valid done,
        counter at 0); rollback wouldn't help network failures anyway.
-     - `ESP32-CAM/host.cpp`'s captive-portal `/factory_reset` handler
-       — operator action.
      - `ESP32-CAM/ota.cpp`'s `httpOtaCheckAndApply` — boot into the
        just-flashed slot. THIS one IS in setup() but it's a clean
        reboot ON SUCCESS (Update.end() returned ok); the new slot

--- a/docs/09-architecture-decisions/adr-018-captive-portal-wifi-only.md
+++ b/docs/09-architecture-decisions/adr-018-captive-portal-wifi-only.md
@@ -1,0 +1,133 @@
+# ADR-018: Captive portal is Wi-Fi-credentials-only; identity / URLs / camera defaulted in firmware; reconfigure by re-flash
+
+## Status
+
+Accepted
+
+## Context
+
+The captive portal served at `http://192.168.4.1` while a module is in
+setup (AP) mode is the only UI a field operator touches during
+onboarding. Over time it accreted every configurable knob the firmware
+has: module name, the two server URLs (each split into base / port /
+endpoint since #79, [ADR-010](adr-010-esp-firmware-tls-trust-model.md)),
+camera resolution / flip / brightness / saturation, and — added when
+issue #40 moved factory reset off the GPIO0 strap pin — a "Factory
+reset (advanced)" disclosure with a confirm checkbox and a dedicated
+`/factory_reset` route.
+
+Every one of those fields is a decision the operator should not be
+making in the field:
+
+- **Module name** is derivable from the MAC with zero operator input
+  (`hf::moduleNameFromMac`, the #91/#92/#93/#94 collision fix), so a
+  free-text field just invites typos and same-batch collisions.
+- **Server URLs** are constant for production (`highfive.schutera.com`)
+  and constant-per-developer for a LAN stack — neither value belongs in
+  a per-module form the operator retypes on every onboard.
+- **Camera settings** have one correct production value each
+  (`ESP32-CAM/lib/firmware_defaults/firmware_defaults.h`); the form
+  prefilled a _different_ "form fallback" than the production reader
+  used, which surprised operators (the vertical-flip `0`-prefill that
+  shipped flipped-`1` firmware is documented in chapter 11's
+  "Dual-reader asymmetry").
+- **Factory reset on the form** is dead weight now that re-flash erases
+  config (see Decision): two routes (`/factory_reset` plus its
+  confirm-checkbox JS), a session-token contract, and a banner, all to
+  do what a re-flash now does as a side effect.
+
+This is a **restore**, not a new idea. A Wi-Fi-only form existed
+historically (commit `59523d3`, 2026-03-30, "streamline setup flow").
+Complexity crept back in via `ad9ee17`, and the factory-reset
+disclosure arrived in `8c1be9c` (issue #40). The lesson — "advanced
+knobs do not belong on the operator-facing form" — was relearned each
+time. This ADR records the re-simplification so the next person who
+reaches for "just add one field to the captive portal" finds the
+recorded reason not to.
+
+The precedent for build-time-injected configuration already exists:
+the Google Geolocation API key is injected as a `-D` macro at build
+time from a gitignored file or env var, never hardcoded and never on
+the form (issue #18, chapter 11 "Third-party API keys belong in
+build-time macros, not source"). Server URLs fit the same mould.
+
+## Decision
+
+The captive portal asks for **Wi-Fi SSID and password only**. Every
+other value is defaulted under the hood:
+
+- **Module name** — auto-derived from the MAC by
+  `ESP32-CAM/esp_init.cpp`'s `generateModuleName`, which delegates to
+  `hf::moduleNameFromMac`.
+- **Camera settings** — the production fallbacks in
+  `ESP32-CAM/lib/firmware_defaults/firmware_defaults.h`
+  (`hf::defaults::kResolutionProductionFallback` and siblings).
+- **Server URLs** — baked in at build time, mirroring the
+  `GEO_API_KEY` pattern. The production defaults
+  (`https://highfive.schutera.com/new_module` and `/upload`) live as
+  `#ifndef`-guarded `HF_INIT_URL_DEFAULT` / `HF_UPLOAD_URL_DEFAULT`
+  macros in `firmware_defaults.h`. A developer points a module at a
+  local LAN stack by writing the gitignored file
+  `ESP32-CAM/DEV_SERVER_HOST` (host/IP only, e.g. `192.168.1.50`) or
+  exporting the `DEV_SERVER_HOST` env var; `ESP32-CAM/build.sh` and
+  `ESP32-CAM/extra_scripts.py` then compose and inject
+  `-DHF_INIT_URL_DEFAULT="http://<host>:8002/new_module"` and
+  `-DHF_UPLOAD_URL_DEFAULT="http://<host>:8000/upload"` (8002 =
+  duckdb-service host port, 8000 = image-service host port). When the
+  saved `/config.json` carries no `INIT_URL` / `UPLOAD_URL`,
+  `ESP32-CAM/esp_init.cpp`'s `loadConfig` applies these compiled-in
+  defaults.
+
+**Reconfigure is done by re-flashing.** The web-installer flash now
+performs a full chip erase (`eraseAll: true` in
+`homepage/src/components/setup/flashEsp.ts`'s `flashEsp`), which wipes
+the NVS `configured` flag and the SPIFFS `/config.json`. After any
+(re)flash the module therefore boots straight into its Wi-Fi setup
+page. The `/factory_reset` route and its "Factory reset (advanced)"
+disclosure are removed from `ESP32-CAM/host.cpp`'s `sendConfigForm` and
+`runAccessPoint`. The "moved to a new network" case is still covered
+without a re-flash: the module auto-reopens its setup access point
+after `WIFI_FAIL_AP_FALLBACK_THRESH` consecutive failed Wi-Fi joins
+(`ESP32-CAM/ESP32-CAM.ino`).
+
+## Consequences
+
+**Enables.** A field operator types exactly two values (SSID +
+password) and nothing else — no URL retyping, no camera knobs, no
+chance of a name-collision typo on a same-batch deploy. The onboarding
+form, its JS validator, and the `/save` handler shrink to one
+contract (Wi-Fi credentials), removing the URL-triple validation and
+the factory-reset confirm-checkbox half of the old `/save`-plus-
+`/factory_reset` surface.
+
+**Costs.** Pointing a module at a non-production stack is now a
+build-time action, not a field action. A developer must write
+`ESP32-CAM/DEV_SERVER_HOST` (or export `DEV_SERVER_HOST`) **before**
+building/flashing; there is no longer a form field to redirect a
+flashed module at a different server. This is the intended trade-off —
+the same one `GEO_API_KEY` already makes — and is documented in
+[`docs/07-deployment-view/esp-flashing.md`](../07-deployment-view/esp-flashing.md).
+The gitignored `DEV_SERVER_HOST` file joins `GEO_API_KEY` in the repo
+root `.gitignore`.
+
+**Forecloses.** There is no in-field way to change a module's server
+URLs or camera settings without a re-flash. For a fleet whose server
+host genuinely changes, that means a re-flash visit (or an OTA of a
+firmware built against the new default) rather than a captive-portal
+edit. Given the production host is stable and a re-flash already erases
+config, this is acceptable.
+
+**Reconfigure semantics.** Re-flash is now the supported reset path:
+there is no factory-reset button anywhere. The legacy "hold IO0 for 5
+seconds" GPIO0-strap procedure was already removed in issue #40
+(chapter 11 "GPIO0 is a strap pin"); this ADR removes the captive-
+portal factory-reset route that replaced it. The
+`scripts/check-stale-reset-prose.sh` gate from #40 still guards against
+"hold this button at boot" prose reappearing.
+
+**Migration.** Existing modules keep their saved `/config.json` URLs
+until they are re-flashed; `loadConfig`'s compiled-in defaults only
+apply when those keys are absent (or after a re-flash erases them). No
+forced re-onboard is triggered by shipping this firmware via OTA — the
+saved URLs continue to work — but the next USB/web-installer flash of
+any module erases its config and reopens the Wi-Fi-only setup page.

--- a/docs/10-quality-requirements/manual-tests-field-reliability.md
+++ b/docs/10-quality-requirements/manual-tests-field-reliability.md
@@ -140,8 +140,8 @@ from a fluke.)
 
 **Steps**:
 
-1. Factory-reset the module to clear any cached config (jumper +
-   reboot per [`esp-flashing.md` "Reconfiguration"](../07-deployment-view/esp-flashing.md#reconfiguration-factory-reset)).
+1. Reset the module to clear any cached config by re-flashing
+   (per [`esp-flashing.md` "Reconfiguration"](../07-deployment-view/esp-flashing.md#reconfiguration-re-flash)).
 2. Re-onboard via the captive portal.
 3. Capture the boot serial:
    ```powershell

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -86,6 +86,48 @@ write the lesson here so the next contributor doesn't repeat it.
 Format: short title + **What happened** + **Why it happened** +
 **How to avoid it next time**.
 
+### ESP config-form complexity creep — re-simplified to the `59523d3` Wi-Fi-only shape
+
+**What happened.** The captive portal that a field operator uses to
+onboard an ESP32-CAM started as a Wi-Fi-credentials-only form (commit
+`59523d3`, 2026-03-30, "streamline setup flow"). Over the following
+months it re-accreted every configurable knob the firmware has: a
+free-text module name, both server URLs (each split into base / port /
+endpoint since #79, [ADR-010](../09-architecture-decisions/adr-010-esp-firmware-tls-trust-model.md)),
+the four camera settings, and — when #40 moved factory reset off the
+GPIO0 strap pin — a "Factory reset (advanced)" disclosure with its own
+`/factory_reset` route. The complexity crept back via `ad9ee17`; the
+factory-reset disclosure landed in `8c1be9c`. We re-simplified back to
+the `59523d3` Wi-Fi-only shape ([ADR-018](../09-architecture-decisions/adr-018-captive-portal-wifi-only.md)):
+module name is derived from the MAC
+(`ESP32-CAM/esp_init.cpp`'s `generateModuleName`), server URLs are
+baked in at build time behind `DEV_SERVER_HOST` (mirroring `GEO_API_KEY`),
+camera settings come from `firmware_defaults.h`, and reconfigure is by
+re-flash (the web-installer flash now does a full chip erase via
+`eraseAll: true` in `homepage/src/components/setup/flashEsp.ts`'s
+`flashEsp`, so a re-flash wipes config and reopens the Wi-Fi-only setup
+page — the `/factory_reset` route is gone).
+
+**Why it happened.** Each individual addition looked locally reasonable
+("operators sometimes want to retarget a module", "let's expose the
+camera flip", "we need an in-field reset now that IO0 is unusable"). No
+single PR was wrong on its own terms, but the cumulative effect was a
+form that asked the operator to make six decisions they should never
+make in the field — three of which (the form-vs-production fallback
+asymmetry on camera settings, name typos, URL retyping) actively caused
+bugs. The form had no recorded "this is deliberately minimal" guard, so
+the default reviewer instinct was "one more field is fine".
+
+**How to avoid it next time.** Keep advanced knobs — server URLs,
+camera settings, module name, factory reset — **off** the operator-
+facing captive portal. Default them in firmware (`firmware_defaults.h`
+production fallbacks, MAC-derived name) or behind a build-time file
+(`DEV_SERVER_HOST`, the same pattern `GEO_API_KEY` uses), and make
+reconfigure a re-flash rather than a form field. ADR-018 is the
+recorded "deliberately minimal" guard: when a PR proposes adding a
+field to the captive portal, it has to argue past ADR-018 first. The
+operator types exactly two values, SSID and password, and nothing else.
+
 ### Admin "failed to load images": stale `IMAGE_SERVICE_URL` after a no-`--update-env` PM2 restart, masking an unbounded image-list query that tripped a 5s timeout
 
 **What happened.** The admin page (`/admin`) showed "Failed to load

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -287,20 +287,16 @@ Three quick pulses (~450 ms total) means the most recent WiFi join timed out. Th
 
 Note: the LED stays silent in AP mode — the on-board LED is the camera flash, so steady-state signalling would be obnoxious. Use the phone's WiFi list to confirm the captive portal is back, not the LED.
 
-### Factory reset to re-enter configuration
+### Reconfigure or reset a module
 
-Two paths, depending on whether the module is currently in AP mode or already joined to WiFi:
+To put a configured module back into its WiFi-only setup page — new SSID, changed password, or a full wipe — **re-flash it**. Flashing now does a full chip erase, which clears the saved config (the `configured` flag in NVS and `/config.json` in SPIFFS), so the module boots straight back into AP-config mode.
 
-**From AP mode** (the `ESP32-Access-Point` SSID is visible — either a fresh-flashed board, or one that hit the 3-consecutive-WiFi-join-failure auto-fallback):
+1. Re-flash via the homepage setup wizard **Step 2** (or the standalone web installer). The flash erases the saved config as a side effect.
+2. After the flash completes, the module reopens the `ESP32-Access-Point` SSID and serves its WiFi setup page at <http://192.168.4.1>. Reconnect to it and enter the new credentials.
 
-1. Connect to `ESP32-Access-Point` and visit <http://192.168.4.1>.
-2. Scroll to the **Factory reset (advanced)** section at the bottom of the form.
-3. Tick the confirmation checkbox and click **Factory reset**. The module reboots and reopens the AP for fresh configuration.
+There is no separate in-band reset button anymore — flashing _is_ the reset. The captive portal exposes Wi-Fi configuration only.
 
-**From STA mode** (the module joined WiFi but you want to move it to a different network) — there is no in-band reset. Either:
-
-- Cause three consecutive WiFi-join failures so the module's auto-fallback re-opens `ESP32-Access-Point`, then use the AP-mode steps above. The least disruptive way: reconnect to `ESP32-Access-Point`, open `http://192.168.4.1`, and save intentionally wrong WiFi credentials — the board will fail three times (~90 s total) and reopen the AP automatically.
-- Or, with a serial cable: `cd ESP32-CAM && pio run -t erase && pio run -t upload`.
+**If you only want to move the module to a different network**, you don't even need to re-flash: cause three consecutive WiFi-join failures and the module's auto-fallback re-opens `ESP32-Access-Point` on its own. The least disruptive way: reconnect to `ESP32-Access-Point`, open <http://192.168.4.1>, and save intentionally wrong WiFi credentials — the board fails three times (~90 s total) and reopens the AP automatically.
 
 > The "hold IO0 for 5 seconds" procedure documented in older guides did not work — GPIO0 is a strap pin and holding it LOW at boot puts the ESP32 into UART download mode instead of running the firmware. Removed in #40; see chapter 11 "Lessons learned" for the post-mortem.
 
@@ -312,7 +308,7 @@ Two paths, depending on whether the module is currently in AP mode or already jo
 
 The ESP32 must be able to reach the server's IP. A common mistake is configuring the module to join a phone hotspot while the server runs on the home router — those are separate networks.
 
-**Rule:** the Initialization Base URL and Upload Base URL you enter in the config form must use the server's **LAN IP** on the **same network** the ESP32 will join.
+**Rule:** the ESP32 must join the **same network** the server is on. Production modules reach `https://highfive.schutera.com` (baked in at build time, no operator action). For a **local dev** stack, the server URL is set from the host's **LAN IP** via the gitignored `ESP32-CAM/DEV_SERVER_HOST` build file — not `localhost`, which would resolve to the ESP32 itself.
 
 Find your LAN IP: `ipconfig` (Windows, look at WLAN/Ethernet adapter), `ip addr` (Linux/Mac).
 

--- a/homepage/.env.example
+++ b/homepage/.env.example
@@ -2,20 +2,18 @@
 # Get yours at: https://dashboard.stripe.com/payment-links
 VITE_STRIPE_LINK=https://buy.stripe.com/your-link-here
 
-# Server URLs for Setup Wizard & ESP Module Configuration
+# Backend URL for the Setup Wizard / dashboard
 # ---
-# For LOCAL development (leave empty — defaults apply):
-#   VITE_API_URL        → http://localhost:3002/api  (backend for dashboard/polling)
-#   VITE_INIT_BASE_URL  → http://localhost:8002       (duckdb-service, sent to ESP)
-#   VITE_UPLOAD_BASE_URL→ http://localhost:8000       (image-service, sent to ESP)
+# For LOCAL development (leave empty — default applies):
+#   VITE_API_URL → http://localhost:3002/api  (backend for dashboard/polling)
+#
+# The ESP module's server URLs are no longer set here — they are baked into
+# firmware at build time (production default https://highfive.schutera.com),
+# so the homepage doesn't supply them to the module any more.
 #
 # For PRODUCTION deployment (VITE_API_URL is REQUIRED — a prod `vite build`
 # with it unset compiles fine but THROWS at first page load via
 # src/services/api-key-validator.ts, rendering a blank page on every route.
 # Set it here, in .env.production, or inline: `VITE_API_URL=… npm run build`):
 #   VITE_API_URL=https://api.highfive-bees.com/api
-#   VITE_INIT_BASE_URL=https://api.highfive-bees.com:8002
-#   VITE_UPLOAD_BASE_URL=https://api.highfive-bees.com:8000
 VITE_API_URL=
-VITE_INIT_BASE_URL=
-VITE_UPLOAD_BASE_URL=

--- a/homepage/src/__tests__/flashEsp.test.ts
+++ b/homepage/src/__tests__/flashEsp.test.ts
@@ -1,5 +1,25 @@
-import { describe, it, expect } from 'vitest';
-import { assertFirmwareResponse, ESP_IMAGE_MAGIC } from '../components/setup/flashEsp';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Hoisted spies for the esptool-js mock. flashEsp() constructs an ESPLoader
+// and a Transport; we record the writeFlash options so the erase-policy test
+// can assert eraseAll without touching real Web Serial (absent in jsdom).
+const writeFlash = vi.fn().mockResolvedValue(undefined);
+const loaderMain = vi.fn().mockResolvedValue(undefined);
+const flashId = vi.fn().mockResolvedValue(undefined);
+const after = vi.fn().mockResolvedValue(undefined);
+const transportDisconnect = vi.fn().mockResolvedValue(undefined);
+vi.mock('esptool-js', () => ({
+  ESPLoader: vi.fn().mockImplementation(() => ({
+    main: loaderMain,
+    flashId,
+    writeFlash,
+    after,
+  })),
+  Transport: vi.fn().mockImplementation(() => ({ disconnect: transportDisconnect })),
+}));
+
+import { assertFirmwareResponse, ESP_IMAGE_MAGIC, flashEsp } from '../components/setup/flashEsp';
+import type { Manifest } from '../components/setup/flashEsp';
 
 // Issue #43: when /firmware.bin is missing, Vite's SPA fallback returns
 // index.html with HTTP 200 + content-type: text/html. flashEsp used to read
@@ -119,5 +139,67 @@ describe('assertFirmwareResponse', () => {
     await expect(assertFirmwareResponse(resp, '/firmware.bin')).rejects.toThrow(
       /byte 0x1000 is 0xAA.*expected 0xE9/,
     );
+  });
+});
+
+// The wizard's only reconfigure mechanism is now re-flashing: a full-chip
+// erase before writing wipes NVS (the `configured` flag) + SPIFFS
+// (`/config.json`) so a re-flashed module always reboots into its Wi-Fi
+// setup portal. eraseAll: false would leave the saved Wi-Fi config in place,
+// silently defeating "reconfigure by re-flash". This test pins the policy.
+describe('flashEsp writeFlash erase policy', () => {
+  beforeEach(() => {
+    writeFlash.mockClear();
+    loaderMain.mockClear();
+    flashId.mockClear();
+    after.mockClear();
+    transportDisconnect.mockClear();
+
+    // Web Serial port picker: return a stub port with a close() method.
+    const port = { close: vi.fn().mockResolvedValue(undefined) };
+    (navigator as unknown as { serial: { requestPort: () => Promise<unknown> } }).serial = {
+      requestPort: vi.fn().mockResolvedValue(port),
+    };
+
+    // Firmware fetch: a valid merge_bin-shaped blob (0xFF pad, 0xE9 at 0x1000).
+    const bytes = new Uint8Array(0x1001).fill(0xff);
+    bytes[0x1000] = ESP_IMAGE_MAGIC;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(bytes, {
+        status: 200,
+        headers: { 'content-type': 'application/octet-stream' },
+      }),
+    ) as typeof fetch;
+
+    // jsdom 25's FileReader.readAsBinaryString rejects the Blob produced
+    // from a fetched Uint8Array body ("parameter 1 is not of type 'Blob'"),
+    // which flashEsp's blobToBinaryString relies on. Stub it so the flash
+    // path reaches writeFlash; the byte content is irrelevant to this test
+    // (we only assert the erase option), so resolve with an empty string.
+    vi.spyOn(FileReader.prototype, 'readAsBinaryString').mockImplementation(function (
+      this: FileReader,
+    ) {
+      Object.defineProperty(this, 'result', { value: '', configurable: true });
+      this.onload?.(new ProgressEvent('load') as ProgressEvent<FileReader>);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('flashes with eraseAll: true so a re-flash wipes saved Wi-Fi config', async () => {
+    const manifest: Manifest = {
+      name: 'HiveHive',
+      version: 'test',
+      builds: [{ chipFamily: 'ESP32', parts: [{ path: '/firmware.bin', offset: 0 }] }],
+    };
+
+    const states: string[] = [];
+    await flashEsp(manifest, (p) => states.push(p.state));
+
+    expect(writeFlash).toHaveBeenCalledTimes(1);
+    expect(writeFlash.mock.calls[0][0]).toMatchObject({ eraseAll: true });
+    expect(states).toContain('finished');
   });
 });

--- a/homepage/src/__tests__/useSetupWizard.test.ts
+++ b/homepage/src/__tests__/useSetupWizard.test.ts
@@ -29,9 +29,8 @@ describe('useSetupWizard.startVerification — mid-poll classification (#44)', (
     healthCheck.mockReset();
     healthCheck.mockResolvedValue({ status: 'ok', timestamp: '' });
     vi.useFakeTimers();
-    // The hook's mount effects also fetch /firmware.json and
-    // /__dev-api/lan-ip — stub those so the test isn't coupled to
-    // their implementations. Stash the original so afterEach can
+    // The hook's mount effect also fetches /firmware.json — stub it so
+    // the test isn't coupled to its implementation. Stash the original so afterEach can
     // restore it and the next test in this file (or next file run
     // in the same worker) doesn't inherit the override.
     originalFetch = globalThis.fetch;
@@ -66,8 +65,8 @@ describe('useSetupWizard.startVerification — mid-poll classification (#44)', (
     getAllModules.mockRejectedValue(new Error('fetch failed'));
 
     const { result } = renderHook(() => useSetupWizard());
-    // Drain the mount-effect promises (loadFirmware, detectLanIp,
-    // snapshotModules) so subsequent assertions see the post-mount state.
+    // Drain the mount-effect promises (loadFirmware, snapshotModules)
+    // so subsequent assertions see the post-mount state.
     await act(async () => {
       await Promise.resolve();
     });

--- a/homepage/src/components/setup/espConfig.ts
+++ b/homepage/src/components/setup/espConfig.ts
@@ -1,4 +1,12 @@
 /**
+ * DEAD PATH — not wired into the live wizard. Onboarding sends the user to the
+ * ESP's own captive portal via `Step4Configure`'s `window.open('http://192.168.4.1')`;
+ * the user types their Wi-Fi credentials there. `sendConfigToEsp` /
+ * `submitConfigViaForm` below (and `useSetupWizard`'s `sendConfig`) are never
+ * invoked by any rendered component. The payload is kept in sync with the
+ * firmware's Wi-Fi-only `/save` contract (session + ssid + password) so it
+ * stays correct if ever re-wired, but it can be deleted outright in a cleanup.
+ *
  * In dev, the Vite proxy at /esp-api forwards to http://192.168.4.1,
  * bypassing CORS entirely. In production (static build), we hit the
  * ESP directly — requires CORS headers in firmware.
@@ -10,10 +18,6 @@ const BYPASS_SESSION = 'hivehive-setup';
 export interface EspConfig {
   ssid: string;
   password: string;
-  initBase: string;
-  initEndpoint: string;
-  uploadBase: string;
-  uploadEndpoint: string;
 }
 
 /**
@@ -52,19 +56,13 @@ export async function sendConfigToEsp(config: EspConfig): Promise<void> {
     console.warn('[espConfig] No session token found in form HTML');
   }
 
+  // The firmware /save handler reads only session/ssid/password. Server URLs
+  // are baked into firmware at build time and module name + camera settings
+  // are derived on-device, so we no longer send init_base/upload_base/res/etc.
   const params = new URLSearchParams({
     session: sessionToken,
     ssid: config.ssid,
     password: config.password,
-    init_base: config.initBase,
-    init_endpoint: config.initEndpoint,
-    upload_base: config.uploadBase,
-    upload_endpoint: config.uploadEndpoint,
-    interval: '300',
-    res: 'vga',
-    vflip: '0',
-    bright: '0',
-    sat: '0',
   });
 
   console.log('[espConfig] POSTing config to', `${ESP_BASE}/save`);
@@ -94,19 +92,11 @@ export async function sendConfigToEsp(config: EspConfig): Promise<void> {
  * Uses a bypass session token accepted by the ESP firmware.
  */
 function submitConfigViaForm(config: EspConfig): void {
+  // Firmware /save reads only session/ssid/password (see the fetch path above).
   const fields: Record<string, string> = {
     session: BYPASS_SESSION,
     ssid: config.ssid,
     password: config.password,
-    init_base: config.initBase,
-    init_endpoint: config.initEndpoint,
-    upload_base: config.uploadBase,
-    upload_endpoint: config.uploadEndpoint,
-    interval: '300',
-    res: 'vga',
-    vflip: '0',
-    bright: '0',
-    sat: '0',
   };
 
   // Open a small popup to receive the response (auto-closed after a few seconds).

--- a/homepage/src/components/setup/flashEsp.ts
+++ b/homepage/src/components/setup/flashEsp.ts
@@ -91,12 +91,20 @@ export async function flashEsp(
     onProgress({ state: 'erasing' });
 
     // --- 4. Flash firmware with progress callback ---
+    // eraseAll erases the entire flash chip before writing. The manifest
+    // (Step2Flash.tsx FIRMWARE_MANIFEST) is a single merged image at offset 0
+    // covering bootloader + partition table + app, so a full-chip erase is
+    // safe — nothing we need to preserve lives outside that image. The erase
+    // also wipes the NVS namespace (the `configured` flag) and the SPIFFS
+    // partition (`/config.json`), so a re-flashed module always boots back
+    // into its Wi-Fi setup portal. This is the "reconfigure by re-flash"
+    // mechanism that replaced the captive-portal factory reset.
     await loader.writeFlash({
       fileArray,
       flashSize: 'keep',
       flashMode: 'keep',
       flashFreq: 'keep',
-      eraseAll: false,
+      eraseAll: true,
       compress: true,
       reportProgress: (_fileIndex: number, written: number, total: number) => {
         const percent = Math.round((written / total) * 100);

--- a/homepage/src/components/setup/useSetupWizard.ts
+++ b/homepage/src/components/setup/useSetupWizard.ts
@@ -28,16 +28,6 @@ export interface WizardState {
   verificationBackendUnreachable: boolean;
 }
 
-const INIT_BASE_URL = import.meta.env.VITE_INIT_BASE_URL || 'http://localhost:8000';
-const UPLOAD_BASE_URL = import.meta.env.VITE_UPLOAD_BASE_URL || 'http://localhost:8000';
-
-export const SERVER_CONFIG = {
-  initBaseUrl: INIT_BASE_URL,
-  initEndpoint: '/new_module',
-  uploadBaseUrl: UPLOAD_BASE_URL,
-  uploadEndpoint: '/upload',
-} as const;
-
 const MAX_POLLS = 24; // 2 minutes at 5s intervals
 const POLL_INTERVAL = 5000;
 // If the trailing run of consecutive poll errors is at least this long when
@@ -45,15 +35,6 @@ const POLL_INTERVAL = 5000;
 // the window), classify the timeout as "backend unreachable" rather than
 // "module didn't show up". See issue #44.
 const POLL_BACKEND_DOWN_TAIL = 5;
-
-/**
- * Replace "localhost" or "127.0.0.1" in a URL with the given LAN IP.
- * This is needed because the ESP module can't reach "localhost" —
- * from its perspective, localhost is the ESP itself.
- */
-function replaceLocalhost(url: string, lanIp: string): string {
-  return url.replace('://localhost', `://${lanIp}`).replace('://127.0.0.1', `://${lanIp}`);
-}
 
 export function useSetupWizard() {
   const [state, setState] = useState<WizardState>({
@@ -75,7 +56,6 @@ export function useSetupWizard() {
     verificationBackendUnreachable: false,
   });
 
-  const lanIpRef = useRef<string | null>(null);
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollCountRef = useRef(0);
   // Trailing-run counter for poll catches. Reset to 0 on any successful
@@ -104,7 +84,6 @@ export function useSetupWizard() {
   // field for "did this module just come alive?".)
   useEffect(() => {
     loadFirmware();
-    detectLanIp();
     snapshotModules();
   }, []);
 
@@ -146,21 +125,6 @@ export function useSetupWizard() {
       // Backend might not be reachable yet (user on ESP AP) — that's fine,
       // startVerification will take a fallback snapshot.
       console.log('[SetupWizard] Could not snapshot modules on mount (backend unreachable)');
-    }
-  };
-
-  const detectLanIp = async () => {
-    try {
-      const resp = await fetch('/__dev-api/lan-ip');
-      if (resp.ok) {
-        const data = await resp.json();
-        if (data.ip && data.ip !== 'localhost') {
-          lanIpRef.current = data.ip;
-          console.log('[SetupWizard] Detected LAN IP:', data.ip);
-        }
-      }
-    } catch {
-      // Not in dev or Vite plugin not available — that's fine
     }
   };
 
@@ -233,23 +197,13 @@ export function useSetupWizard() {
   const sendConfig = useCallback(async () => {
     setState((s) => ({ ...s, configSending: true, configError: null }));
 
-    // Replace localhost with LAN IP if detected
-    let initBase = SERVER_CONFIG.initBaseUrl;
-    let uploadBase = SERVER_CONFIG.uploadBaseUrl;
-    if (lanIpRef.current) {
-      initBase = replaceLocalhost(initBase, lanIpRef.current);
-      uploadBase = replaceLocalhost(uploadBase, lanIpRef.current);
-      console.log('[SetupWizard] Sending ESP URLs with LAN IP:', { initBase, uploadBase });
-    }
-
+    // The firmware /save handler now reads only ssid/password (+ session):
+    // server URLs are baked in at build time and module name + camera
+    // settings are derived on-device. We no longer compute or send them.
     try {
       await sendConfigToEsp({
         ssid: state.wifiSsid,
         password: state.wifiPassword,
-        initBase,
-        initEndpoint: SERVER_CONFIG.initEndpoint,
-        uploadBase,
-        uploadEndpoint: SERVER_CONFIG.uploadEndpoint,
       });
       setState((s) => ({ ...s, configSending: false, configSent: true }));
     } catch (err) {

--- a/homepage/src/i18n/translations.ts
+++ b/homepage/src/i18n/translations.ts
@@ -250,8 +250,8 @@ const translations = {
       photoStep: 'Photo: Step {n}',
       tips: 'Tips',
       factoryReset:
-        "To reconfigure your module: open http://192.168.4.1 (the module reopens this portal automatically after three failed WiFi joins), expand 'Factory reset (advanced)' at the bottom of the form, tick the confirmation checkbox, and submit. With a serial cable: cd ESP32-CAM && pio run -t erase && pio run -t upload.",
-      factoryResetLabel: 'Factory Reset:',
+        'To reconfigure your module (new WiFi network or a changed password), simply re-flash it from the setup wizard (Step 2). Flashing now wipes the saved configuration, so the module reboots straight into its WiFi setup page. The module also reopens its setup access point automatically after three failed WiFi joins.',
+      factoryResetLabel: 'Reconfigure:',
       ctaTitle: 'Module assembled?',
       ctaText: 'Now flash the firmware and connect your module to the server.',
       ctaCta: 'Start Setup Wizard',
@@ -400,7 +400,7 @@ const translations = {
     // ---- Step 4: Configure ----
     step4: {
       title: 'Configure Your Module',
-      text: 'Open the module\u2019s configuration page to enter your WiFi details and server settings.',
+      text: 'Open the module\u2019s configuration page. It asks for only your WiFi name and password \u2014 everything else is set up automatically.',
       openConfigPage: 'Open Configuration Page',
       configDoneBtn: 'I\u2019ve saved the configuration',
       reconnectTitle: 'Configuration Saved!',
@@ -444,9 +444,9 @@ const translations = {
         apTitle: 'Is the access point still visible?',
         apText:
           "If you can still see 'ESP32-Access-Point' in your WiFi list, the module hasn't connected to your home network yet. Reconnect and verify the WiFi settings.",
-        resetTitle: 'Factory Reset',
+        resetTitle: 'Re-flash to reconfigure',
         resetText:
-          "Open http://192.168.4.1 (the module reopens this access point after three failed WiFi joins), expand 'Factory reset (advanced)' at the bottom of the form, tick the confirmation checkbox, and submit. The module reboots into the configuration portal.",
+          'To re-enter your WiFi details, re-flash the module from the setup wizard (Step 2). Flashing now wipes the saved configuration, so the module reboots straight into its WiFi setup page. It also reopens its setup access point automatically after three failed WiFi joins.',
       },
     },
 
@@ -700,8 +700,8 @@ const translations = {
       photoStep: 'Foto: Schritt {n}',
       tips: 'Tipps',
       factoryReset:
-        "Zum Neukonfigurieren deines Moduls: \u00F6ffne http://192.168.4.1 (das Modul \u00F6ffnet diesen Zugangspunkt nach drei fehlgeschlagenen WLAN-Verbindungsversuchen automatisch erneut), klappe 'Factory reset (advanced)' unten im Formular auf, aktiviere die Best\u00E4tigungs-Checkbox und sende ab. Mit einem seriellen Kabel: cd ESP32-CAM && pio run -t erase && pio run -t upload.",
-      factoryResetLabel: 'Werkseinstellungen:',
+        'Zum Neukonfigurieren deines Moduls (neues WLAN oder ge\u00E4ndertes Passwort) flashe es einfach im Setup-Assistenten neu (Schritt 2). Das Flashen l\u00F6scht jetzt die gespeicherte Konfiguration, sodass das Modul direkt in seine WLAN-Einrichtungsseite startet. Das Modul \u00F6ffnet seinen Einrichtungs-Zugangspunkt au\u00DFerdem nach drei fehlgeschlagenen WLAN-Verbindungsversuchen automatisch erneut.',
+      factoryResetLabel: 'Neukonfigurieren:',
       ctaTitle: 'Modul zusammengebaut?',
       ctaText: 'Jetzt die Firmware flashen und dein Modul mit dem Server verbinden.',
       ctaCta: 'Setup-Assistent starten',
@@ -850,7 +850,7 @@ const translations = {
     // ---- Step 4: Configure ----
     step4: {
       title: 'Modul konfigurieren',
-      text: '\u00D6ffne die Konfigurationsseite des Moduls, um deine WLAN-Daten und Servereinstellungen einzugeben.',
+      text: '\u00D6ffne die Konfigurationsseite des Moduls. Sie fragt nur nach deinem WLAN-Namen und Passwort \u2014 alles andere wird automatisch eingerichtet.',
       openConfigPage: 'Konfigurationsseite \u00F6ffnen',
       configDoneBtn: 'Ich habe die Konfiguration gespeichert',
       reconnectTitle: 'Konfiguration gespeichert!',
@@ -895,9 +895,9 @@ const translations = {
         apTitle: 'Ist der Access Point noch sichtbar?',
         apText:
           "Wenn du 'ESP32-Access-Point' noch in deiner WLAN-Liste siehst, hat sich das Modul noch nicht mit deinem Heimnetzwerk verbunden. Verbinde dich erneut und \u00FCberpr\u00FCfe die WLAN-Einstellungen.",
-        resetTitle: 'Werkseinstellungen',
+        resetTitle: 'Zum Neukonfigurieren neu flashen',
         resetText:
-          "\u00D6ffne http://192.168.4.1 (das Modul \u00F6ffnet diesen Zugangspunkt nach drei fehlgeschlagenen WLAN-Verbindungsversuchen erneut), klappe 'Factory reset (advanced)' unten im Formular auf, aktiviere die Best\u00E4tigungs-Checkbox und sende ab. Das Modul startet neu in das Konfigurationsportal.",
+          'Um deine WLAN-Daten erneut einzugeben, flashe das Modul im Setup-Assistenten neu (Schritt 2). Das Flashen l\u00F6scht jetzt die gespeicherte Konfiguration, sodass das Modul direkt in seine WLAN-Einrichtungsseite startet. Es \u00F6ffnet seinen Einrichtungs-Zugangspunkt au\u00DFerdem nach drei fehlgeschlagenen WLAN-Verbindungsversuchen automatisch erneut.',
       },
     },
 

--- a/scripts/check-stale-reset-prose.sh
+++ b/scripts/check-stale-reset-prose.sh
@@ -63,7 +63,8 @@ if [[ -n "$hits" ]]; then
   echo ""
   echo "  The 'hold IO0 / left button for N seconds' procedure is unreachable on"
   echo "  AI Thinker ESP32-CAM-MB (GPIO0 is a strap pin). Replace with the"
-  echo "  captive-portal procedure: POST /factory_reset on http://192.168.4.1."
+  echo "  current reconfigure procedure: re-flash the module (the web installer"
+  echo "  erases the saved config and reopens the Wi-Fi setup page)."
   echo "  See docs/11-risks-and-technical-debt/README.md \"GPIO0 is a strap pin\"."
   echo "  The post-mortem file itself is allowlisted."
   exit 1


### PR DESCRIPTION
## What changed

The ESP32-CAM setup page at `http://192.168.4.1` now shows **WiFi SSID + WiFi Password + Save** and nothing else. Module name, server URLs and camera settings are derived under the hood; the factory-reset control is removed.

**Firmware**
- `host.cpp`: `sendConfigForm` renders only SSID + password; `/save` reads only `ssid`/`password`/`session`; the `/factory_reset` route + form are removed; `saveConfig` persists only `NETWORK.SSID`/`PASSWORD`.
- `esp_init.cpp`'s `loadConfig`: when the saved config has no `INIT_URL`/`UPLOAD_URL`, falls back to compile-time defaults (RAM-only, before the empty-check). Module name (MAC-derived) and camera (production fallbacks) were already defaulted.
- `firmware_defaults.h`: `HF_INIT_URL_DEFAULT`/`HF_UPLOAD_URL_DEFAULT` (`#ifndef`) default to `https://highfive.schutera.com/{new_module,upload}`.

**Dev URL override (mirrors the `GEO_API_KEY` pattern)**
- Write a gitignored `ESP32-CAM/DEV_SERVER_HOST` file (a LAN host/IP) or export `DEV_SERVER_HOST`; `build.sh` + `extra_scripts.py` compose and inject `-DHF_INIT_URL_DEFAULT="http://<host>:8002/new_module"` / `-DHF_UPLOAD_URL_DEFAULT="http://<host>:8000/upload"`. Absent → production URLs.

**Reconfigure = re-flash**
- `flashEsp.ts` now passes `eraseAll: true`, so a (re)flash full-erases the chip → wipes NVS (`configured` flag) + SPIFFS (`/config.json`) → the module boots back into its Wi-Fi setup page. The 3-failed-join auto-AP-fallback remains as a safety net.

**Homepage**: the wizard's (dead) auto-config payload was trimmed to `ssid`/`password`/`session` and the dead `SERVER_CONFIG`/LAN-IP/URL plumbing removed; Step 4 + reconfigure copy updated (EN + DE).

**Docs**: ADR-018; `esp-flashing.md` (`DEV_SERVER_HOST` + re-flash); building-block, hardware-notes, troubleshooting updated to the Wi-Fi-only / re-flash model; chapter-11 lesson on config-form complexity creep.

## Why

Non-technical beekeepers faced a four-section setup form (module name, Wi-Fi, init/upload URL+port+endpoint, camera settings, factory-reset disclosure). Intent: **users enter only their Wi-Fi credentials — nothing more**; everything else under the hood, and no user-facing factory reset. This is a **restore** — `59523d3` was once exactly this before complexity crept back via `ad9ee17` / `8c1be9c`. See ADR-018.

## How tested

- [x] ESP32-CAM native (`pio test -e native`) — **211/211**
- [ ] End-to-end (`pytest tests/e2e`) — n/a (no request/flow shape change crossing those services)
- [ ] Backend unit — n/a (no backend changes)
- [ ] image-service unit — n/a
- [ ] duckdb-service unit — n/a
- [x] Homepage unit (React 19 + Vite) — **136 pass**, `npm run build` clean
- [ ] Manual / hardware-in-the-loop verification — **needs a board** (plan below)

Also: `arduino-cli compile` clean on both paths; `strings` confirms the prod binary bakes `highfive.schutera.com` and a `DEV_SERVER_HOST=192.168.1.50` binary bakes `192.168.1.50:8002/8000` (and not the prod URL). `make check-citations` + `check-stale-reset-prose` + all pre-push gates green. Two `senior-reviewer` rounds; all P0/P1 addressed.

### Remaining manual check (hardware; PowerShell)
```powershell
docker compose up --build -d
Start-Process chrome -ArgumentList 'http://localhost:5173/setup'
# 1. Flash via Step 2 against an ALREADY-configured module → it must boot into the AP (proves eraseAll wipes config)
# 2. Join ESP32-Access-Point / esp-12345, then:
curl.exe http://192.168.4.1/        # form HTML must contain NO module_name/init_base/res/factory_reset
# 3. Submit Wi-Fi → module appears on the dashboard with an auto-generated name + working uploads
curl.exe http://localhost:3002/api/health
```

## Deferred (P2, follow-up)
- `lib/form_query/`'s `splitUrlForForm`/`joinUrlFromForm`/`isValidPortString` now have no production callers (still unit-tested) — removal candidate.
- `build.sh`'s post-compile over-escaping guard covers `FIRMWARE_VERSION` but not the new URL macros (quoting verified via `strings`).
- The vestigial `espConfig.ts`/`sendConfigToEsp` dead path is marked but not deleted (deletion touches wizard wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
