### PR TITLE
feat: streamline ESP onboarding (restyle, auto-return, geo-key guard)

### DIFF
--- a/ESP32-CAM/build.sh
+++ b/ESP32-CAM/build.sh
@@ -54,10 +54,16 @@ fi
 
 # GEO_API_KEY is the Google Geolocation API key used by getGeolocation in
 # esp_init.cpp. Sourced from env var first, then a .gitignored file (so
-# local dev doesn't have to export it every shell). Missing key is NOT
-# fatal: the firmware's runtime guard logs a clear message and skips the
-# HTTPS call. We never print the value — only its length — so this script
-# can run in CI without leaking the secret into build logs.
+# local dev doesn't have to export it every shell). A missing key is
+# FATAL for this release path (see the GeoKey check below): build.sh
+# produces the web-installer firmware.bin an operator flashes, and a
+# keyless binary reports (0,0,0) and never appears on the dashboard map.
+# Set HF_ALLOW_NO_GEO_KEY=1 to build keyless on purpose (a compile check
+# that is never flashed). The local `pio run -e esp32cam` smoke env does
+# not require the key (CI may still pass GEO_API_KEY to it as a secret on
+# main; that's the pipeline's choice, not build.sh's). We never
+# print the value — only its length — so this script can run in CI without
+# leaking the secret into build logs.
 # Strip ALL whitespace from both sources (not just outer) so the env-var
 # and file paths cannot diverge on a stray trailing newline (the common
 # shape of a CI secret written via `echo "$KEY" > file`) OR an embedded
@@ -105,19 +111,40 @@ if [ -n "${GEO_API_KEY}" ]; then
   echo "  GeoKey:  set (len=${#GEO_API_KEY})"
 else
   echo "  GeoKey:  <unset>"
-  # First-boot side effect: with the geolocation fields left at their
-  # 0.0f defaults, the module reports (lat=0, lng=0, acc=0) on its
-  # first heartbeat and the homepage map plots it at Null Island in
-  # the Gulf of Guinea until an operator corrects it. Loud on stderr
-  # so the message survives a `> build.log` redirect. See
+  # build.sh is the path that produces the web-installer firmware.bin an
+  # operator actually flashes (homepage Step 2 serves it). A keyless build
+  # leaves the geolocation fields at their 0.0f defaults, so the module
+  # reports (lat=0, lng=0, acc=0) on its first heartbeat and the homepage
+  # map plots it at Null Island — i.e. the module never appears anywhere
+  # the operator can see it. Shipping that is the "new modules don't show
+  # up on the dashboard" failure, so a missing key here is FATAL by default.
+  #
+  # Escape hatch: HF_ALLOW_NO_GEO_KEY=1 builds keyless on purpose — for a CI
+  # compile check that is never flashed to a real device. The pio smoke
+  # env (`pio run -e esp32cam`) stays keyless without this flag because it
+  # is a compile-only gate, not a release path. Loud on stderr so the
+  # message survives a `> build.log` redirect. See
+  # docs/07-deployment-view/esp-flashing.md and
   # docs/08-crosscutting-concepts/auth.md "Third-party API keys".
-  echo "" >&2
-  echo "WARNING: GEO_API_KEY is unset. Firmware will skip the Google" >&2
-  echo "         Geolocation call at first boot and report (0, 0, 0)," >&2
-  echo "         which plots the module at Null Island on the dashboard." >&2
-  echo "         Set GEO_API_KEY or write ESP32-CAM/GEO_API_KEY for a" >&2
-  echo "         release build intended to reach an operator's map view." >&2
-  echo "" >&2
+  if [ "${HF_ALLOW_NO_GEO_KEY:-}" = "1" ]; then
+    echo "" >&2
+    echo "WARNING: GEO_API_KEY is unset but HF_ALLOW_NO_GEO_KEY=1 is set —" >&2
+    echo "         building a keyless binary on purpose. It reports (0, 0, 0)" >&2
+    echo "         and must NOT be flashed to a device meant to appear on the" >&2
+    echo "         dashboard map." >&2
+    echo "" >&2
+  else
+    echo "" >&2
+    echo "ERROR: GEO_API_KEY is unset. A release build flashed to an operator" >&2
+    echo "       would skip the Google Geolocation call and report (0, 0, 0)," >&2
+    echo "       so the module never appears on the dashboard map." >&2
+    echo "       Fix: export GEO_API_KEY=... or write ESP32-CAM/GEO_API_KEY" >&2
+    echo "       (gitignored). To build keyless on purpose (CI compile check," >&2
+    echo "       never flashed), re-run with HF_ALLOW_NO_GEO_KEY=1." >&2
+    echo "       See docs/07-deployment-view/esp-flashing.md." >&2
+    echo "" >&2
+    exit 1
+  fi
 fi
 echo ""
 

--- a/ESP32-CAM/host.cpp
+++ b/ESP32-CAM/host.cpp
@@ -60,6 +60,16 @@ String resolveKeepCurrentField(const String& submitted, const String& current) {
   );
 }
 
+// HTML-attribute-escape an operator-controlled value before echoing it
+// into the config form. The only reflected operator input on this page is
+// the saved SSID (`cfg_ssid`); the password is never echoed and the
+// session token is server-generated hex. See `hf::htmlEscape` for why
+// this matters now that the saved page runs a script and holds a
+// window.opener handle to the wizard tab.
+String htmlEscape(const String& src) {
+  return String(hf::htmlEscape(std::string(src.c_str())).c_str());
+}
+
 /*
   -------------------------------------
   -- LOAD EXISTING CONFIG TO PREFILL --
@@ -173,51 +183,79 @@ void sendConfigForm(WiFiClient &client, bool saved = false) {
   client.println("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
   client.println("<title>ESP32 Configuration</title>");
 
+  // Honey/bee visual language mirrored from the homepage design tokens
+  // (homepage/src/style.css — the sRGB-fallback hex values, chosen for
+  // broad in-app-browser compatibility on phones). Keeps the captive
+  // portal visually consistent with the setup wizard the operator just
+  // came from. Class names are unchanged so the form HTML + validator
+  // below keep working.
   client.println(
   "<style>"
   ":root{"
-  "  --primary:#2563eb;"
-  "  --primary-dark:#1e40af;"
-  "  --bg:#f3f6fb;"
-  "  --card:#ffffff;"
-  "  --text:#1f2937;"
-  "  --muted:#6b7280;"
-  "  --border:#e5e7eb;"
-  "  --error:#dc2626;"
+  "  --primary:#ed8936;"      // hf-honey-500
+  "  --primary-dark:#dd6b20;" // hf-honey-600
+  "  --bg:#fdfcf9;"           // hf-paper
+  "  --card:#ffffff;"         // hf-surface
+  "  --text:#1f1d18;"         // hf-ink
+  "  --soft:#54514a;"         // hf-ink-soft
+  "  --muted:#84807a;"        // hf-ink-mute
+  "  --border:#e8e4dd;"       // hf-line
+  "  --honey-100:#fff3d6;"
+  "  --error:#e11d48;"        // hf-danger
   "}"
 
   "*{box-sizing:border-box;}"
-  "body{margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);}"
-  ".container{max-width:760px;margin:40px auto;padding:0 20px;}"
-  ".card{background:var(--card);border-radius:16px;box-shadow:0 10px 30px rgba(0,0,0,0.08);padding:32px;}"
-  "h1{text-align:center;margin-top:0;font-size:26px;}"
+  "body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI','Inter','Roboto','Helvetica Neue',Arial,sans-serif;-webkit-font-smoothing:antialiased;background:var(--bg);color:var(--text);line-height:1.55;}"
+  ".container{max-width:460px;margin:0 auto;padding:32px 20px;min-height:100dvh;display:flex;flex-direction:column;justify-content:center;}"
+  ".card{background:var(--card);border-radius:20px;box-shadow:0 2px 6px rgba(0,0,0,0.05),0 8px 24px rgba(0,0,0,0.08);padding:28px;}"
 
-  ".section{margin-top:28px;padding-top:18px;border-top:1px solid var(--border);}"
-  ".section h2,.summary-as-h2{margin:0 0 10px 0;font-size:18px;font-weight:600;cursor:pointer;}"
-  ".section-desc{font-size:13px;color:var(--muted);margin-bottom:16px;}"
+  ".brand{display:flex;justify-content:center;margin-bottom:14px;}"
+  ".brand-badge{width:64px;height:64px;border-radius:999px;background:var(--honey-100);display:flex;align-items:center;justify-content:center;font-size:32px;}"
+  "h1{text-align:center;margin:0 0 6px;font-size:22px;font-weight:700;letter-spacing:-0.02em;}"
+  ".lede{text-align:center;color:var(--soft);font-size:14px;margin:0 0 22px;}"
+
+  ".section{margin-top:4px;}"
+  ".section-desc{font-size:13px;color:var(--muted);margin-bottom:18px;}"
 
   ".field{margin-bottom:18px;}"
   "label{display:block;font-weight:600;font-size:14px;margin-bottom:6px;}"
 
-  "input,select{"
-  "  width:100%;padding:10px 12px;border-radius:8px;"
-  "  border:1px solid var(--border);font-size:14px;background:#fafafa;"
-  "}"
-
-  "input:focus,select:focus{outline:none;border-color:var(--primary);background:#fff;box-shadow:0 0 0 3px rgba(37,99,235,0.15);}"
-
-  ".row{display:flex;gap:14px;}"
-  ".row .field{flex:1;}"
+  "input{width:100%;padding:12px 14px;border-radius:10px;border:1px solid var(--border);font-size:16px;background:#fcfbf9;color:var(--text);}"
+  "input:focus{outline:none;border-color:var(--primary);background:#fff;box-shadow:0 0 0 4px rgba(237,137,54,0.22);}"
 
   ".description{font-size:12px;color:var(--muted);margin-top:6px;}"
 
   ".error-field{border-color:var(--error) !important;background:#fff5f5 !important;}"
   ".error-message{color:var(--error);font-size:13px;margin-top:12px;text-align:center;display:none;}"
 
-  "button{margin-top:20px;width:100%;padding:12px;border:none;border-radius:999px;font-size:15px;font-weight:600;background:var(--primary);color:#fff;cursor:pointer;transition:0.2s;}"
+  "button{margin-top:8px;width:100%;padding:13px;border:none;border-radius:999px;font-size:15px;font-weight:600;background:var(--primary);color:#fff;cursor:pointer;transition:background .2s;}"
   "button:hover{background:var(--primary-dark);}"
 
-  ".message{background:#e6f4ea;color:#14532d;padding:12px;border-radius:8px;margin-bottom:16px;font-size:14px;}"
+  ".message{background:#eaf7ee;color:#14532d;border:1px solid #bfe6cc;padding:14px;border-radius:12px;margin-bottom:18px;font-size:14px;text-align:center;}"
+  ".message strong{display:block;margin-bottom:2px;}"
+
+  // Dark mode: honour the device's prefers-color-scheme so the portal
+  // matches the rest of the app (which also flips on this query). The
+  // portal is a separate origin and can't read the homepage's manual theme
+  // toggle, so the OS preference is the only signal — and it's the
+  // homepage's primary trigger too. OKLCH values are copied verbatim from
+  // the homepage dark tokens (homepage/src/style.css); the honey accents
+  // (badge bg, button) intentionally stay as-is, mirroring how the homepage
+  // keeps brand colours constant across themes. A browser without OKLCH
+  // support keeps the light :root hex above — acceptable degradation.
+  "@media (prefers-color-scheme: dark){"
+  "  :root{"
+  "    --bg:oklch(18% 0.015 60);"
+  "    --card:oklch(22% 0.015 60);"
+  "    --text:oklch(96% 0.01 80);"
+  "    --soft:oklch(80% 0.01 80);"
+  "    --muted:oklch(65% 0.01 80);"
+  "    --border:oklch(32% 0.015 60);"
+  "  }"
+  "  input{background:oklch(25% 0.015 60);}"
+  "  input:focus{background:oklch(27% 0.015 60);}"
+  "  .message{background:oklch(32% 0.05 150);color:oklch(90% 0.08 150);border-color:oklch(45% 0.08 150);}"
+  "}"
   "</style>"
   );
 
@@ -258,11 +296,34 @@ void sendConfigForm(WiFiClient &client, bool saved = false) {
 
   client.println("</head><body>");
   client.println("<div class=\"container\"><div class=\"card\">");
-  client.println("<h1>Connect your module to WiFi</h1>");
-
+  // Bee badge + lede mirror the setup wizard's branded step cards so the
+  // operator sees one continuous visual language. Bee glyph as an HTML
+  // entity (&#128029;) keeps this source file pure-ASCII.
+  client.println("<div class=\"brand\"><div class=\"brand-badge\" aria-hidden=\"true\">&#128029;</div></div>");
+  // Saved render is a clean confirmation that early-returns below — the
+  // WiFi form is NOT re-shown. Re-rendering an editable form with a "Save"
+  // button under a "Saved!" banner reads as "did it actually save?".
   if (saved) {
-    client.println("<div class=\"message\"><strong>Configuration saved successfully.</strong> Your module is connecting to your WiFi now.</div>");
+    client.println("<h1>You&rsquo;re all set</h1>");
+    client.println("<div class=\"message\"><strong>Saved &mdash; your module is connecting.</strong> This page will close and take you back to setup. If it doesn't, switch back to the HiveHive tab.</div>");
+    // Auto-return to the setup wizard. The wizard (the window that opened
+    // this page via window.open) listens for exactly this message string
+    // in homepage/src/components/setup/useSetupWizard.ts and advances to
+    // the verification step. targetOrigin '*' because the wizard origin
+    // varies (production vs LAN dev) and the payload is a non-secret
+    // literal. window.close() only works for script-opened windows; the
+    // banner copy above covers browsers that block it.
+    client.println("<script>");
+    client.println("try{if(window.opener){window.opener.postMessage('hivehive-config-saved','*');}}catch(e){}");
+    client.println("setTimeout(function(){try{window.close();}catch(e){}},1800);");
+    client.println("</script>");
+    client.println("</div></div></body></html>");
+    client.println();
+    return;
   }
+
+  client.println("<h1>Connect your module to WiFi</h1>");
+  client.println("<p class=\"lede\">Enter your home WiFi and your module takes care of the rest.</p>");
 
   client.println("<form action=\"/save\" method=\"POST\" autocomplete=\"off\" onsubmit=\"validateForm(event)\">");
   client.println("<input type=\"hidden\" name=\"session\" value=\"" + sessionToken + "\">");
@@ -273,7 +334,7 @@ void sendConfigForm(WiFiClient &client, bool saved = false) {
 
   client.println("<div class=\"field\">");
   client.println("<label>WiFi SSID</label>");
-  client.println("<input type=\"text\" name=\"ssid\" value=\"" + cfg_ssid + "\">");
+  client.println("<input type=\"text\" name=\"ssid\" value=\"" + htmlEscape(cfg_ssid) + "\">");
   client.println("<div class=\"description\">Your WiFi must be 2.4 GHz — the module cannot use 5 GHz networks.</div>");
   client.println("</div>");
 

--- a/ESP32-CAM/lib/form_query/form_query.cpp
+++ b/ESP32-CAM/lib/form_query/form_query.cpp
@@ -5,6 +5,22 @@
 
 namespace hf {
 
+std::string htmlEscape(const std::string& in) {
+    std::string out;
+    out.reserve(in.size());
+    for (char c : in) {
+        switch (c) {
+            case '&': out += "&amp;";  break;
+            case '<': out += "&lt;";   break;
+            case '>': out += "&gt;";   break;
+            case '"': out += "&quot;"; break;
+            case '\'': out += "&#39;"; break;
+            default:  out += c;        break;
+        }
+    }
+    return out;
+}
+
 std::string urlDecode(const std::string& src) {
     std::string decoded;
     decoded.reserve(src.size());

--- a/ESP32-CAM/lib/form_query/form_query.h
+++ b/ESP32-CAM/lib/form_query/form_query.h
@@ -133,4 +133,19 @@ std::string rewriteLegacyHighfiveUrl(const std::string& url);
 // brick the next boot.
 bool isValidPortString(const std::string& port);
 
+// HTML-escape a string for safe interpolation into an HTML attribute
+// value (and element text). Escapes the five characters that can break
+// out of a double-quoted attribute or inject markup: `&`, `<`, `>`,
+// `"`, `'`.
+//
+// Used by `host.cpp`'s `sendConfigForm` to echo the operator-entered
+// Wi-Fi SSID back into the form's `value="..."`. That echo is reflected
+// (the SSID is POSTed to `/save`, stored, then re-rendered on the saved
+// page), and the saved page now runs a `<script>` and holds a
+// `window.opener` handle to the setup-wizard tab — so an unescaped SSID
+// such as `"></script><script>window.opener.location=...</script>`
+// would execute (reflected XSS / reverse tabnabbing). Escaping at the
+// echo site closes that path regardless of what the operator types.
+std::string htmlEscape(const std::string& in);
+
 }  // namespace hf

--- a/ESP32-CAM/test/test_native_form_query/test_form_query.cpp
+++ b/ESP32-CAM/test/test_native_form_query/test_form_query.cpp
@@ -19,6 +19,7 @@
 #include "form_query.h"
 
 using hf::getParam;
+using hf::htmlEscape;
 using hf::isValidPortString;
 using hf::joinUrlFromForm;
 using hf::resolveKeepCurrentField;
@@ -471,6 +472,47 @@ static void test_port_invalid_leading_zero(void) {
     TEST_ASSERT_FALSE(isValidPortString("0443"));
 }
 
+// --- htmlEscape ------------------------------------------------------------
+//
+// The captive portal echoes the operator-entered SSID back into the form's
+// `value="..."`. That echo is reflected and the saved page now runs a
+// <script> + holds a window.opener handle to the wizard tab, so an
+// unescaped SSID is a reflected-XSS / reverse-tabnabbing vector. These
+// tests pin that the five attribute-breaking characters are escaped.
+
+static void test_htmlescape_plain_passthrough(void) {
+    TEST_ASSERT_EQUAL_STRING("MyHomeNet", htmlEscape("MyHomeNet").c_str());
+}
+
+static void test_htmlescape_empty(void) {
+    TEST_ASSERT_EQUAL_STRING("", htmlEscape("").c_str());
+}
+
+static void test_htmlescape_all_five_specials(void) {
+    // & must be first in the output for each, and all five escape.
+    TEST_ASSERT_EQUAL_STRING("&amp;&lt;&gt;&quot;&#39;",
+                             htmlEscape("&<>\"'").c_str());
+}
+
+static void test_htmlescape_literal_ampersand(void) {
+    // A literal ampersand in an SSID (e.g. "Bob & Alice") escapes once.
+    TEST_ASSERT_EQUAL_STRING("Bob &amp; Alice", htmlEscape("Bob & Alice").c_str());
+}
+
+static void test_htmlescape_neutralizes_attribute_breakout_xss(void) {
+    // The exact reverse-tabnabbing payload the senior review called out:
+    // an SSID that closes the value attribute and injects a script. After
+    // escaping, no raw '"' or '<' survives, so it cannot break out of the
+    // value="..." attribute or open a tag.
+    const std::string out =
+        htmlEscape("\"></script><script>window.opener.location='http://x'</script>");
+    TEST_ASSERT_EQUAL_STRING(
+        "&quot;&gt;&lt;/script&gt;&lt;script&gt;window.opener.location=&#39;http://x&#39;&lt;/script&gt;",
+        out.c_str());
+    TEST_ASSERT_TRUE(out.find('<') == std::string::npos);
+    TEST_ASSERT_TRUE(out.find('"') == std::string::npos);
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
 
@@ -542,6 +584,12 @@ int main(int, char**) {
     RUN_TEST(test_port_invalid_whitespace);
     RUN_TEST(test_port_invalid_overflow_during_accumulation);
     RUN_TEST(test_port_invalid_leading_zero);
+
+    RUN_TEST(test_htmlescape_plain_passthrough);
+    RUN_TEST(test_htmlescape_empty);
+    RUN_TEST(test_htmlescape_all_five_specials);
+    RUN_TEST(test_htmlescape_literal_ampersand);
+    RUN_TEST(test_htmlescape_neutralizes_attribute_breakout_xss);
 
     return UNITY_END();
 }

--- a/docs/07-deployment-view/esp-flashing.md
+++ b/docs/07-deployment-view/esp-flashing.md
@@ -65,12 +65,22 @@ The chip is now waiting for firmware.
 
 ### Provide the Geolocation API key (one-time, before first build)
 
-> **Skip this and your modules will plot at Null Island in the
-> Gulf of Guinea on the dashboard.** The Google Geolocation API key
+> **Required for any release build.** The Google Geolocation API key
 > used by the firmware's first-boot WiFi-AP lookup is **build-time
-> injected** — it is no longer hardcoded. Without a key, the
-> firmware compiles cleanly and the runtime guard skips the lookup,
-> but every module reports `(0, 0, 0)` to the backend.
+> injected** — it is no longer hardcoded. `ESP32-CAM/build.sh` (the
+> path that produces the web-installer `firmware.bin` an operator
+> flashes) now **errors and exits** when no key is found — a keyless
+> binary compiles cleanly, but the runtime guard skips the lookup and
+> every module reports `(0, 0, 0)`, so it plots at Null Island in the
+> Gulf of Guinea and is filtered out of the dashboard map (i.e. the
+> module never appears anywhere the operator can see it). Failing the
+> build is cheaper than shipping that.
+>
+> **Escape hatch:** set `HF_ALLOW_NO_GEO_KEY=1` to build a keyless
+> binary on purpose — a CI compile check that is never flashed. The
+> `pio run -e esp32cam` smoke env stays keyless without this flag,
+> because it is a compile-only gate (not a release path) and produces
+> a binary that is never flashed.
 
 Write the key to the gitignored `ESP32-CAM/GEO_API_KEY` file once
 (it's listed in the repo root `.gitignore` next to `secrets.h`):
@@ -95,7 +105,22 @@ export GEO_API_KEY="AIza<your-google-geolocation-api-key>"
 Either source survives in `extra_scripts.py`'s pre-build hook,
 which prints `[extra_scripts] GEO_API_KEY len=<N>` so you can
 confirm the value reached the build (the value itself is **never**
-logged). Full mechanism, source order, and rotation procedure:
+logged). `build.sh` likewise echoes `GeoKey: set (len=<N>)` when the
+key is found and aborts with a self-describing `ERROR:` when it is
+not. To run a CI compile check without a key on purpose, set the
+escape hatch first:
+
+```powershell
+# Windows / PowerShell — keyless compile check, never flashed
+$env:HF_ALLOW_NO_GEO_KEY = "1"; bash ESP32-CAM/build.sh
+```
+
+```bash
+# Linux / macOS — keyless compile check, never flashed
+HF_ALLOW_NO_GEO_KEY=1 bash ESP32-CAM/build.sh
+```
+
+Full mechanism, source order, and rotation procedure:
 [`docs/08-crosscutting-concepts/auth.md` → "Third-party API keys:
 Geolocation"](../08-crosscutting-concepts/auth.md#third-party-api-keys-geolocation).
 The leak that prompted this design: [chapter 11 lessons-learned →
@@ -218,6 +243,21 @@ Under the hood, after you save:
 > **Capture cadence is hardcoded.** The shipping firmware captures once on first boot plus once daily at noon local time (`TZ_EU_CENTRAL` — `CET`/`CEST` — configured in `ESP32-CAM/esp_init.cpp`'s `configTzTime` call). There is no operator-configurable interval field on the form; an earlier `Capture Interval (ms)` knob was dead-weight (stored but never read) and was removed when issue #65 was resolved. If operator-configurable cadence is later wanted, the wiring would touch `ESP32-CAM/ESP32-CAM.ino`'s `loop` and interact with ADR-007's daily-reboot logic — a separate feature PR.
 
 Click **Save Configuration**. The module reboots, joins your Wi-Fi, registers itself with the server, and starts uploading images. It will appear on the dashboard at `http://localhost:5173/dashboard` within a minute.
+
+> **The config page now closes itself.** After you save, the page
+> (served by `ESP32-CAM/host.cpp`'s `sendConfigForm`) posts a
+> `hivehive-config-saved` message back to the setup wizard
+> (`window.opener.postMessage`) and calls `window.close()` after a
+> short delay. The wizard
+> (`homepage/src/components/setup/useSetupWizard.ts`) listens for that
+> message and auto-advances to the verification step, so you land back
+> in the wizard without clicking through — no manual navigation. If
+> your browser blocks `window.close()` or `postMessage` (some in-app
+> and privacy-hardened browsers do), the page stays open with a "this
+> page will close and take you back to setup — if it doesn't, switch
+> back to the HiveHive tab" banner; switch tabs manually and use the
+> de-emphasized **"I've finished configuring"** fallback link on
+> wizard Step 4 (`Step4Configure.tsx`) to advance.
 
 ---
 

--- a/docs/08-crosscutting-concepts/auth.md
+++ b/docs/08-crosscutting-concepts/auth.md
@@ -153,13 +153,24 @@ geolocation lookup.` and returns before the HTTPS call. No
 `{latitude: 0.0f, longitude: 0.0f, accuracy: 0.0f}`. If
 `getGeolocation` skips its lookup, those zeros remain and ship
 to the backend on the first heartbeat. The `homepage` map view
-has no `(0, 0)` special-case today, so the module plots at the
-Null Island coordinate in the Gulf of Guinea until an operator
-manually corrects the location. A release build without
-`GEO_API_KEY` therefore produces map-broken modules. `build.sh`
-prints `WARNING:` on `stderr` when the key is unset for this
-reason — do not suppress it unless you have a `dev` / `test`
-build that will never reach the dashboard.
+filters the `(0, 0)` Null Island sentinel client-side, so the
+module plots nowhere — it never appears on the dashboard map
+until an operator manually corrects the location. A release build
+without `GEO_API_KEY` therefore produces invisible modules.
+
+**`build.sh` hard-requires the key for release builds.** Because
+`build.sh` is the path that produces the web-installer `firmware.bin`
+an operator actually flashes, a missing `GEO_API_KEY` is now **fatal**
+there: the script prints a self-describing `ERROR:` on `stderr` and
+exits non-zero rather than emitting a binary that would ship
+`(0, 0, 0)` modules. The escape hatch is `HF_ALLOW_NO_GEO_KEY=1`,
+which downgrades the failure to a `WARNING:` and builds a keyless
+binary on purpose — intended only for a CI compile check that is never
+flashed. The `pio run -e esp32cam` smoke env stays keyless without the
+flag, because it is a compile-only gate (not a release path): its
+firmware's runtime guard skips the Google call and the binary is never
+flashed to a real device. Do not suppress the `build.sh` error for any
+build that will reach an operator.
 
 Only the **length** of the key is logged at build time
 (`[extra_scripts] GEO_API_KEY len=<N>`); the value never appears

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -1026,6 +1026,77 @@ sides at once.
   invariant is "only patch from (0,0)". Same bucket as the "module
   physically moved" deferred-follow-up above.
 
+### A keyless release build shipped `(0, 0, 0)` modules that never appeared on the map
+
+**What happened.** A firmware binary built **without `GEO_API_KEY`**
+compiled cleanly and flashed fine, but every module flashed with it
+reported `(latitude=0, longitude=0, accuracy=0)` on first boot. The
+homepage map filters that `(0, 0)` Null Island sentinel client-side, so
+those modules registered, uploaded, and heartbeated normally yet never
+appeared anywhere the operator looks — the "new modules don't show up on
+the dashboard" symptom, with no error to point at.
+
+**Why it happened.** The Geolocation key is build-time-injected (issue
+#18) and a missing key was only ever a **warning**: `build.sh` printed
+`WARNING:` on `stderr` and produced the keyless binary anyway. The
+firmware's runtime guard correctly skips the Google lookup on an empty
+key, so nothing failed loudly — the binary was indistinguishable from a
+good one until a flashed module silently no-showed on the map. This is a
+sibling of the "First-boot geolocation race" entry above, but a distinct
+root cause: that one is a _transient_ boot failure with a key present
+(recoverable via deferred retry); this one is a _missing key at build
+time_ (no key to retry with — every boot reports zeros).
+
+**How to avoid it next time.** A latent constraint that only surfaces as
+a silent field no-show should be a build error, not a warning (same
+lesson as the "Critical-rules prose-to-code audit" entries). `build.sh`
+now **errors and exits non-zero** when no key is found, so a keyless
+binary can no longer reach an operator by accident. The deliberate
+keyless path (a CI compile check that is never flashed) is gated behind
+an explicit `HF_ALLOW_NO_GEO_KEY=1` opt-in that downgrades the failure
+to a warning; the `pio run -e esp32cam` smoke env stays keyless as a
+compile-only gate whose binary is never flashed. The guard lives in
+`ESP32-CAM/build.sh`'s GeoKey block; operator-facing docs are
+[`docs/07-deployment-view/esp-flashing.md`](../07-deployment-view/esp-flashing.md)
+and [`docs/08-crosscutting-concepts/auth.md`](../08-crosscutting-concepts/auth.md#third-party-api-keys-geolocation).
+
+### A dormant unescaped SSID echo became a live reflected-XSS path the moment the captive-portal page started running script
+
+**What happened.** The captive portal's `sendConfigForm`
+(`ESP32-CAM/host.cpp`) had long echoed the operator-entered Wi-Fi SSID
+back into the form's `value="..."` **without HTML-escaping it**. For
+years this was harmless: the page rendered no script and held no handle
+to any other window, so a `"`/`<` in an SSID could at worst mangle the
+form's own markup (self-XSS over a public-PSK AP). The onboarding-flow
+change that made the saved page (a) run a `<script>` to
+`postMessage('hivehive-config-saved')` + `window.close()` and (b) be
+opened by the setup wizard via `window.open('http://192.168.4.1',
+'_blank')` **without `noopener`** (the handle is needed for the
+postMessage handoff) turned that dormant echo into a live **reflected
+XSS / reverse-tabnabbing** vector: an SSID like
+`"></script><script>window.opener.location=...</script>` survives the
+round-trip (POST `/save` → stored → re-rendered on the saved page) and
+can navigate the operator's wizard tab.
+
+**Why it happened.** The escaping gap predated the feature; the feature
+silently changed its blast radius. Nobody re-audited the existing echo
+when adding the script + opener handle, because the diff "only added a
+redirect," not an injection sink. The vector was caught by the
+end-of-implementation senior-review, not by a test.
+
+**How to avoid it next time.** Escape **every** operator-reflected value
+at the output sink, not "where it looks risky today" — a sink's risk is
+a function of the whole page, which a later change can alter without
+touching the echo. The fix added a host-testable `hf::htmlEscape`
+(`ESP32-CAM/lib/form_query/`) and routed the SSID echo through it, with
+Unity tests in `test_native_form_query` that pin the attribute-breakout
+payload produces no raw `<` or `"`. Related: the wizard's `message`
+listener (`homepage/src/components/setup/useSetupWizard.ts`) accepts the
+fixed signal from any origin and is safe **only** because it reads no
+payload data — a `SECURITY:` comment now pins that invariant so a future
+change that starts trusting the payload adds an origin/source check
+first.
+
 ### "Three layers, one rule" was actually four surfaces — the dashboard side-list silently filtered pending modules (PR II final-pass smoke)
 
 **What happened.** PR II's design intent was: a module stuck at the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -217,6 +217,23 @@ The access point name in the firmware is `ESP32-Access-Point` with password `esp
 
 **Fix:** use **Chrome or Firefox**. Open a fresh tab to `http://192.168.4.1` — do not use a cached page.
 
+### Config page didn't close itself / wizard didn't advance after saving
+
+**Symptom:** you saved Wi-Fi credentials and saw the "Saved — your
+module is connecting" banner, but the config tab stayed open and the
+setup wizard did not move to the verification step on its own.
+
+**Cause:** on save, the config page posts a `hivehive-config-saved`
+message back to the wizard and calls `window.close()` so the operator
+is returned to the wizard automatically. Some in-app and
+privacy-hardened browsers block `window.close()` and/or
+`postMessage` from a script-opened window, so neither signal lands.
+
+**Fix:** switch back to the HiveHive tab manually, then click the
+de-emphasized **"I've finished configuring"** fallback link on wizard
+**Step 4** to advance to verification. The save already succeeded — the
+module is connecting regardless of whether the page auto-closed.
+
 ### Board crashes and reboots every ~44 seconds in AP mode (firmware before fix)
 
 **Symptoms:**
@@ -336,6 +353,45 @@ curl http://localhost:8002/modules
 ```
 
 Your module should appear with its MAC-derived ID, name, and battery level. The dashboard-derived `Module.status` (`'online' | 'offline' | 'unknown'`) only exists on the **backend's** `/api/modules` response — duckdb-service's direct `/modules` response does not carry a `status` field after [#69](https://github.com/schutera/highfive/issues/69); status is computed from `lastSeenAt` in `backend/src/database.ts`'s `fetchAndAssemble`.
+
+### Module is registered but never shows up on the dashboard **map**
+
+**Symptom.** `curl http://localhost:8002/modules` lists the module (so
+it joined Wi-Fi and registered fine), but it never appears on the
+dashboard map — the marker is simply absent.
+
+**Cause.** The firmware was built **without a `GEO_API_KEY`**. A keyless
+binary skips the first-boot Google Geolocation lookup, so the module
+reports `(latitude=0, longitude=0, accuracy=0)`. The homepage map
+filters that `(0, 0)` Null Island sentinel client-side, so the module
+plots nowhere. Confirm by checking the module's stored coordinates:
+
+```bash
+curl http://localhost:8002/modules   # look for lat/lng both 0
+```
+
+**Fix.** Rebuild the firmware **with** the Geolocation API key set, then
+re-flash:
+
+```powershell
+# Windows / PowerShell — from repo root, key in env or ESP32-CAM\GEO_API_KEY
+"AIza<your-google-geolocation-api-key>" | Out-File -NoNewline -Encoding ascii ESP32-CAM\GEO_API_KEY
+bash ESP32-CAM/build.sh
+```
+
+`build.sh` now **errors and exits** when no key is found, so a keyless
+release binary can no longer be produced by accident — this symptom only
+occurs with a binary built before that guard, or one built deliberately
+with the `HF_ALLOW_NO_GEO_KEY=1` escape hatch (a CI compile check that
+should never be flashed). See
+[07-deployment-view/esp-flashing.md → "Provide the Geolocation API key"](07-deployment-view/esp-flashing.md#provide-the-geolocation-api-key-one-time-before-first-build)
+and [08-crosscutting-concepts/auth.md → "Third-party API keys: Geolocation"](08-crosscutting-concepts/auth.md#third-party-api-keys-geolocation).
+
+> A module whose **boot-time** lookup failed transiently (flaky Wi-Fi,
+> not a missing key) can self-recover: the firmware's deferred-retry
+> path attaches a fresh fix to a later heartbeat and duckdb-service
+> patches the `(0, 0)` row (issue #89). That path needs a key baked in —
+> it does nothing for a keyless build.
 
 ---
 

--- a/homepage/src/__tests__/useSetupWizard.test.ts
+++ b/homepage/src/__tests__/useSetupWizard.test.ts
@@ -152,3 +152,101 @@ describe('useSetupWizard.startVerification — mid-poll classification (#44)', (
     expect(result.current.state.verificationTimedOut).toBe(false);
   });
 });
+
+// The captive-portal config page (served by the ESP firmware) calls
+// `window.opener.postMessage('hivehive-config-saved', '*')` and then
+// `window.close()` after the user saves their WiFi credentials. The wizard
+// hook listens for that message and auto-advances to Step 5 so the user
+// doesn't have to manually click "I've finished configuring" and navigate.
+// This is the load-bearing handoff: if the listener stops firing, the whole
+// automatic-handoff feature silently degrades to the manual fallback.
+describe('useSetupWizard — postMessage handoff from the ESP config popup', () => {
+  beforeEach(() => {
+    getAllModules.mockReset();
+    healthCheck.mockReset();
+    // Mount effect snapshots modules and fetches /firmware.json — keep both
+    // benign so the test is coupled only to the message-handoff behaviour.
+    getAllModules.mockResolvedValue([]);
+    healthCheck.mockResolvedValue({ status: 'ok', timestamp: '' });
+  });
+
+  /** Mimic the ESP popup's `window.opener.postMessage(...)`. */
+  function dispatchConfigSaved(data: unknown = 'hivehive-config-saved') {
+    window.dispatchEvent(new MessageEvent('message', { data }));
+  }
+
+  it('advances to step 5 and sets configSent when the popup posts the saved signal', async () => {
+    const { result } = renderHook(() => useSetupWizard());
+    // Drain the mount-effect promises so we assert on post-mount state.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Simulate the user having navigated to the configure step.
+    act(() => result.current.goToStep(4));
+    expect(result.current.state.currentStep).toBe(4);
+    expect(result.current.state.configSent).toBe(false);
+
+    act(() => dispatchConfigSaved());
+
+    expect(result.current.state.configSent).toBe(true);
+    expect(result.current.state.currentStep).toBe(5);
+    expect(result.current.state.direction).toBe('forward');
+  });
+
+  it('still advances when the message arrives before the user reaches step 4', async () => {
+    // Math.max(currentStep, 5) means an out-of-order signal (e.g. the popup
+    // fires while the opener is still on an earlier step) still lands on 5
+    // rather than yanking the wizard backwards or forwards by a fixed delta.
+    const { result } = renderHook(() => useSetupWizard());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.state.currentStep).toBe(1);
+
+    act(() => dispatchConfigSaved());
+
+    expect(result.current.state.configSent).toBe(true);
+    expect(result.current.state.currentStep).toBe(5);
+  });
+
+  it('ignores unrelated window messages', async () => {
+    const { result } = renderHook(() => useSetupWizard());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => result.current.goToStep(4));
+    act(() => dispatchConfigSaved('some-other-message'));
+
+    // Unrelated chatter (extensions, devtools, other frames) must not trip
+    // the handoff.
+    expect(result.current.state.configSent).toBe(false);
+    expect(result.current.state.currentStep).toBe(4);
+  });
+
+  it('removes the message listener on unmount (no leak across wizard remounts)', async () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useSetupWizard());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The handler the hook registered for 'message'.
+    const registered = addSpy.mock.calls.find(([type]) => type === 'message')?.[1];
+    expect(registered).toBeTypeOf('function');
+
+    unmount();
+
+    // The exact same handler reference must be torn down so repeated mounts
+    // (e.g. React Strict Mode, or re-entering the wizard) don't stack
+    // listeners that each fire on a single popup message.
+    expect(removeSpy).toHaveBeenCalledWith('message', registered);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/homepage/src/components/setup/Step4Configure.tsx
+++ b/homepage/src/components/setup/Step4Configure.tsx
@@ -134,9 +134,46 @@ export default function Step4Configure({
           </button>
 
           {opened && (
-            <button onClick={markConfigDone} className="hf-btn hf-btn-secondary mt-4 px-8 py-3">
-              {t('step4.configDoneBtn')}
-            </button>
+            <>
+              {/* Primary path: the captive-portal page closes itself and
+                  postMessages back to advance the wizard automatically
+                  (handled in useSetupWizard). This is just a reassurance
+                  that the wizard is waiting for that signal. */}
+              <p className="mt-5 mb-1 flex items-center gap-2 text-hf-sm text-hf-fg-soft text-center">
+                <svg
+                  className="w-4 h-4 shrink-0 animate-spin"
+                  style={{ color: 'var(--hf-honey-700)' }}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                {t('step4.waitingForSave')}
+              </p>
+
+              {/* Secondary / de-emphasized fallback for browsers that block
+                  window.close() or postMessage from the popup. */}
+              <p className="mt-4 text-hf-xs text-hf-fg-soft">{t('step4.manualFallbackHint')}</p>
+              <button
+                onClick={markConfigDone}
+                className="mt-1 text-hf-xs underline text-hf-fg-soft hover:text-hf-fg transition-colors"
+              >
+                {t('step4.configDoneBtn')}
+              </button>
+            </>
           )}
         </>
       )}

--- a/homepage/src/components/setup/useSetupWizard.ts
+++ b/homepage/src/components/setup/useSetupWizard.ts
@@ -97,6 +97,16 @@ export function useSetupWizard() {
   // Listen for the post-save signal from the ESP popup
   // (ESP firmware's /save handler calls window.opener.postMessage(...))
   // and auto-advance to Step 5 so the user doesn't have to navigate manually.
+  //
+  // SECURITY: there is intentionally no e.origin / e.source check here. The
+  // ESP serves the popup from http://192.168.4.1 and posts with
+  // targetOrigin '*', so a strict origin filter would break the real flow.
+  // This is safe ONLY because the handler reads NO data off the message — it
+  // matches a fixed literal and advances a wizard step, nothing more. The
+  // worst a hostile frame can do is nudge the wizard to step 5. Do NOT start
+  // reading attacker-controllable payload (an SSID, a token, a URL) off this
+  // message without first adding an origin/source check (e.g. retain the
+  // window.open() handle from Step4Configure and assert e.source === it).
   useEffect(() => {
     const onMessage = (e: MessageEvent) => {
       if (e.data === 'hivehive-config-saved') {

--- a/homepage/src/i18n/translations.ts
+++ b/homepage/src/i18n/translations.ts
@@ -400,8 +400,11 @@ const translations = {
     // ---- Step 4: Configure ----
     step4: {
       title: 'Configure Your Module',
-      text: 'Open the module\u2019s configuration page. It asks for only your WiFi name and password \u2014 everything else is set up automatically.',
+      text: 'Open the module\u2019s configuration page. It asks for only your WiFi name and password \u2014 everything else is set up automatically. After you save, the page closes itself and brings you back here automatically.',
       openConfigPage: 'Open Configuration Page',
+      waitingForSave:
+        'Waiting for you to save the configuration\u2026 this page will continue automatically.',
+      manualFallbackHint: 'Page didn\u2019t close on its own?',
       configDoneBtn: 'I\u2019ve saved the configuration',
       reconnectTitle: 'Configuration Saved!',
       reconnectText:
@@ -850,8 +853,11 @@ const translations = {
     // ---- Step 4: Configure ----
     step4: {
       title: 'Modul konfigurieren',
-      text: '\u00D6ffne die Konfigurationsseite des Moduls. Sie fragt nur nach deinem WLAN-Namen und Passwort \u2014 alles andere wird automatisch eingerichtet.',
+      text: '\u00D6ffne die Konfigurationsseite des Moduls. Sie fragt nur nach deinem WLAN-Namen und Passwort \u2014 alles andere wird automatisch eingerichtet. Nach dem Speichern schlie\u00DFt sich die Seite von selbst und bringt dich automatisch hierher zur\u00FCck.',
       openConfigPage: 'Konfigurationsseite \u00F6ffnen',
+      waitingForSave:
+        'Warte darauf, dass du die Konfiguration speicherst\u2026 diese Seite geht automatisch weiter.',
+      manualFallbackHint: 'Seite hat sich nicht von selbst geschlossen?',
       configDoneBtn: 'Ich habe die Konfiguration gespeichert',
       reconnectTitle: 'Konfiguration gespeichert!',
       reconnectText:

--- a/homepage/src/style.css
+++ b/homepage/src/style.css
@@ -263,6 +263,17 @@ button:focus-visible,
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+  /* Exception: loading spinners must keep turning even under reduced
+     motion. The blanket rule above sets animation-iteration-count: 1, which
+     freezes Tailwind's `animate-spin` after a single instant rotation — a
+     frozen spinner reads as "stuck", the opposite of the "working…" it's
+     meant to convey. A small, continuous, non-parallax rotation is exactly
+     the kind of motion the reduced-motion guideline tolerates, so we
+     restore it for the spinner utility specifically. */
+  .animate-spin {
+    animation-duration: 0.8s !important;
+    animation-iteration-count: infinite !important;
+  }
 }
 
 /* ================================================================


### PR DESCRIPTION
Captive portal + setup wizard:
- Restyle the ESP captive portal (host.cpp sendConfigForm) to the homepage honey/bee theme, with prefers-color-scheme dark mode mirroring the homepage tokens. The saved page is a clean confirmation that early-returns (no form re-render under a "Saved!" banner).
- On save the portal postMessages the setup wizard and closes itself, so the wizard auto-advances to the verify step (useSetupWizard already listened for the signal). Step4Configure shows a waiting state with a de-emphasized manual fallback for browsers that block window.close/postMessage.
- Restore loading-spinner motion under prefers-reduced-motion (the blanket reduce-motion rule froze every animation, including spinners).

Security:
- HTML-escape the operator-entered SSID before echoing it into the form value="" (host-testable hf::htmlEscape + Unity tests). The restyle made the page run a script and hold a window.opener handle, turning a dormant unescaped echo into a reflected-XSS / reverse-tabnabbing vector. A SECURITY comment pins the origin-less wizard message listener's invariant.

Geolocation:
- build.sh now errors (exit 1) when GEO_API_KEY is unset for a release build, instead of silently shipping a (0,0,0) binary that never appears on the dashboard map. Escape hatch HF_ALLOW_NO_GEO_KEY=1 for keyless CI compile checks; pio smoke stays keyless.

Docs: esp-flashing, auth, troubleshooting, and chapter-11 lessons (keyless-build no-show, reflected-XSS) updated accordingly.

# Pull Request

## What changed

<!-- A short summary of the change. Bullet points are fine. -->

## Why

<!-- Motivation / linked issue (e.g. Closes #123). What problem does this solve? -->

## How tested

Mark each suite that was run locally and passed. Leave unchecked if not applicable
(but explain why in a comment).

- [ ] ESP32-CAM native (`pio test -e native`)
- [ ] End-to-end (`pytest tests/e2e`)
- [ ] Backend unit (Node 22 + TS)
- [ ] image-service unit (Python 3.11)
- [ ] duckdb-service unit (Python 3.11)
- [ ] Homepage unit (React 19 + Vite)
- [ ] Manual / hardware-in-the-loop verification (describe below)

<!-- Notes on test environment, fixtures, or manual steps. -->

## Checklist

- [ ] Tests added or updated to cover the change
- [ ] Documentation updated where applicable (README, ARCHITECTURE, service-level docs)
- [ ] No secrets, credentials, or large binaries committed
- [ ] CI is green on this branch
- [ ] Breaking changes called out in the description (API, schema, env vars, hardware)

## Screenshots / logs (optional)

<!-- UI changes, before/after, or relevant log excerpts. -->
