### PR TITLE
fix: keep ESP camera capture dark (move upload LED pulse past grab)

### DIFF
--- a/ESP32-CAM/ESP32-CAM.ino
+++ b/ESP32-CAM/ESP32-CAM.ino
@@ -520,11 +520,13 @@ bool captureAndUpload() {
   Serial.println("");
   Serial.printf("-- Trying to capture and post image number %d\n", counter++);
 
-  // Single 50 ms pulse on entry so the operator can see the board is
-  // alive between long sleep intervals. Connected is silent; without
-  // this pulse the board would emit no visible signal whatsoever.
-  ledSetMode(hf::LedMode::Uploading);
-
+  // The single 50 ms "alive + uploading" pulse is deliberately fired from
+  // inside postImage() AFTER esp_camera_fb_get() returns the frame — NOT
+  // here on entry. On this board the bright GPIO4 status LED *is* the camera
+  // flash, and setting Uploading here lit it during the capture instant (a
+  // needless energy cost and a flash in the operator's face). Moving the
+  // pulse past the grab keeps the capture dark while preserving the upload
+  // blink. See postImage() in client.cpp.
   int httpCode = -1;
   for (int attempt = 0; attempt < 3; attempt++) {
     if (attempt > 0) {

--- a/ESP32-CAM/client.cpp
+++ b/ESP32-CAM/client.cpp
@@ -64,11 +64,20 @@ int postImage(esp_config_t *esp_config) {
 
   char *UPLOAD_URL = esp_config->UPLOAD_URL;
   
-  // Capture image (flash off)
+  // Capture image with the flash OFF. On the AI-Thinker board the bright
+  // GPIO4 status LED doubles as the camera flash, so the capture instant is
+  // kept dark on purpose — the Uploading liveness pulse is fired only AFTER
+  // the grab below, not before it (it used to be set on captureAndUpload
+  // entry, i.e. during the capture). Saves energy and stops flashing the
+  // operator on every shot.
   camera_fb_t *fb = esp_camera_fb_get();
   if (!fb) {
     return -1;
   }
+  // Frame is in hand — now fire the single 50 ms "alive + uploading" blink.
+  // ledOnAt(Uploading) is HIGH only for the first 50 ms, so this is one
+  // brief pulse at the *start of upload*, after the (dark) capture.
+  ledSetMode(hf::LedMode::Uploading);
 
   String filename = createFileName();
   String boundary = "------------------------esp32" + String(millis());

--- a/docs/06-runtime-view/esp-reliability.md
+++ b/docs/06-runtime-view/esp-reliability.md
@@ -226,14 +226,19 @@ light a small room. The pattern logic in
 [`lib/led_state/`](../../ESP32-CAM/lib/led_state/) is therefore
 deliberately minimal: every pattern fires briefly and then stays
 silent. Steady-state modes (powered, connected, captive-portal-up,
-trying-to-join) emit no LED at all. The Arduino-side wrapper lives in
+trying-to-join) emit no LED at all. The capture instant itself is
+**dark** — the upload pulse is fired from
+[`client.cpp`'s `postImage`](../../ESP32-CAM/client.cpp) only after the
+frame is grabbed, so the flash never lights during `esp_camera_fb_get()`
+(see [hardware-notes.md → "Camera flash LED"](../08-crosscutting-concepts/hardware-notes.md#camera-flash-led--capture-stays-dark)).
+The Arduino-side wrapper lives in
 [`led.cpp`](../../ESP32-CAM/led.cpp).
 
 | Pattern                                      | Meaning                                                                                       |
 | -------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | Off (default)                                | Anything that isn't an active failure or an upload — including AP mode, Connecting, Connected |
 | Three 50 ms pulses (~450 ms total), then off | WiFi join timed out (~1 s LED hold before reboot)                                             |
-| Single 50 ms pulse, then off                 | Capture+upload starting (one pulse per capture)                                               |
+| Single 50 ms pulse, then off                 | Upload starting — fired _after_ the (dark) capture, one pulse per upload                      |
 
 If you need to confirm the board is alive in steady state, use the
 phone WiFi list (AP mode), the serial monitor, or the dashboard

--- a/docs/08-crosscutting-concepts/hardware-notes.md
+++ b/docs/08-crosscutting-concepts/hardware-notes.md
@@ -24,6 +24,18 @@ Brave and some mobile browsers silently fail to submit the session
 token, causing the form to reload blank after Save. There is no error
 message — the form just looks like nothing happened.
 
+## Camera flash LED — capture stays dark
+
+On the AI-Thinker board the bright **GPIO4** status LED doubles as the
+camera flash. Capture is deliberately **dark**: the `Uploading` liveness
+pulse is fired from `ESP32-CAM/client.cpp`'s `postImage` **after** the
+frame is grabbed (`esp_camera_fb_get()` returns), not before it. The LED
+is therefore off during the capture instant — saves energy and stops
+flashing the operator on every shot. The brief ~50 ms upload blink is
+preserved (it now marks the start of upload, just after the dark
+capture). Earlier firmware set the pulse on `captureAndUpload` entry,
+which lit the LED while the camera grabbed the frame.
+
 ## Wi-Fi constraints
 
 - **2.4 GHz only.** The ESP32 does not support 5 GHz Wi-Fi. If your


### PR DESCRIPTION
On the AI-Thinker ESP32-CAM the bright GPIO4 status LED doubles as the camera flash. captureAndUpload set LedMode::Uploading (a 50 ms GPIO4 pulse) on entry — i.e. it lit the LED during esp_camera_fb_get(), a needless energy cost and a flash in the operator's face on every shot.

Move the Uploading pulse into postImage(), fired AFTER the frame is captured, so the capture instant stays dark while the brief upload- in-progress blink is preserved.

Note: the ordering invariant (LED not set before the grab) is enforced by call placement and a contract comment, not a unit test — the capture path pulls in esp_camera/WiFi/HTTPClient and isn't host-compilable, so the native Unity suite can't exercise it. Verified by review + on-device build. Split out of the onboarding PR so it stands on its own review.

Docs: hardware-notes (capture stays dark) and esp-reliability (LED legend) updated.

# Pull Request

## What changed

<!-- A short summary of the change. Bullet points are fine. -->

## Why

<!-- Motivation / linked issue (e.g. Closes #123). What problem does this solve? -->

## How tested

Mark each suite that was run locally and passed. Leave unchecked if not applicable
(but explain why in a comment).

- [ ] ESP32-CAM native (`pio test -e native`)
- [ ] End-to-end (`pytest tests/e2e`)
- [ ] Backend unit (Node 22 + TS)
- [ ] image-service unit (Python 3.11)
- [ ] duckdb-service unit (Python 3.11)
- [ ] Homepage unit (React 19 + Vite)
- [ ] Manual / hardware-in-the-loop verification (describe below)

<!-- Notes on test environment, fixtures, or manual steps. -->

## Checklist

- [ ] Tests added or updated to cover the change
- [ ] Documentation updated where applicable (README, ARCHITECTURE, service-level docs)
- [ ] No secrets, credentials, or large binaries committed
- [ ] CI is green on this branch
- [ ] Breaking changes called out in the description (API, schema, env vars, hardware)

## Screenshots / logs (optional)

<!-- UI changes, before/after, or relevant log excerpts. -->
