### PR TITLE
chore(ui-tests): remove diagnostic probe step from ui-playwright job (closes #123)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -353,39 +353,6 @@ jobs:
       - name: Seed UI-specific fixtures
         run: python tests/ui/scripts/seed_ui_fixtures.py
 
-      # Probe each surface the specs depend on BEFORE Playwright runs.
-      # If the dashboard renders empty, this section makes the cause
-      # obvious without trace-viewer download (CORS reject vs. empty DB
-      # vs. unreachable backend look very different from this output).
-      #
-      # TODO(#123): remove this step once `ui-playwright` has 5 consecutive
-      # green runs on PRs to main. The probes earned their keep during
-      # iteration-1's first four CI rounds (CORS, wire-shape, strict-mode)
-      # but become noise once the failure modes are familiar.
-      - name: Diagnostic — probe stack from runner
-        run: |
-          set -x
-          echo "--- /api/health (backend, no auth) ---"
-          curl -sS -o /dev/null -w "HTTP %{http_code}\n" http://localhost:4002/api/health || true
-          echo "--- /api/modules (backend, X-API-Key) ---"
-          curl -sS -H 'X-API-Key: hf_test_key' http://localhost:4002/api/modules | head -c 600 || true
-          echo ""
-          echo "--- /api/modules (backend, browser-shaped Origin) ---"
-          curl -sS -H 'X-API-Key: hf_test_key' \
-            -H 'Origin: http://localhost:6173' \
-            -D /tmp/api_headers.txt \
-            http://localhost:4002/api/modules -o /dev/null
-          echo "Response headers:"
-          cat /tmp/api_headers.txt || true
-          echo "--- / (homepage nginx) ---"
-          curl -sS -o /dev/null -w "HTTP %{http_code}\n" http://localhost:6173/ || true
-          echo "--- /dashboard (homepage SPA fallback) ---"
-          curl -sS -o /dev/null -w "HTTP %{http_code}\n" http://localhost:6173/dashboard || true
-          echo "--- homepage bundle env (grep for VITE_API_URL bake) ---"
-          curl -sS http://localhost:6173/ | grep -oE 'assets/[A-Za-z0-9_-]+\.js' | head -1 \
-            | xargs -I {} curl -sS "http://localhost:6173/{}" \
-            | grep -oE '"http://localhost:[0-9]+/api"|hf_test_key|VITE_API' | head -10 || true
-
       - name: Run Playwright specs
         working-directory: tests/ui
         run: npx playwright test


### PR DESCRIPTION
## What

Removes the unconditional **"Diagnostic — probe stack from runner"** step from the `ui-playwright` job in `.github/workflows/tests.yml`. Pure CI chore, no service code touched, −33 lines.

## Why now — #123's acceptance criterion is met

#123 gated removal on **5 consecutive green `ui-playwright` runs on PRs to `main`** after PR #122 merged (2026-05-21). Measured against the **"UI tests (Playwright)"** job:

Since the last Playwright failure (2026-06-04 10:31) there are **9 consecutive green runs** across 7 branches — `fix/esp-geolocation-tls-root-r4`, `fix/esp-capture-led-timing`, `feat/onboarding-flow`, `feat/esp-config-wifi-only`, `fix/wizard-show-ap-password`, `chore/firmware-digger-rebuild`, `fix/module-delete-decimal-mac`, plus the green re-runs of `fix/dashboard-panel-layout` and `feat/image-gallery-pagination`. 9 ≥ 5.

## Option (1) delete vs. (2) gate behind `if: failure()`

#123's rule: pick (1) unless an intervening `ui-playwright` failure proves the probes still earn their keep on every run. There **were** failures between merge and threshold (06-03/06-04), but they were genuine test failures — panel layout, pagination, wire-shape pin — **not** the stack-bring-up / CORS / "dashboard renders empty" class these probes diagnose. So the probes did not earn their per-run cost → **option (1)**.

## What's covered on red runs (and the one exception)

The `if: failure()` steps — Playwright report, traces, compose logs per service, and inline failure summary — cover post-mortem diagnosis for the failure modes that have actually recurred. The removed step only added noise to **green** logs.

One honest exception: the probe's homepage-bundle grep (the baked `VITE_API_URL` over `assets/*.js`) has **no exact failure-path twin**. The compose-logs step captures container *runtime* logs, not the contents of the nginx-served JS bundle — so a wrong-API-origin bake is no longer grep-able straight from the logs. It remains **inferable** from the Playwright trace's network requests (a wrong origin shows up there), and the bundle config is now stable in `tests/ui/docker-compose.ui.yml`, so this is a slight diagnosis-ergonomics cost on a non-recurring failure class, not a lost capability. Next person debugging a red `ui-playwright`: look in the trace, not for a grep'd bundle line.

## Verification

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/tests.yml'))"` → OK
- Diff is a single contiguous block removal (comment + step); the `Run Playwright specs` step is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
