### PR TITLE
docs: OTA firmware release runbook + branch/tag model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ To ship new ESP32-CAM firmware to the field, follow the runbook — do **not** i
 
 Ground truth, in execution order:
 
-- **The checklist** — [`firmware-release.md` → Release checklist](docs/07-deployment-view/firmware-release.md#release-checklist): bump both `ESP32-CAM/VERSION` + `ESP32-CAM/SEQUENCE` → `bash ESP32-CAM/build.sh` (needs `GEO_API_KEY`) → republish the **frontend image** (the artifacts are gitignored, so `git pull` doesn't carry them) → commit on `main` + annotated `prod-<codename>` tag → verify `curl https://highfive.schutera.com/firmware.json`.
+- **The checklist** — [`firmware-release.md` → Release checklist](docs/07-deployment-view/firmware-release.md#release-checklist): bump both `ESP32-CAM/VERSION` + `ESP32-CAM/SEQUENCE` → `bash ESP32-CAM/build.sh` (needs `GEO_API_KEY`) → rebuild the **frontend image** (the artifacts are gitignored, so `git pull` doesn't carry them) → commit on `main` + annotated `prod-<codename>` tag → verify `curl https://highfive.schutera.com/firmware.json`.
 - **Why `SEQUENCE` is the gate** — [`ADR-008` → Sequence + allow_downgrade addendum](docs/09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md#sequence--allow_downgrade-addendum-pr-ii-83) and [`ESP32-CAM/lib/ota_version/ota_version.h`](ESP32-CAM/lib/ota_version/ota_version.h).
 - **The build/publish script** — [`ESP32-CAM/build.sh`](ESP32-CAM/build.sh) (writes the 3 artifacts + manifest into `homepage/public/`).
 - **Runtime fetch/flash/rollback** — [`docs/06-runtime-view/ota-update-flow.md`](docs/06-runtime-view/ota-update-flow.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,20 @@ The `pio run -e esp32cam` line builds the firmware as a smoke test — it works 
 
 Full testing strategy: [`docs/10-quality-requirements/`](docs/10-quality-requirements/README.md). CI gate manifest: [`docs/10-quality-requirements/ci-gates.md`](docs/10-quality-requirements/ci-gates.md).
 
+## Cutting a firmware OTA release
+
+To ship new ESP32-CAM firmware to the field, follow the runbook — do **not** improvise: [`docs/07-deployment-view/firmware-release.md`](docs/07-deployment-view/firmware-release.md). **The one rule:** bump `ESP32-CAM/SEQUENCE` (not just `VERSION`) — the on-device comparator flashes only when the published manifest's `sequence` is strictly greater, so merging firmware source to `main` ships nothing until a higher-`SEQUENCE` build is published and a `prod-<codename>` tag exists. This silent no-op has shipped twice (#150, #132).
+
+Ground truth, in execution order:
+
+- **The checklist** — [`firmware-release.md` → Release checklist](docs/07-deployment-view/firmware-release.md#release-checklist): bump both `ESP32-CAM/VERSION` + `ESP32-CAM/SEQUENCE` → `bash ESP32-CAM/build.sh` (needs `GEO_API_KEY`) → republish the **frontend image** (the artifacts are gitignored, so `git pull` doesn't carry them) → commit on `main` + annotated `prod-<codename>` tag → verify `curl https://highfive.schutera.com/firmware.json`.
+- **Why `SEQUENCE` is the gate** — [`ADR-008` → Sequence + allow_downgrade addendum](docs/09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md#sequence--allow_downgrade-addendum-pr-ii-83) and [`ESP32-CAM/lib/ota_version/ota_version.h`](ESP32-CAM/lib/ota_version/ota_version.h).
+- **The build/publish script** — [`ESP32-CAM/build.sh`](ESP32-CAM/build.sh) (writes the 3 artifacts + manifest into `homepage/public/`).
+- **Runtime fetch/flash/rollback** — [`docs/06-runtime-view/ota-update-flow.md`](docs/06-runtime-view/ota-update-flow.md).
+- **The trap to avoid** — [chapter 11 → "Merging firmware source is not a release"](docs/11-risks-and-technical-debt/README.md#merging-firmware-source-is-not-a-release--the-sequence-bump-is-the-release-150-132).
+
+Firmware OTA is cut on `main` + `prod-*` tags; the `production` branch is the Docker-services deploy track only ([branch & tag model](docs/07-deployment-view/firmware-release.md#git-branch--tag-model)).
+
 ## Documentation map (arc42)
 
 The `docs/` folder follows arc42. Use this table to find the chapter relevant to your task — and to know **which chapter to update when you finish a change**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Full testing strategy: [`docs/10-quality-requirements/`](docs/10-quality-require
 
 ## Cutting a firmware OTA release
 
-To ship new ESP32-CAM firmware to the field, follow the runbook — do **not** improvise: [`docs/07-deployment-view/firmware-release.md`](docs/07-deployment-view/firmware-release.md). **The one rule:** bump `ESP32-CAM/SEQUENCE` (not just `VERSION`) — the on-device comparator flashes only when the published manifest's `sequence` is strictly greater, so merging firmware source to `main` ships nothing until a higher-`SEQUENCE` build is published and a `prod-<codename>` tag exists. This silent no-op has shipped twice (#150, #132).
+To ship new ESP32-CAM firmware to the field, follow the runbook — do **not** improvise: [`docs/07-deployment-view/firmware-release.md`](docs/07-deployment-view/firmware-release.md). **The one rule:** bump `ESP32-CAM/SEQUENCE` (a new `VERSION` codename alone won't flash) — the on-device comparator requires the manifest's `version` to differ **and** its `sequence` to be strictly greater, so merging firmware source to `main` ships nothing until a higher-`SEQUENCE` build is published and a `prod-<codename>` tag exists. This silent no-op has shipped twice (#150, #132).
 
 Ground truth, in execution order:
 

--- a/docs/07-deployment-view/README.md
+++ b/docs/07-deployment-view/README.md
@@ -9,3 +9,4 @@ over USB and then operates autonomously.
 - [production-deployment.md](production-deployment.md) — **supported production path**: `docker-compose.prod.yml` (all four services: backend + frontend + image-service + duckdb-service, with `duckdb_data` volume) behind a host-Nginx terminator that handles TLS for `highfive.schutera.com` + `api.highfive.schutera.com` via Let's Encrypt
 - [production-runbook.md](production-runbook.md) — non-recommended legacy bare-metal path (PM2 + Nginx, no Docker, Node backend only — upload pipeline not covered)
 - [esp-flashing.md](esp-flashing.md) — ESP32-CAM firmware flashing & onboarding (incl. `ESP32-CAM/build.sh` and `ESP32-CAM/VERSION`)
+- [firmware-release.md](firmware-release.md) — **how to cut an OTA firmware release**: the end-to-end runbook (bump `VERSION`+`SEQUENCE` → `build.sh` → republish frontend → commit + `prod-<codename>` tag), the `main`-vs-`production` branch model, and where each OTA mechanism is defined

--- a/docs/07-deployment-view/esp-flashing.md
+++ b/docs/07-deployment-view/esp-flashing.md
@@ -409,6 +409,13 @@ existing 30 s sleeps).
 
 ### Boot-time HTTP pull
 
+> **Cutting a release for the whole fleet?** Use the canonical
+> end-to-end runbook: [firmware-release.md](firmware-release.md). It
+> covers the full sequence (build → republish the frontend image →
+> commit → `prod-<codename>` tag → verify), the gitignored-artifact
+> publish step, and the `main`-vs-`production` branch model. The two
+> paragraphs below are the firmware-side mechanics it builds on.
+
 Bump `ESP32-CAM/VERSION` (per [ADR-006](../09-architecture-decisions/adr-006-bee-name-firmware-versioning.md)
 the value is the next bee-species name), **and** bump
 `ESP32-CAM/SEQUENCE` (PR II / issue #83) to the next integer. The

--- a/docs/07-deployment-view/firmware-release.md
+++ b/docs/07-deployment-view/firmware-release.md
@@ -1,0 +1,193 @@
+# Cutting a firmware OTA release
+
+The end-to-end procedure for shipping a new ESP32-CAM firmware to the
+deployed fleet over the air. This is the **operator runbook**; the
+runtime mechanics live in
+[../06-runtime-view/ota-update-flow.md](../06-runtime-view/ota-update-flow.md)
+and the design rationale in
+[../09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md](../09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md).
+
+## The one rule
+
+**Bump `ESP32-CAM/SEQUENCE`, or the fleet never pulls your release.**
+
+A module flashes itself only when the published manifest's `sequence`
+is **strictly greater** than the sequence baked into the running
+binary (see [the comparator](#how-a-module-decides-to-flash)). Merging
+firmware _source_ to `main` changes nothing on the field: until a build
+with a higher `SEQUENCE` is published, every module keeps running what
+it has. Bumping `VERSION` (the bee-name label) alone is **not** enough —
+the label differing is necessary but not sufficient. This silent no-op
+has shipped twice; see
+[chapter 11 → "Merging firmware source is not a release"](../11-risks-and-technical-debt/README.md#merging-firmware-source-is-not-a-release--the-sequence-bump-is-the-release-150-132).
+
+## Mental model
+
+```mermaid
+flowchart TD
+    A["Bump ESP32-CAM/VERSION (next bee name)<br/>+ ESP32-CAM/SEQUENCE (+1)"] --> B["bash ESP32-CAM/build.sh<br/>(GEO_API_KEY required)"]
+    B --> C["3 artifacts in homepage/public/:<br/>firmware.bin (merged, web installer)<br/>firmware.app.bin (app-only, OTA)<br/>firmware.json (manifest)"]
+    C --> D["Stage artifacts into the prod host's<br/>checkout homepage/public/ — gitignored,<br/>so 'git pull' does NOT carry them"]
+    D --> E["Rebuild + restart the frontend container<br/>(Vite copies public/ → dist/ → nginx html)"]
+    E --> F["host-Nginx serves /firmware.json<br/>+ /firmware.app.bin"]
+    F --> G["Module's next daily reboot:<br/>GET /firmware.json → seq higher? →<br/>GET /firmware.app.bin → flash → reboot"]
+    A --> H["Commit bump on main<br/>+ tag prod-&lt;codename&gt; (release ledger)"]
+```
+
+## Release checklist
+
+The numbered actions. Steps 1, 2, 5 happen in your local clone; steps
+3–4 and 6 touch the prod host and the live fleet.
+
+0. **Pre-flight.** Be on a clean `main` (`git switch main && git pull`).
+   Have the Google Geolocation key available — either `export
+GEO_API_KEY=...` or the gitignored `ESP32-CAM/GEO_API_KEY` file. A
+   keyless build is **fatal by default** (it would ship `(0,0,0)`
+   modules that never appear on the map — see
+   [build.sh](../../ESP32-CAM/build.sh)'s `GeoKey` block and the
+   chapter-11 "keyless release" lesson).
+
+1. **Bump both version files.** This is the release itself:
+   - `ESP32-CAM/VERSION` → the next bee-species codename
+     ([ADR-006](../09-architecture-decisions/adr-006-bee-name-firmware-versioning.md);
+     the value is just a human label, must differ from the deployed one).
+   - `ESP32-CAM/SEQUENCE` → the current integer **+ 1** (the actual OTA
+     gate; monotonic, never reused, never decremented).
+
+2. **Build.** From the repo root, in Git Bash / bash:
+
+   ```bash
+   cd ESP32-CAM && bash build.sh
+   ```
+
+   `build.sh` compiles with `-DFIRMWARE_VERSION` / `-DFIRMWARE_SEQUENCE`
+   injected, stitches the merged web-installer image, and writes all
+   three artifacts into `homepage/public/` plus the `firmware.json`
+   manifest ([build.sh](../../ESP32-CAM/build.sh)). It runs on Windows
+   11 + Git Bash unchanged (#99). **Read the final lines** — confirm the
+   printed `version`, `sequence`, and `app_md5`; note `app_md5` for the
+   tag in step 5. `build.sh` warns on stderr if `SEQUENCE` is **lower**
+   than the previously-published manifest (an accidental downgrade).
+
+3. **Publish the artifacts to prod.** The three files are **gitignored
+   build outputs** ([.gitignore](../../.gitignore) → `homepage/public/firmware.json`),
+   so a `git pull` on the prod host does **not** carry them. They are
+   baked into the **frontend container** at image-build time (Vite
+   copies `homepage/public/*` → `dist/`, which
+   [homepage/Dockerfile](../../homepage/Dockerfile) serves as the nginx
+   html root). So publishing means: get the three files into the prod
+   host's checkout `homepage/public/`, then **rebuild the frontend
+   image**:
+
+   ```bash
+   # On the prod host, with the new firmware.{bin,app.bin,json} staged
+   # into homepage/public/ (scp them from your local build, or run
+   # build.sh on the host if the arduino-cli toolchain is installed there):
+   docker compose -f docker-compose.prod.yml up -d --build frontend
+   ```
+
+   Host-Nginx already proxies `/firmware.json` and `/firmware.app.bin`
+   (exact-match `location =` blocks) to the frontend container —
+   [production-deployment.md → OTA firmware artifacts](production-deployment.md).
+   No Nginx change is needed per release.
+
+4. **Verify it is served.** From anywhere:
+
+   ```bash
+   curl.exe -s https://highfive.schutera.com/firmware.json
+   ```
+
+   Confirm `version` and `sequence` match what you just built, and that
+   `app_md5` matches step 2's output (the binary the fleet will fetch).
+
+5. **Record the release in git.** Commit the `VERSION` / `SEQUENCE` bump
+   to `main`, then tag it:
+
+   ```bash
+   git add ESP32-CAM/VERSION ESP32-CAM/SEQUENCE
+   git commit -m "chore(esp): bump firmware to <codename> / sequence <N> — <why>"
+   git tag -a prod-<codename> -m "deploy: firmware OTA <codename> / sequence <N> (app_md5 <...>). <go-ahead / bench-test / rollback status>."
+   git push origin main --follow-tags
+   ```
+
+   The annotated `prod-<codename>` tag is the **release ledger** — the
+   human record of "this commit's VERSION/SEQUENCE was built and
+   published to the OTA server." The binaries are not in git, so the
+   `app_md5` in the tag note is what pins the release to a specific
+   build. See [Git: branch & tag model](#git-branch--tag-model).
+
+6. **Confirm the fleet picks it up.** Modules check `/firmware.json` on
+   **every boot, including the daily reboot** ([ADR-007](../09-architecture-decisions/adr-007-esp-reliability-breaker-and-daily-reboot.md)),
+   so the whole fleet converges within ≤ 24 h with no further action.
+   Watch the dashboard's **Firmware** pill / `latestHeartbeat.fwVersion`
+   flip to the new codename, or poll:
+   ```bash
+   curl.exe -s https://highfive.schutera.com/api/modules
+   ```
+   A module whose pill never advances may be un-migrated (needs a
+   one-time USB flash — see
+   [esp-flashing.md → First-time OTA migration](esp-flashing.md#first-time-ota-migration-one-way-usb-only)),
+   or it OTA-flashed and rolled back (a setup-stage panic — the next
+   telemetry sidecar names the failing stage).
+
+## How a module decides to flash
+
+The on-device comparator
+([`shouldOtaUpdate`](../../ESP32-CAM/lib/ota_version/ota_version.h)) returns
+true **iff**:
+
+> `manifest.version != my_version` **AND** `my_sequence != 0` **AND**
+> (`manifest.sequence > my_sequence` **OR** `manifest.allow_downgrade == true`)
+
+- The **sequence** is the real lever; the version label only has to
+  differ. This is why step 1 bumps _both_.
+- `my_sequence != 0` is the **dev escape hatch**: an Arduino-IDE build
+  that bypasses `build.sh` compiles with `FIRMWARE_SEQUENCE = 0` and
+  refuses to auto-flash itself onto a fleet release.
+- `allow_downgrade` is the deliberate-rollback override (default
+  `false`). Full semantics:
+  [ADR-008 → Sequence + allow_downgrade addendum](../09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md#sequence--allow_downgrade-addendum-pr-ii-83).
+
+## Git: branch & tag model
+
+Two deployment tracks share the repo and are easy to conflate:
+
+| Track                                                                  | Source of truth                                                                                      | "Deploy" action                                                                                      |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Firmware OTA** (this doc)                                            | `ESP32-CAM/VERSION` + `ESP32-CAM/SEQUENCE` on **`main`**, marked by `prod-<codename>` annotated tags | `build.sh` → stage artifacts → rebuild frontend image. **Does not involve the `production` branch.** |
+| **Web services** (backend / frontend / image-service / duckdb-service) | the **`production` branch** per [production-deployment.md](production-deployment.md)                 | `git pull` on the host → `docker compose -f docker-compose.prod.yml up -d --build`                   |
+
+Firmware releases are cut on `main` and pinned by `prod-*` tags; the
+binaries themselves are gitignored and pinned by `app_md5` in the tag
+note. The `production` branch is a **separate** concern (the Docker
+services) and the firmware OTA path never touches it.
+
+> **Known drift (verify before relying on it).** `origin/production` is
+> currently far behind `main`, yet the live services run `main`-only
+> code (e.g. the #142 admin-session endpoints respond in prod). Whether
+> services are now deployed from `main` or the `production` branch is
+> stale needs operator confirmation — see
+> [chapter 11 → "`production` branch drifted from the deployed services"](../11-risks-and-technical-debt/README.md#production-branch-drifted-from-the-deployed-services-undocumented-deploy-source).
+
+## Rollback
+
+A fleet rollback is a deliberate, sequenced operation — you cannot just
+lower `SEQUENCE` (the comparator refuses it). Set `allow_downgrade:
+true` for one publish, then un-set it on the next regular release.
+Step-by-step:
+[esp-flashing.md → How to deliberately roll back a fleet](esp-flashing.md#how-to-deliberately-roll-back-a-fleet-pr-ii--issue-83).
+Note that a bricked OTA self-recovers without a rollback publish — the
+app-side counter reverts to the previous slot after 3 faulty boots
+([ADR-008 rollback](../09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md)).
+
+## Ground truth — where each piece is defined
+
+| Piece                                        | Authoritative source                                                                                                                                                                                                          |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Version label scheme (bee names)             | [ADR-006](../09-architecture-decisions/adr-006-bee-name-firmware-versioning.md)                                                                                                                                               |
+| Sequence gate + `allow_downgrade` comparator | [ADR-008 addendum](../09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md#sequence--allow_downgrade-addendum-pr-ii-83), [`lib/ota_version/ota_version.h`](../../ESP32-CAM/lib/ota_version/ota_version.h) |
+| Build + 3-artifact publish + manifest fields | [`ESP32-CAM/build.sh`](../../ESP32-CAM/build.sh), [ADR-008 decision §3](../09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md)                                                                          |
+| Runtime fetch / flash / rollback sequence    | [ota-update-flow.md](../06-runtime-view/ota-update-flow.md), [`ESP32-CAM/ota.cpp`](../../ESP32-CAM/ota.cpp)                                                                                                                   |
+| Host-Nginx serving of `/firmware.*`          | [production-deployment.md](production-deployment.md)                                                                                                                                                                          |
+| First-time USB migration (one-way)           | [esp-flashing.md](esp-flashing.md#first-time-ota-migration-one-way-usb-only)                                                                                                                                                  |
+| Incident: source-merge ≠ release             | [chapter 11](../11-risks-and-technical-debt/README.md#merging-firmware-source-is-not-a-release--the-sequence-bump-is-the-release-150-132)                                                                                     |

--- a/docs/07-deployment-view/firmware-release.md
+++ b/docs/07-deployment-view/firmware-release.md
@@ -28,7 +28,7 @@ flowchart TD
     A["Bump ESP32-CAM/VERSION (next bee name)<br/>+ ESP32-CAM/SEQUENCE (+1)"] --> B["bash ESP32-CAM/build.sh<br/>(GEO_API_KEY required)"]
     B --> C["3 artifacts in homepage/public/:<br/>firmware.bin (merged, web installer)<br/>firmware.app.bin (app-only, OTA)<br/>firmware.json (manifest)"]
     C --> D["Stage artifacts into the prod host's<br/>checkout homepage/public/ — gitignored,<br/>so 'git pull' does NOT carry them"]
-    D --> E["Rebuild + restart the frontend container<br/>(Vite copies public/ → dist/ → nginx html)"]
+    D --> E["Rebuild the frontend image<br/>(Vite copies public/ → dist/ → nginx html)"]
     E --> F["host-Nginx serves /firmware.json<br/>+ /firmware.app.bin"]
     F --> G["Module's next daily reboot:<br/>GET /firmware.json → seq higher? →<br/>GET /firmware.app.bin → flash → reboot"]
     A --> H["Commit bump on main<br/>+ tag prod-&lt;codename&gt; (release ledger)"]
@@ -99,8 +99,11 @@ GEO_API_KEY=...` or the gitignored `ESP32-CAM/GEO_API_KEY` file. A
    > ([production-deployment.md → OTA firmware artifacts](production-deployment.md));
    > and (2) you are rebuilding the checkout your services actually deploy
    > from, which is itself unsettled (see
-   > [Git: branch & tag model](#git-branch--tag-model)). No Nginx change
-   > is needed per release.
+   > [Git: branch & tag model](#git-branch--tag-model)). **If (1) is
+   > false** — `public/` is served from a host static path or a bind-mount
+   > rather than baked into the image — then the publish _action_ changes:
+   > drop the three files at that path directly, with **no** image
+   > rebuild. No Nginx change is needed per release.
 
 4. **Verify it is served.** From anywhere:
 
@@ -198,7 +201,8 @@ app-side counter reverts to the previous slot after 3 faulty boots
 | Version label scheme (bee names)             | [ADR-006](../09-architecture-decisions/adr-006-bee-name-firmware-versioning.md)                                                                                                                                               |
 | Sequence gate + `allow_downgrade` comparator | [ADR-008 addendum](../09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md#sequence--allow_downgrade-addendum-pr-ii-83), [`lib/ota_version/ota_version.h`](../../ESP32-CAM/lib/ota_version/ota_version.h) |
 | Build + 3-artifact publish + manifest fields | [`ESP32-CAM/build.sh`](../../ESP32-CAM/build.sh), [ADR-008 decision §3](../09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md)                                                                          |
-| Runtime fetch / flash / rollback sequence    | [ota-update-flow.md](../06-runtime-view/ota-update-flow.md), [`ESP32-CAM/ota.cpp`](../../ESP32-CAM/ota.cpp)                                                                                                                   |
+| Runtime fetch / flash sequence               | [ota-update-flow.md](../06-runtime-view/ota-update-flow.md), [`ESP32-CAM/ota.cpp`](../../ESP32-CAM/ota.cpp)                                                                                                                   |
+| App-side rollback (faulty-boot counter)      | [ADR-008](../09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md), [`ESP32-CAM/ESP32-CAM.ino`](../../ESP32-CAM/ESP32-CAM.ino)'s `forceRollbackIfPendingTooLong`                                          |
 | Host-Nginx serving of `/firmware.*`          | [production-deployment.md](production-deployment.md)                                                                                                                                                                          |
 | First-time USB migration (one-way)           | [esp-flashing.md](esp-flashing.md#first-time-ota-migration-one-way-usb-only)                                                                                                                                                  |
 | Incident: source-merge ≠ release             | [chapter 11](../11-risks-and-technical-debt/README.md#merging-firmware-source-is-not-a-release--the-sequence-bump-is-the-release-150-132)                                                                                     |

--- a/docs/07-deployment-view/firmware-release.md
+++ b/docs/07-deployment-view/firmware-release.md
@@ -70,14 +70,15 @@ GEO_API_KEY=...` or the gitignored `ESP32-CAM/GEO_API_KEY` file. A
    than the previously-published manifest (an accidental downgrade).
 
 3. **Publish the artifacts to prod.** The three files are **gitignored
-   build outputs** ([.gitignore](../../.gitignore) → `homepage/public/firmware.json`),
-   so a `git pull` on the prod host does **not** carry them. They are
-   baked into the **frontend container** at image-build time (Vite
-   copies `homepage/public/*` → `dist/`, which
+   build outputs** (the `*.bin` glob and the explicit
+   `homepage/public/firmware.json` line in [.gitignore](../../.gitignore)),
+   so a `git pull` on the prod host does **not** carry them. With the
+   committed topology they are baked into the **frontend container** at
+   image-build time (Vite copies `homepage/public/*` → `dist/`, which
    [homepage/Dockerfile](../../homepage/Dockerfile) serves as the nginx
-   html root). So publishing means: get the three files into the prod
-   host's checkout `homepage/public/`, then **rebuild the frontend
-   image**:
+   html root; the container has no bind-mount). So publishing means: get
+   the three files into the prod host's checkout `homepage/public/`, then
+   **rebuild the frontend image**:
 
    ```bash
    # On the prod host, with the new firmware.{bin,app.bin,json} staged
@@ -86,10 +87,20 @@ GEO_API_KEY=...` or the gitignored `ESP32-CAM/GEO_API_KEY` file. A
    docker compose -f docker-compose.prod.yml up -d --build frontend
    ```
 
-   Host-Nginx already proxies `/firmware.json` and `/firmware.app.bin`
-   (exact-match `location =` blocks) to the frontend container —
-   [production-deployment.md → OTA firmware artifacts](production-deployment.md).
-   No Nginx change is needed per release.
+   > **Verify this transport against your live prod host before relying
+   > on it.** The step is _derived from the committed topology_
+   > (host-Nginx → frontend container; `public/` baked into the image; no
+   > bind-mount) — it is **not** confirmed against how the last release
+   > (`woolcarder`) actually shipped, because the binaries are published
+   > out-of-band and are not in git. Confirm two things on the host: (1)
+   > `/firmware.json` is really served by the frontend container — the
+   > documented host-Nginx `location =` blocks proxy it to
+   > `127.0.0.1:8081`, not a host static path
+   > ([production-deployment.md → OTA firmware artifacts](production-deployment.md));
+   > and (2) you are rebuilding the checkout your services actually deploy
+   > from, which is itself unsettled (see
+   > [Git: branch & tag model](#git-branch--tag-model)). No Nginx change
+   > is needed per release.
 
 4. **Verify it is served.** From anywhere:
 
@@ -128,7 +139,7 @@ GEO_API_KEY=...` or the gitignored `ESP32-CAM/GEO_API_KEY` file. A
    one-time USB flash — see
    [esp-flashing.md → First-time OTA migration](esp-flashing.md#first-time-ota-migration-one-way-usb-only)),
    or it OTA-flashed and rolled back (a setup-stage panic — the next
-   telemetry sidecar names the failing stage).
+   telemetry sidecar names the failing stage; see [Rollback](#rollback)).
 
 ## How a module decides to flash
 

--- a/docs/07-deployment-view/production-deployment.md
+++ b/docs/07-deployment-view/production-deployment.md
@@ -12,6 +12,14 @@ For a non-Docker production option (Nginx + PM2 on bare metal), see
 [production-runbook.md](production-runbook.md). For dev-laptop setup,
 see [docker-compose.md](docker-compose.md).
 
+> **This doc covers the web services only.** Shipping new **ESP32-CAM
+> firmware** to the field is a separate track — cut on `main` and marked
+> by `prod-<codename>` tags, not deployed from this branch. See
+> [firmware-release.md](firmware-release.md). ⚠️ The `production` branch
+> this guide clones is currently behind `main` while the live services
+> run `main`-only code; verify your actual services deploy source before
+> relying on it — [chapter 11 → "`production` branch drifted"](../11-risks-and-technical-debt/README.md#production-branch-drifted-from-the-deployed-services-undocumented-deploy-source).
+
 ## Topology at a glance
 
 ```

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -86,6 +86,71 @@ write the lesson here so the next contributor doesn't repeat it.
 Format: short title + **What happened** + **Why it happened** +
 **How to avoid it next time**.
 
+### Merging firmware source is not a release — the SEQUENCE bump is the release (#150, #132)
+
+**What happened.** PR #150 merged the noon-capture firmware source to
+`main` but left `ESP32-CAM/VERSION=carpenter` / `ESP32-CAM/SEQUENCE=4` —
+identical version identifiers to the already-deployed release. The
+on-device OTA comparator
+([`shouldOtaUpdate`](../../ESP32-CAM/lib/ota_version/ota_version.h)) only
+flashes when the published manifest's `sequence` is **strictly greater**
+than the running one, so **every field module silently ignored the
+merge**: the fix sat on `main`, looked shipped, and reached zero
+modules. A colleague had to cut a real release (`woolcarder` / sequence
+5, commit `39d2faa`) — bump both files, rebuild, republish — before the
+fleet pulled it. Per that release commit, **#132 was an earlier instance
+of the same class** (a rebuilt same-sequence binary that silently drifts
+from the deployed one).
+
+**Why it happened.** "Merge to `main`" is the release ritual for the web
+services, so it reads as done — but firmware has a second, manual gate:
+the artifacts are gitignored and served from a **rebuilt frontend
+image**, and the comparator keys on `SEQUENCE`, not on the source being
+present. Nothing fails loudly — CI is green, the diff is merged, and the
+only signal that the fleet didn't update is the dashboard **Firmware**
+pill never advancing, which nobody watches by default. Bumping `VERSION`
+alone has the same trap: the label differs but `sequence` doesn't, so
+the comparator still refuses.
+
+**How to avoid it next time.** Treat a firmware change as **unshipped
+until a `prod-<codename>` tag exists**. Follow the runbook at
+[`docs/07-deployment-view/firmware-release.md`](../07-deployment-view/firmware-release.md):
+bump **both** `VERSION` and `SEQUENCE`, run `build.sh`, republish the
+frontend image, commit, and tag. After publishing, verify
+`curl https://highfive.schutera.com/firmware.json` shows the new
+`sequence` and that a module's `latestHeartbeat.fwVersion` flips within a
+daily-reboot cycle. The one-line invariant: **the `SEQUENCE` integer
+must increment for a release to reach the field; if it didn't change,
+nothing shipped.**
+
+### `production` branch drifted from the deployed services (undocumented deploy source)
+
+**What happened.** While auditing the OTA-release docs, `origin/production`
+— the branch
+[`production-deployment.md`](../07-deployment-view/production-deployment.md)
+names as the prod services source — was found sitting far behind `main`
+with a divergent history, while the **live** services clearly run
+`main`-only code: e.g. the #142 admin-session endpoints
+(`POST /api/admin/login`) respond in production, and that commit is on
+`main` but not on `production`. So the documented deploy source does not
+match what is actually deployed.
+
+**Why it happened.** Two deploy tracks share the repo — firmware OTA (cut
+on `main` + `prod-*` tags) and the Docker services (documented as
+deployed from `production`). The services track was evidently re-pointed
+at `main` (or deployed ad hoc) without updating the `production` branch
+or the doc, so the branch became a stale artifact that still reads as
+authoritative.
+
+**How to avoid it next time.** Pick and document one services deploy
+source. If services now deploy from `main`, update
+[`production-deployment.md`](../07-deployment-view/production-deployment.md)
+and retire the `production` branch; if `production` is still intended,
+fast-forward it on every services deploy. Until reconciled, do not trust
+the `production` branch as a picture of prod. Firmware OTA is unaffected
+(it lives on `main` + `prod-*` tags) — see
+[`firmware-release.md` → Git: branch & tag model](../07-deployment-view/firmware-release.md#git-branch--tag-model).
+
 ### Production API key shipped in the public JS bundle; the `/admin` gate authenticated nothing (issue #142)
 
 **What happened.** The homepage read `VITE_API_KEY` and Vite inlined the


### PR DESCRIPTION
## What

Adds a single canonical runbook for cutting an ESP32-CAM **OTA firmware release**, and documents the surrounding model that was previously undocumented or scattered. Docs-only — no code or behaviour change.

Motivated by the documentation gap surfaced while investigating #150/#132: merging firmware *source* to `main` is **not** a release (the on-device comparator gates on `SEQUENCE`), and there was no end-to-end procedure, no record of the `prod-<codename>` tag convention, and no statement of the `main`-vs-`production` branch split.

## Changes

- **New:** [`docs/07-deployment-view/firmware-release.md`](https://github.com/schutera/highfive/blob/docs/ota-release-runbook/docs/07-deployment-view/firmware-release.md) — the end-to-end runbook (bump `VERSION`+`SEQUENCE` → `build.sh` → republish the **frontend image** → commit + `prod-<codename>` tag → verify), the `SEQUENCE`-is-the-gate comparator, the gitignored-artifact publish step, the branch/tag model, rollback, and a ground-truth source table. Includes one **mermaid** flow diagram.
- **ch11 lessons:** "Merging firmware source is not a release — the SEQUENCE bump is the release (#150, #132)" and "`production` branch drifted from the deployed services".
- **Cross-links:** chapter-07 index + the esp-flashing OTA section now point at the runbook; `production-deployment.md` notes the firmware-vs-services split + the branch drift.
- **CLAUDE.md:** a concise **"Cutting a firmware OTA release"** section with strict links to each ground-truth doc section, so future sessions can execute a release straight from the docs.

## Verification

- `bash scripts/check-doc-citations.sh` → **7 OK, 0 problems**.
- All ADR / section anchor targets verified to exist.
- Docs-only; **no manual testing required** (no code paths changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)