### PR TITLE
feat(esp): gate OTA mark-valid on first server contact (#148 Phase 3, item 3)

### DIFF
--- a/ESP32-CAM/ESP32-CAM.ino
+++ b/ESP32-CAM/ESP32-CAM.ino
@@ -7,6 +7,7 @@
 #include "breadcrumb.h"
 #include "module_id.h"
 #include "loop_health.h"
+#include "ota_rollback.h"
 #include "ota.h"
 #include <Arduino.h>
 #include <ArduinoOTA.h>
@@ -42,6 +43,14 @@ static_assert(TASK_WDT_TIMEOUT_S >= 60,
 // `forceRollbackIfPendingTooLong()` below and the comment that calls
 // it in setup() for the design context.
 #define HF_OTA_MAX_PENDING_BOOTS 3
+// Max consecutive boots a freshly-OTA'd ("unproven") slot may run WITHOUT ever
+// making successful server contact before this firmware reverts it (#148
+// Phase 3). The liveness watchdog reboots a mute slot every ~2 h, so 3 ≈ 6–8 h
+// of total silence before rollback — long enough that a transient outage is an
+// unlikely cause, short enough to self-heal a genuinely broken push same-day.
+// Only ever consulted while the "unproven" flag is set, so a proven/factory
+// slot is immune (see lib/ota_rollback and ADR-008 invariant #3).
+#define HF_OTA_MAX_NOCONTACT_BOOTS 3
 // FACTORY_RESET_SETTLE_MS and WIFI_FAIL_AP_FALLBACK_THRESH live in
 // esp_init.h alongside the NVS helpers they gate on.
 
@@ -62,75 +71,132 @@ hf::WifiHealthMonitor wifiHealth;
 // uploads only) both miss. Pure logic in lib/loop_health, native-tested.
 hf::LivenessMonitor livenessMon;
 
-// App-side OTA rollback (#26 / manual T4). Counts consecutive boots in
-// PENDING_VERIFY state. Once the threshold is exceeded, calls
-// esp_ota_mark_app_invalid_rollback_and_reboot() which forces the
-// bootloader to revert to the previously-valid slot. Required because
-// arduino-esp32's prebuilt bootloader does NOT enable
-// CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE — without this app-side check,
-// a setup()-panicking slot would reboot forever.
+// App-side OTA rollback (#26 / manual T4, extended for #148 Phase 3). Required
+// because arduino-esp32's prebuilt bootloader does NOT enable
+// CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE — without this app-side check a bad slot
+// would reboot forever. Two NVS-backed rollback triggers, both reverting via
+// esp_ota_mark_app_invalid_rollback_and_reboot():
+//   pv_boots — consecutive faulty (panic/WDT/brownout) reboots (#26)
+//   nc_boots — consecutive boots of an UNPROVEN (freshly-OTA'd) slot that never
+//              made server contact (#148; never increments for a proven slot)
+// Decision logic is the pure, native-tested state machine in lib/ota_rollback;
+// this function is the NVS + esp_ota glue around it.
 static void forceRollbackIfPendingTooLong() {
-  // Manual T4 showed that gating on `esp_ota_get_state_partition()`
-  // does not work here: arduino-esp32's prebuilt loader leaves the
-  // ROM `app_state` field untouched, and `esp_ota_set_boot_partition`
-  // in the IDF version we ship can in practice leave a newly-flashed
-  // slot reporting ESP_OTA_IMG_VALID immediately. A check that
-  // returns early when state == VALID therefore silently skips every
-  // bricked OTA, which is what round-1 + round-2 of manual T4
-  // reproduced (mining slot heartbeat→abort→heartbeat→abort with no
-  // rollback ever firing).
+  // Why not gate on esp_ota_get_state_partition(): manual T4 showed it does not
+  // work here — arduino-esp32's prebuilt loader leaves the ROM `app_state`
+  // field untouched and can leave a newly-flashed slot reporting
+  // ESP_OTA_IMG_VALID immediately, so a "return early if VALID" check silently
+  // skips every bricked OTA. Hence the state-free counter design above.
   //
-  // State-free design instead: count consecutive faulty reboots
-  // (panic/WDT/brownout) since the last successful mark-valid. A
-  // healthy slot's setup reaches the reset path at end-of-setup() and
-  // the counter cycles 0→0–1; a slot that crashes between this check
-  // and mark-valid accumulates monotonically until the threshold
-  // trips, at which point we force a bootloader-side rollback to the
-  // previous slot.
-  //
-  // Reset-reason gate: count only boots whose previous run died
-  // ungracefully (PANIC/TASK_WDT/INT_WDT/BROWNOUT). Clean reboots
-  // (POWERON, EXT, SW, DEEPSLEEP) do NOT increment, because the
-  // existing AP-fallback path in `setup()` and `setupWifiConnection`
-  // already calls `ESP.restart()` (reset_reason=SW) on three
-  // consecutive WiFi-join failures, and three of those in a row
-  // would otherwise hit `HF_OTA_MAX_PENDING_BOOTS = 3` and trigger a
-  // false rollback to old firmware on a transient WiFi outage. The
-  // collision was caught by senior-review of this PR before merge;
-  // see lessons-learned in chapter-11.
+  // Reset-reason gate (load-bearing — ADR-008 invariant #1): count only boots
+  // whose previous run died ungracefully (PANIC/TASK_WDT/INT_WDT/BROWNOUT).
+  // Clean reboots (POWERON, EXT, SW, DEEPSLEEP) do NOT increment pv_boots — the
+  // AP-fallback / WiFi-join-timeout and the liveness/WiFi-health watchdogs all
+  // use ESP.restart() (reset_reason=SW), so e.g. three transient WiFi outages
+  // (WIFI_FAIL_AP_FALLBACK_THRESH) can't trip the faulty counter. Collision
+  // caught by senior-review before the #26 merge; see chapter-11.
   esp_reset_reason_t rr = esp_reset_reason();
   const bool faulty = (rr == ESP_RST_PANIC) || (rr == ESP_RST_TASK_WDT) ||
                       (rr == ESP_RST_INT_WDT) || (rr == ESP_RST_WDT) ||
                       (rr == ESP_RST_BROWNOUT);
-  if (!faulty) return;
 
+  hf::OtaGateState st;
   Preferences p;
   p.begin("ota", false);
-  uint32_t attempts = p.getUInt("pv_boots", 0) + 1;
-  p.putUInt("pv_boots", attempts);
-  p.end();
+  st.unproven = p.getUChar("unproven", 0) != 0;
+  st.pvBoots  = p.getUInt("pv_boots", 0);
+  st.ncBoots  = p.getUInt("nc_boots", 0);
 
-  logf("[OTA] faulty-boot %u/%u (reset_reason=%d)",
-       (unsigned)attempts, (unsigned)HF_OTA_MAX_PENDING_BOOTS, (int)rr);
+  const hf::OtaGateAction action = hf::otaBootGate(
+      st, faulty, HF_OTA_MAX_PENDING_BOOTS, HF_OTA_MAX_NOCONTACT_BOOTS);
 
-  if (attempts >= HF_OTA_MAX_PENDING_BOOTS) {
-    logf("[OTA] threshold reached — forcing rollback");
-    // Reset the counter so the slot we roll back TO (which will boot
-    // next) starts fresh — otherwise a legitimate future OTA would
-    // see a stale counter and roll back prematurely.
-    Preferences q;
-    q.begin("ota", false);
-    q.putUInt("pv_boots", 0);
-    q.end();
+  if (action == hf::OtaGateAction::Rollback) {
+    logf("[OTA] rollback (pv=%u/%u nc=%u/%u unproven=%d rr=%d) — reverting slot",
+         (unsigned)st.pvBoots, (unsigned)HF_OTA_MAX_PENDING_BOOTS,
+         (unsigned)st.ncBoots, (unsigned)HF_OTA_MAX_NOCONTACT_BOOTS,
+         (int)st.unproven, (int)rr);
+    // Persist a clean, proven state for the slot we revert TO (it was the
+    // previously-good slot) so it can't immediately re-trip a rollback during
+    // a prolonged outage, then force the bootloader-side revert.
+    hf::otaResetForRollback(st);
+    p.putUChar("unproven", st.unproven ? 1 : 0);
+    p.putUInt("pv_boots", st.pvBoots);
+    p.putUInt("nc_boots", st.ncBoots);
+    p.end();
     delay(200);  // flush serial before reboot
-    // App-initiated rollback works regardless of bootloader's
-    // CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE setting. Returns ESP_FAIL
-    // if there is no previous valid slot to roll back to — in that
-    // case we fall through and continue setup as usual (we have no
-    // better option; the slot will keep retrying until an operator
-    // intervenes via USB).
+    // App-initiated rollback works regardless of the bootloader's
+    // CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE setting. Returns ESP_FAIL if there
+    // is no previous valid slot (factory) — then we fall through and continue
+    // setup; the slot keeps retrying until an operator intervenes via USB.
     esp_ota_mark_app_invalid_rollback_and_reboot();
+    return;
   }
+
+  // Persist only when a counter could have changed: a faulty reset bumped
+  // pv_boots, or an unproven slot counted this boot in nc_boots. A clean boot
+  // of a proven slot changes nothing, so skip the NVS write entirely — this
+  // restores the old `if (!faulty) return;` fast-path explicitly rather than
+  // leaning on NVS's identical-write dedup.
+  if (faulty || st.unproven) {
+    p.putUInt("pv_boots", st.pvBoots);
+    p.putUInt("nc_boots", st.ncBoots);
+    logf("[OTA] boot gate pv=%u/%u nc=%u/%u unproven=%d (reset_reason=%d)",
+         (unsigned)st.pvBoots, (unsigned)HF_OTA_MAX_PENDING_BOOTS,
+         (unsigned)st.ncBoots, (unsigned)HF_OTA_MAX_NOCONTACT_BOOTS,
+         (int)st.unproven, (int)rr);
+  }
+  p.end();
+}
+
+// First-good-contact handler (#148 Phase 3). Called on every successful server
+// contact (2xx heartbeat or upload). For a freshly-OTA'd ("unproven") slot the
+// FIRST contact is the proof of health the no-contact rollback path waits for —
+// so it clears `unproven` and zeroes the counters in NVS, which both satisfies
+// the no-contact gate and lets the end-of-setup() block mark the slot valid.
+//
+// CRUCIALLY this does NOT itself call esp_ota_mark_app_valid_cancel_rollback().
+// That IDF call is permanent — once a slot is ESP_OTA_IMG_VALID it can no
+// longer be reverted by esp_ota_mark_app_invalid_rollback_and_reboot() — so it
+// must stay at end-of-setup(), AFTER every stage that can panic (camera init).
+// Calling it here, before camera init, would brick a slot that gets one good
+// boot heartbeat and then panic-loops in initEspCamera (ADR-008's "every stage
+// that can panic has succeeded" mark-valid placement; senior-review P0 on this
+// PR). Clearing `unproven`
+// here is safe: a camera-init panic before end-of-setup means mark-valid never
+// fires, so the faulty-boot counter (pv_boots) still rolls the slot back.
+//
+// A static latch makes this an O(1) no-op once the slot is no longer unproven
+// (or for a proven/factory slot), so it's cheap to call from the hot
+// heartbeat/upload paths.
+static void noteServerContactForOtaGate() {
+  static bool settledThisBoot = false;
+  if (settledThisBoot) return;
+  hf::OtaGateState st;
+  Preferences p;
+  p.begin("ota", false);
+  st.unproven = p.getUChar("unproven", 0) != 0;
+  if (!st.unproven) {  // proven/factory — nothing to clear, latch and leave
+    p.end();
+    settledThisBoot = true;
+    return;
+  }
+  st.pvBoots = p.getUInt("pv_boots", 0);
+  st.ncBoots = p.getUInt("nc_boots", 0);
+  if (hf::otaOnFirstContact(st)) {  // transitions unproven→false, zeroes counters
+    p.putUChar("unproven", 0);
+    p.putUInt("pv_boots", st.pvBoots);
+    p.putUInt("nc_boots", st.ncBoots);
+    logf("[OTA] first server contact — slot proven; mark-valid deferred to end of setup()");
+  }
+  p.end();
+  settledThisBoot = true;
+}
+
+// A successful server contact feeds both loop()-health watchdogs: the liveness
+// no-contact timer (#148 item 2) and the OTA mark-valid gate (#148 item 3).
+static void onServerContact(uint32_t nowMs) {
+  livenessMon.noteContact(nowMs);
+  noteServerContactForOtaGate();
 }
 
 
@@ -439,13 +505,13 @@ void setup() {
   stageStartMs = millis();
   const bool bootHbOk = (sendHeartbeat(&esp_config) == 0);
   hbScheduler.recordResult(millis(), bootHbOk);
-  // #148 Phase 3: a 2xx boot heartbeat already proved live server contact, so
-  // seed the liveness watchdog with it. Without this the watchdog's first
-  // knowledge is the loop-entry anchor, not the contact that actually
-  // happened — harmless today (loop entry re-anchors with a full 2 h window)
-  // but an honest anchor if kNoContactRebootMs is ever shortened.
+  // #148 Phase 3: a 2xx boot heartbeat is the earliest proof of live server
+  // contact — it both seeds the liveness watchdog (item 2) and, on a freshly-
+  // OTA'd slot, validates the slot + cancels rollback (item 3) before camera
+  // init. So a good OTA image that can reach the server is confirmed within
+  // seconds of boot, not deferred to the loop.
   if (bootHbOk) {
-    livenessMon.noteContact(millis());
+    onServerContact(millis());
   }
   logf("[STAGE] sendHeartbeat:boot took=%lums", millis() - stageStartMs);
   /*
@@ -513,30 +579,36 @@ void setup() {
     bootPrefs.end();
   }
 
-  // OTA rollback gate (#26). If this boot is the first boot after an
-  // OTA flash, the new slot is "pending verify" — the bootloader will
-  // revert to the previous slot on the next reset unless we mark this
-  // boot good. Placed at the very end of setup() — after WiFi,
-  // registration, camera init, AND the warm-up loop — so a binary
-  // that hard-faults in any setup stage auto-rolls back without
-  // manual intervention. (An earlier draft of this gate fired before
-  // camera init on the argument that recoverCamera() handles soft
-  // NULL-frame stalls; senior-review caught that recoverCamera does
-  // NOT recover from a driver-level panic or null-deref in
-  // initEspCamera/configure_camera_sensor, so a regression there
-  // would brick the slot permanently if mark-valid had already
-  // fired. The right threshold is "every stage that can panic has
-  // succeeded".) On a non-OTA boot the call is a no-op
-  // (mark_valid_cancel_rollback is idempotent for ESP_OTA_IMG_VALID).
+  // OTA rollback gate (#26, narrowed by #148 Phase 3). Surviving setup() —
+  // WiFi, registration, camera init, AND the warm-up loop — clears the
+  // faulty-boot crash-loop counter for a proven/factory slot and (idempotently)
+  // marks it valid. (This stage placement was earned: an earlier draft fired
+  // before camera init, but senior-review caught that recoverCamera() does NOT
+  // recover from a driver-level panic in initEspCamera/configure_camera_sensor,
+  // so the right threshold is "every stage that can panic has succeeded".)
+  //
+  // For a freshly-OTA'd ("unproven") slot, surviving setup() is NO LONGER
+  // proof of health: a boots-clean-but-can't-reach-the-server image used to
+  // validate itself here and never roll back. otaOnSetupComplete() returns
+  // false for such a slot, so mark-valid is DEFERRED to the first real server
+  // contact (noteServerContactForOtaGate, fed by the boot heartbeat / loop
+  // heartbeat / upload). A slot that never phones home is reverted by the
+  // no-contact path in forceRollbackIfPendingTooLong(). See lib/ota_rollback
+  // and ADR-008's #148 addendum.
   hf::breadcrumbSet("setup:ota_mark_valid");
-  esp_ota_mark_app_valid_cancel_rollback();
-  // Slot confirmed good — clear the pending-verify boot counter so the
-  // next OTA's first boot starts at 0. Paired with the check at the top
-  // of setup() (see `forceRollbackIfPendingTooLong()`).
   {
+    hf::OtaGateState st;
     Preferences p;
     p.begin("ota", false);
-    p.putUInt("pv_boots", 0);
+    st.unproven = p.getUChar("unproven", 0) != 0;
+    st.pvBoots  = p.getUInt("pv_boots", 0);
+    st.ncBoots  = p.getUInt("nc_boots", 0);
+    if (hf::otaOnSetupComplete(st)) {
+      esp_ota_mark_app_valid_cancel_rollback();
+      p.putUInt("pv_boots", st.pvBoots);  // reset to 0 — survived setup
+    } else {
+      logf("[OTA] setup complete but slot unproven — mark-valid deferred to first contact");
+    }
     p.end();
   }
 
@@ -801,10 +873,11 @@ void loop() {
     const int hbRc = sendHeartbeat(&esp_config);
     hbScheduler.recordResult(millis(), hbRc == 0);
     // #148 Phase 3: a 2xx heartbeat is the cheapest proof of live server
-    // contact — feed the liveness watchdog so a healthy hourly cadence keeps
-    // the no-contact timer perpetually fresh.
+    // contact — keeps the liveness no-contact timer fresh (item 2) and
+    // validates a freshly-OTA'd slot if the boot heartbeat hadn't already
+    // (item 3).
     if (hbRc == 0) {
-      livenessMon.noteContact(millis());
+      onServerContact(millis());
     }
   }
 
@@ -818,7 +891,7 @@ void loop() {
     hf::breadcrumbSet("loop:captureAndUpload:first");
     if (captureAndUpload()) {
       firstCaptureDone = true;
-      livenessMon.noteContact(millis());  // #148 Phase 3: 2xx upload == live contact
+      onServerContact(millis());  // #148 Phase 3: 2xx upload == live contact (items 2+3)
     }
   }
 
@@ -841,7 +914,7 @@ void loop() {
         hf::breadcrumbSet("loop:captureAndUpload:noon");
         if (captureAndUpload()) {
           lastCaptureDay = timeinfo.tm_yday;
-          livenessMon.noteContact(millis());  // #148 Phase 3: 2xx upload == live contact
+          onServerContact(millis());  // #148 Phase 3: 2xx upload == live contact (items 2+3)
         }
       }
     }

--- a/ESP32-CAM/lib/ota_rollback/ota_rollback.cpp
+++ b/ESP32-CAM/lib/ota_rollback/ota_rollback.cpp
@@ -1,0 +1,52 @@
+#include "ota_rollback.h"
+
+namespace hf {
+
+OtaGateAction otaBootGate(OtaGateState& s, bool faultyReset,
+                          uint32_t maxFaulty, uint32_t maxNoContact) {
+  if (faultyReset) {
+    s.pvBoots += 1;
+  }
+  // Panic/WDT/brownout loop — the original #26 rollback trigger.
+  if (s.pvBoots >= maxFaulty) {
+    return OtaGateAction::Rollback;
+  }
+  if (s.unproven) {
+    // Check the threshold BEFORE counting this boot: reaching it means the
+    // previous `maxNoContact` boots all failed to validate, so revert now and
+    // don't bother giving this boot another doomed attempt. Otherwise count
+    // this boot as one more unvalidated attempt; otaOnFirstContact() clears it
+    // if contact lands later this boot.
+    if (s.ncBoots >= maxNoContact) {
+      return OtaGateAction::Rollback;
+    }
+    s.ncBoots += 1;
+  }
+  return OtaGateAction::Continue;
+}
+
+bool otaOnFirstContact(OtaGateState& s) {
+  if (!s.unproven) return false;
+  s.unproven = false;
+  s.ncBoots = 0;
+  s.pvBoots = 0;
+  return true;
+}
+
+bool otaOnSetupComplete(OtaGateState& s) {
+  if (s.unproven) {
+    // Surviving setup() is no longer proof of health for a fresh OTA slot — it
+    // must make server contact to validate. Leave counters untouched.
+    return false;
+  }
+  s.pvBoots = 0;  // proven/factory slot survived setup — clear the crash-loop count
+  return true;
+}
+
+void otaResetForRollback(OtaGateState& s) {
+  s.unproven = false;
+  s.pvBoots = 0;
+  s.ncBoots = 0;
+}
+
+}  // namespace hf

--- a/ESP32-CAM/lib/ota_rollback/ota_rollback.h
+++ b/ESP32-CAM/lib/ota_rollback/ota_rollback.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <cstdint>
+
+// Pure, host-testable decision logic for the OTA two-slot rollback gate
+// (issue #26, extended for #148 Phase 3). The firmware ships on Arduino-ESP32's
+// prebuilt bootloader, which does NOT enable CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE,
+// so rollback is driven application-side: this logic decides, from a few NVS-
+// backed counters, whether the running slot should validate itself or revert to
+// the previous (known-good) slot. See ADR-008 for the partition/rollback design
+// and its load-bearing invariants.
+//
+// Following the firmware's established pattern (lib/loop_health, lib/ota_version):
+// all state is a plain struct of integers/bools so this compiles and is exercised
+// on the native test target with no Arduino/NVS/IDF dependency. The .ino + ota.cpp
+// own the glue: reading/writing the "ota" Preferences namespace, classifying the
+// reset reason, calling esp_ota_mark_app_valid_cancel_rollback() /
+// esp_ota_mark_app_invalid_rollback_and_reboot().
+//
+// The #148 Phase 3 extension closes a gap in the original #26 design: marking the
+// slot valid merely on surviving setup() let a fresh OTA image that boots clean
+// but can never reach the server (broken TLS bundle, bad request shape, dead Wi-Fi
+// join) validate itself and never roll back. Validation now requires a real server
+// contact, and a fresh OTA that never makes one rolls back after a bounded number
+// of attempts.
+//
+// SAFETY INVARIANT (the reason this is safe by construction): the no-contact
+// rollback path is gated entirely on `unproven`, a flag set ONLY by the OTA writer
+// just before it boots a freshly-flashed slot. A factory / USB-flashed / already-
+// validated slot has unproven == false and is therefore IMMUNE to no-contact
+// rollback — a multi-hour server or Wi-Fi outage can never roll back good firmware.
+
+namespace hf {
+
+// Rollback thresholds. The .ino mirrors these as HF_OTA_MAX_PENDING_BOOTS /
+// HF_OTA_MAX_NOCONTACT_BOOTS and passes them in; these defaults are what the
+// native tests pin. 3 no-contact boots, with the loop_health liveness watchdog
+// rebooting a mute slot every ~2 h, is ~6–8 h of total radio silence before a
+// fresh OTA reverts — long enough that a transient outage is unlikely to be the
+// cause, short enough to self-heal a genuinely broken push within a workday.
+constexpr uint32_t kOtaMaxFaultyBoots = 3;     // panic/WDT/brownout loop (#26)
+constexpr uint32_t kOtaMaxNoContactBoots = 3;  // unproven slot never phones home (#148)
+
+// Persistent rollback-gate state, mirrored in NVS namespace "ota":
+//   unproven : true iff the running slot was placed by an OTA flash and has not
+//              yet proven itself by making server contact. Set ONLY by the OTA
+//              writer (ota.cpp); cleared on first contact or on rollback.
+//   pvBoots  : consecutive faulty-reset boots since last validation (#26).
+//   ncBoots  : consecutive unproven boots that did not validate (#148).
+struct OtaGateState {
+  bool unproven = false;
+  uint32_t pvBoots = 0;
+  uint32_t ncBoots = 0;
+};
+
+enum class OtaGateAction {
+  Continue,  // proceed with setup()
+  Rollback,  // caller: persist resetForRollback(), then revert the slot
+};
+
+// Called once at setup() start, after the caller has read `s` from NVS and
+// classified whether the PREVIOUS run ended in a faulty reset (panic/WDT/
+// brownout — NOT a clean ESP_RST_SW; see ADR-008 invariant #1). Mutates `s`
+// (the caller persists it) and returns whether to roll back NOW.
+//
+//  - A faulty reset increments pvBoots (unchanged #26 behaviour).
+//  - An unproven slot counts this boot as one more unvalidated attempt
+//    (increments ncBoots) — validation, if it happens later this boot, clears
+//    it via otaOnFirstContact().
+//  - Rolls back if EITHER counter has reached its threshold. The threshold is
+//    checked BEFORE this boot's no-contact increment, so an unproven slot gets
+//    `maxNoContact` full boots to make contact before the (maxNoContact+1)th
+//    boot reverts it.
+OtaGateAction otaBootGate(OtaGateState& s, bool faultyReset,
+                          uint32_t maxFaulty = kOtaMaxFaultyBoots,
+                          uint32_t maxNoContact = kOtaMaxNoContactBoots);
+
+// Called on the first successful server contact of the boot (2xx heartbeat or
+// upload). Idempotent: mutates only while unproven. Returns true exactly once
+// per fresh OTA — when the caller should PERSIST the cleared state (unproven
+// false, counters zeroed). It does NOT mean "mark the app valid now": the IDF
+// esp_ota_mark_app_valid_cancel_rollback() call is permanent and must stay at
+// end-of-setup(), after the stages that can panic — see the .ino and ADR-008
+// invariant #1. Clearing `unproven` here merely lets that later block proceed
+// (and satisfies the no-contact rollback gate). Returns false for an already-
+// proven/factory slot (nothing to do).
+bool otaOnFirstContact(OtaGateState& s);
+
+// Called at end of a clean setup(). A proven/factory slot (unproven == false)
+// resets its faulty-boot counter — the existing "I survived setup" crash-loop
+// guard — and the caller marks the app valid (idempotent for a VALID slot). An
+// unproven slot does NOT reset here: surviving setup is no longer proof of
+// health, so its counters stand until it phones home. Returns true iff the
+// caller should mark the app valid + zero pvBoots.
+bool otaOnSetupComplete(OtaGateState& s);
+
+// Reset state to persist immediately before esp_ota_mark_app_invalid_rollback_
+// and_reboot(): the slot we revert TO was previously the running good slot, so
+// it boots proven with clean counters (prevents the rolled-back slot from
+// immediately re-counting toward another rollback during a prolonged outage).
+void otaResetForRollback(OtaGateState& s);
+
+}  // namespace hf

--- a/ESP32-CAM/ota.cpp
+++ b/ESP32-CAM/ota.cpp
@@ -6,6 +6,7 @@
 #include "url.h"
 
 #include <Arduino.h>
+#include <Preferences.h>
 #include <Update.h>
 #include <WiFi.h>
 #include <WiFiClient.h>
@@ -402,7 +403,21 @@ void httpOtaCheckAndApply(const esp_config_t* config) {
         logf("[OTA] Update.isFinished false after end()");
         return;
     }
-    logf("[OTA] flash complete — restarting onto new slot");
+    // Mark the just-flashed slot UNPROVEN (#148 Phase 3) before booting it.
+    // This is the ONLY place the flag is set — so a factory / USB-flashed slot
+    // is never unproven and is immune to the no-contact rollback path. The new
+    // slot clears this flag once it makes its first successful server contact
+    // (noteServerContactForOtaGate in the .ino); until then it accumulates
+    // toward rollback. Counters are zeroed so the new slot starts clean.
+    {
+        Preferences otaPrefs;
+        otaPrefs.begin("ota", false);
+        otaPrefs.putUChar("unproven", 1);
+        otaPrefs.putUInt("pv_boots", 0);
+        otaPrefs.putUInt("nc_boots", 0);
+        otaPrefs.end();
+    }
+    logf("[OTA] flash complete — slot marked unproven, restarting onto new slot");
     delay(200);
     ESP.restart();
 }

--- a/ESP32-CAM/test/test_native_ota_rollback/test_ota_rollback.cpp
+++ b/ESP32-CAM/test/test_native_ota_rollback/test_ota_rollback.cpp
@@ -1,0 +1,180 @@
+// Native (host) unit tests for the OTA rollback gate state machine
+// (lib/ota_rollback) — issue #26, extended for #148 Phase 3.
+//
+// State is injected as a plain struct, so these run on the native target with
+// no Arduino/NVS/IDF dependency. They pin the behaviours that brick or strand a
+// field module if they regress: a fresh OTA validates on contact; a mute fresh
+// OTA reverts at the threshold; a panic-loop reverts via the faulty counter;
+// and — the safety invariant — a proven/factory slot is NEVER reverted by the
+// no-contact path no matter how long it goes silent.
+
+#include <unity.h>
+
+#include "ota_rollback.h"
+
+using hf::OtaGateAction;
+using hf::OtaGateState;
+using hf::kOtaMaxFaultyBoots;
+using hf::kOtaMaxNoContactBoots;
+using hf::otaBootGate;
+using hf::otaOnFirstContact;
+using hf::otaOnSetupComplete;
+using hf::otaResetForRollback;
+
+void setUp() {}
+void tearDown() {}
+
+// Helper: simulate one boot of the gate. Returns the action; mutates state as
+// the .ino would persist it.
+static OtaGateAction boot(OtaGateState& s, bool faulty) {
+  return otaBootGate(s, faulty);
+}
+
+// ---- Faulty-reset (panic/WDT) loop — original #26 behaviour ----------------
+
+static void test_clean_boot_no_rollback(void) {
+  OtaGateState s;  // factory: proven, counters 0
+  TEST_ASSERT_EQUAL(OtaGateAction::Continue, boot(s, /*faulty=*/false));
+  TEST_ASSERT_EQUAL_UINT32(0, s.pvBoots);
+  TEST_ASSERT_EQUAL_UINT32(0, s.ncBoots);
+}
+
+static void test_faulty_loop_rolls_back_at_threshold(void) {
+  OtaGateState s;
+  // Three consecutive faulty resets → rollback on the third.
+  TEST_ASSERT_EQUAL(OtaGateAction::Continue, boot(s, true));   // pv=1
+  TEST_ASSERT_EQUAL(OtaGateAction::Continue, boot(s, true));   // pv=2
+  TEST_ASSERT_EQUAL(OtaGateAction::Rollback, boot(s, true));   // pv=3 → revert
+}
+
+static void test_faulty_count_survives_proven_slot_only_via_setup(void) {
+  // A proven slot's transient panic must NOT accumulate to a false rollback:
+  // each clean setup completion resets pvBoots (otaOnSetupComplete).
+  OtaGateState s;  // proven
+  boot(s, true);                       // pv=1 after a one-off panic
+  TEST_ASSERT_TRUE(otaOnSetupComplete(s));
+  TEST_ASSERT_EQUAL_UINT32(0, s.pvBoots);   // crash-loop guard cleared
+  boot(s, true);                       // pv=1 again, not 2
+  TEST_ASSERT_EQUAL_UINT32(1, s.pvBoots);
+}
+
+// ---- #148 Phase 3: no-contact rollback for fresh OTA slots -----------------
+
+static void test_fresh_ota_validates_on_first_contact(void) {
+  OtaGateState s;
+  s.unproven = true;  // set by ota.cpp before booting the new slot
+  TEST_ASSERT_EQUAL(OtaGateAction::Continue, boot(s, false));  // nc=1
+  // First heartbeat/upload 2xx lands this boot:
+  TEST_ASSERT_TRUE(otaOnFirstContact(s));   // → caller marks app valid
+  TEST_ASSERT_FALSE(s.unproven);
+  TEST_ASSERT_EQUAL_UINT32(0, s.ncBoots);
+  TEST_ASSERT_EQUAL_UINT32(0, s.pvBoots);
+  // Idempotent: a second contact this boot is a no-op.
+  TEST_ASSERT_FALSE(otaOnFirstContact(s));
+}
+
+static void test_mute_fresh_ota_rolls_back_after_threshold_boots(void) {
+  // Boots clean every time but never makes contact (broken request shape, dead
+  // upload URL, etc.). The liveness watchdog reboots it each cycle; nc_boots
+  // accumulates until the gate reverts it. kOtaMaxNoContactBoots full attempts,
+  // then revert on the next boot.
+  OtaGateState s;
+  s.unproven = true;
+  for (uint32_t i = 0; i < kOtaMaxNoContactBoots; ++i) {
+    TEST_ASSERT_EQUAL(OtaGateAction::Continue, boot(s, false));
+    // No otaOnFirstContact() — mute — and otaOnSetupComplete must NOT validate:
+    TEST_ASSERT_FALSE(otaOnSetupComplete(s));
+    TEST_ASSERT_TRUE(s.unproven);
+  }
+  TEST_ASSERT_EQUAL_UINT32(kOtaMaxNoContactBoots, s.ncBoots);
+  // The next boot reaches the threshold at boot-start → revert.
+  TEST_ASSERT_EQUAL(OtaGateAction::Rollback, boot(s, false));
+}
+
+static void test_fresh_ota_validates_on_last_attempt_no_rollback(void) {
+  // Edge: contact finally lands on the final allowed attempt — must NOT revert.
+  OtaGateState s;
+  s.unproven = true;
+  for (uint32_t i = 0; i < kOtaMaxNoContactBoots; ++i) {
+    TEST_ASSERT_EQUAL(OtaGateAction::Continue, boot(s, false));
+  }
+  // Contact on the last attempt:
+  TEST_ASSERT_TRUE(otaOnFirstContact(s));
+  // A subsequent boot is now a proven slot → never reverts via no-contact.
+  TEST_ASSERT_EQUAL(OtaGateAction::Continue, boot(s, false));
+}
+
+static void test_validated_then_panic_loop_still_rolls_back(void) {
+  // The sequence behind the P0: a fresh OTA gets ONE good boot heartbeat
+  // (clears unproven) and then panic-loops in a later setup stage (camera
+  // init). Because mark-valid is deferred to end-of-setup() — which the panic
+  // never reaches — the slot stays rollback-eligible and the faulty counter
+  // reverts it. (This pins the state-machine half; the .ino/IDF half — that
+  // esp_ota_mark_app_valid_cancel_rollback() is NOT called before camera init —
+  // is the part a unit test cannot see and that the bench matrix must verify.)
+  OtaGateState s;
+  s.unproven = true;
+  boot(s, false);                       // fresh OTA boot
+  TEST_ASSERT_TRUE(otaOnFirstContact(s));  // boot heartbeat lands → proven
+  TEST_ASSERT_FALSE(s.unproven);
+  // ...then panic-loops before end-of-setup (no otaOnSetupComplete reached):
+  TEST_ASSERT_EQUAL(OtaGateAction::Continue, boot(s, true));   // pv=1
+  TEST_ASSERT_EQUAL(OtaGateAction::Continue, boot(s, true));   // pv=2
+  TEST_ASSERT_EQUAL(OtaGateAction::Rollback, boot(s, true));   // pv=3 → revert
+}
+
+// ---- THE safety invariant --------------------------------------------------
+
+static void test_proven_slot_immune_to_no_contact_rollback(void) {
+  // A proven/factory slot (unproven == false) that goes silent for an unbounded
+  // number of boots — e.g. a multi-hour server or Wi-Fi outage — must NEVER be
+  // rolled back. ncBoots must never even increment.
+  OtaGateState s;  // unproven == false
+  for (int i = 0; i < 100; ++i) {
+    TEST_ASSERT_EQUAL(OtaGateAction::Continue, boot(s, false));
+    TEST_ASSERT_EQUAL_UINT32(0, s.ncBoots);
+  }
+}
+
+static void test_factory_slot_setup_complete_marks_valid(void) {
+  // A factory/USB-flashed slot (never OTA'd → unproven false) validates by
+  // surviving setup, exactly as in the pre-#148 design.
+  OtaGateState s;
+  TEST_ASSERT_TRUE(otaOnSetupComplete(s));
+}
+
+static void test_rollback_reset_leaves_clean_proven_state(void) {
+  // After reverting, the slot we boot into was previously good: clean + proven,
+  // so it can't immediately re-trip a rollback during a prolonged outage.
+  OtaGateState s;
+  s.unproven = true;
+  s.pvBoots = 2;
+  s.ncBoots = 3;
+  otaResetForRollback(s);
+  TEST_ASSERT_FALSE(s.unproven);
+  TEST_ASSERT_EQUAL_UINT32(0, s.pvBoots);
+  TEST_ASSERT_EQUAL_UINT32(0, s.ncBoots);
+  // And it now behaves as a proven slot: silence never reverts it.
+  TEST_ASSERT_EQUAL(OtaGateAction::Continue, boot(s, false));
+}
+
+static void test_thresholds_are_three(void) {
+  TEST_ASSERT_EQUAL_UINT32(3, kOtaMaxFaultyBoots);
+  TEST_ASSERT_EQUAL_UINT32(3, kOtaMaxNoContactBoots);
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_clean_boot_no_rollback);
+  RUN_TEST(test_faulty_loop_rolls_back_at_threshold);
+  RUN_TEST(test_faulty_count_survives_proven_slot_only_via_setup);
+  RUN_TEST(test_fresh_ota_validates_on_first_contact);
+  RUN_TEST(test_mute_fresh_ota_rolls_back_after_threshold_boots);
+  RUN_TEST(test_fresh_ota_validates_on_last_attempt_no_rollback);
+  RUN_TEST(test_validated_then_panic_loop_still_rolls_back);
+  RUN_TEST(test_proven_slot_immune_to_no_contact_rollback);
+  RUN_TEST(test_factory_slot_setup_complete_marks_valid);
+  RUN_TEST(test_rollback_reset_leaves_clean_proven_state);
+  RUN_TEST(test_thresholds_are_three);
+  return UNITY_END();
+}

--- a/docs/06-runtime-view/ota-update-flow.md
+++ b/docs/06-runtime-view/ota-update-flow.md
@@ -84,37 +84,60 @@ forever. Verified empirically during manual T4 of #26 (see
 [`docs/10-quality-requirements/manual-tests-ota.md`](../10-quality-requirements/manual-tests-ota.md)).
 
 `ESP32-CAM/ESP32-CAM.ino`'s `forceRollbackIfPendingTooLong`, called
-near the top of `setup()`, owns the recovery. On any boot whose
-previous run died via panic/WDT/brownout (gated by
-`esp_reset_reason()`), it increments an NVS counter
-(`Preferences("ota").pv_boots`). When the counter crosses
-`HF_OTA_MAX_PENDING_BOOTS = 3`, the app calls
-`esp_ota_mark_app_invalid_rollback_and_reboot()`, which marks the
-running slot invalid and asks the bootloader to boot the previous
-valid one. Reaching `esp_ota_mark_app_valid_cancel_rollback()` at
-the end of `setup()` resets the counter to 0. Clean reboots
-(POWERON, SW from AP-fallback, daily reboot, OTA post-flash) do not
-increment, so transient WiFi flakes that trip `WIFI_FAIL_AP_FALLBACK_THRESH`
-do not also trip rollback. Full reasoning lives in
-[`docs/09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md`](../09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md).
+near the top of `setup()`, owns the recovery. Its decision logic is the
+pure, native-tested state machine in
+[`ESP32-CAM/lib/ota_rollback`](../../ESP32-CAM/lib/ota_rollback/ota_rollback.h);
+the function is just NVS + `esp_ota` glue. There are **two** rollback triggers:
 
-The boot heartbeat fires before mark-valid, so a new-`fwVersion`
-heartbeat may briefly appear on the server (and in the dashboard's
-**Firmware** pill — see `homepage/src/components/ModulePanel.tsx`)
-while the slot is still pending verify. If camera init then panics
-and the slot rolls back, the next boot's heartbeat (from the
-previous slot) will correct the reported version. This brief
-flicker is intentional — planting the heartbeat early keeps the
-"boot latency → dashboard refresh" benefit described in the
-image-upload-flow doc.
+1. **Faulty-boot loop (#26).** On any boot whose previous run died via
+   panic/WDT/brownout (gated by `esp_reset_reason()`), it increments
+   `Preferences("ota").pv_boots`. At `HF_OTA_MAX_PENDING_BOOTS = 3` it calls
+   `esp_ota_mark_app_invalid_rollback_and_reboot()`. Clean reboots (POWERON, SW
+   from AP-fallback, daily reboot, liveness/WiFi-health recovery, OTA
+   post-flash) do not increment, so transient WiFi flakes that trip
+   `WIFI_FAIL_AP_FALLBACK_THRESH` do not also trip rollback.
+2. **No-contact loop (#148 Phase 3).** A slot flashed by OTA boots with
+   `Preferences("ota").unproven = 1` (set by `ota.cpp` before the post-flash
+   reboot — the only site that sets it). Such a slot validates only on its
+   first **server contact** (2xx heartbeat/upload), which marks the app valid
+   and clears `unproven`; merely surviving `setup()` no longer validates it.
+   Each unproven boot that fails to make contact increments `nc_boots`; at
+   `HF_OTA_MAX_NOCONTACT_BOOTS = 3` the slot is reverted. Because the liveness
+   watchdog reboots a mute slot every ~2 h, this catches a "boots-clean-but-
+   can't-reach-the-server" image (~6–8 h) that the faulty-boot trigger misses.
 
-Operator-observable: a bricked OTA shows up on the dashboard as a
-module whose **Firmware** pill keeps showing the **old** bee-name
-(the flicker corrects itself), with a breadcrumb in the next
-telemetry sidecar naming which stage of the new firmware's setup()
-failed (e.g. `setup:initEspCamera`, `setup:initNewModuleOnServer`).
-No manual intervention needed — the unit recovers on its own after
-~3 panic-reboot cycles ≈ 30–60 s.
+A **proven/factory slot** (`unproven = 0` — never OTA'd, or already validated)
+is immune to trigger 2: a multi-hour server/Wi-Fi outage never rolls back good
+firmware. Full reasoning + invariants live in
+[`docs/09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md`](../09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md)
+(see the mark-valid-on-first-contact addendum).
+
+Since #148 Phase 3, the `esp_ota_mark_app_valid_cancel_rollback()` IDF call
+**still fires only at end-of-`setup()`** (after camera init — see the "earned
+stage placement" rule below), but it is now **gated on the slot being proven**.
+The first 2xx boot/loop heartbeat clears the `unproven` flag (it does *not*
+mark-valid early — that would be permanent and would defeat the camera-panic
+rollback); the end-of-`setup()` block then marks valid for any proven slot. A
+new-`fwVersion` heartbeat appears on the server (and the dashboard's
+**Firmware** pill — see `homepage/src/components/ModulePanel.tsx`) at first
+contact, slightly before the slot is formally marked valid. Two failure modes,
+two triggers:
+
+- **Reaches the server, then panics in a later setup stage** (e.g.
+  `initEspCamera`): the panic loop reboots before end-of-`setup()`, so
+  mark-valid never fires and the slot stays revert-eligible — `pv_boots`
+  accumulates and reverts it at ~3 cycles, exactly as in the original #26
+  design. Clearing `unproven` at first contact does not undermine this.
+- **Cannot reach the server at all**: never clears `unproven`, so the
+  no-contact trigger (`nc_boots`) reverts it.
+
+Operator-observable: a bricked OTA shows up on the dashboard as a module whose
+**Firmware** pill reverts to (or never leaves) the **old** bee-name, with a
+breadcrumb in the next telemetry sidecar naming which stage of the new
+firmware's setup() failed (e.g. `setup:initEspCamera`,
+`setup:initNewModuleOnServer`, `setup:ota_mark_valid`). No manual intervention
+needed — a panic-loop recovers in ~3 cycles ≈ 30–60 s; a can't-reach-server
+image in ~6–8 h.
 
 ## Partition layout migration
 

--- a/docs/09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md
+++ b/docs/09-architecture-decisions/adr-008-firmware-ota-partition-and-rollback.md
@@ -184,11 +184,14 @@ watchdog feed.
   bootloader-config drift and is good enough for #26.
 
   **Invariants for future maintainers.** The rollback gate's
-  correctness depends on two constraints; both were surfaced by
-  senior-review of this PR and the trail of failures is in chapter 11
-  ([`docs/11-risks-and-technical-debt/README.md`](../11-risks-and-technical-debt/README.md)'s
-  "OTA rollback isn't bootloader-driven on Arduino-ESP32" entry).
-  Future changes to firmware setup() or NVS keys must preserve them:
+  correctness depends on the constraints below — #1–#3 surfaced by
+  senior-review of the #26 PR (trail of failures in chapter 11's
+  ([`docs/11-risks-and-technical-debt/README.md`](../11-risks-and-technical-debt/README.md))
+  "OTA rollback isn't bootloader-driven on Arduino-ESP32" entry), and
+  **#4 added by #148 Phase 3** (in the mark-valid-on-first-contact
+  addendum below: a proven/factory slot is immune to no-contact
+  rollback). Future changes to firmware setup() or NVS keys must
+  preserve all four:
   1. **No setup-time `ESP.restart()` for fatal-this-slot-is-broken
      signals.** `esp_reset_reason()` returns `ESP_RST_SW` after an
      `ESP.restart()` call, which the gate deliberately treats as a
@@ -232,16 +235,30 @@ watchdog feed.
      round-2 reviewer found. Search for other "after N boots
      restart" patterns before changing either constant.
 
-  3. **NVS namespace `"ota"` / key `"pv_boots"` is the hidden contract
-     between increment and reset.** The counter is incremented in
-     `forceRollbackIfPendingTooLong()` at the top of setup() and
-     reset to 0 inside the `esp_ota_mark_app_valid_cancel_rollback()`
-     block at the end of setup(). Renaming either site without the
-     other (or claiming a different NVS namespace) silently breaks
-     the contract: the counter will increment but never reset, every
-     module rolls back to its previous slot on the third boot. If
-     the NVS shape needs to change, change both sites in the same
-     commit.
+  3. **NVS namespace `"ota"` is a multi-site hidden contract.** Its
+     keys are written across several sites that must move in lockstep;
+     renaming a key (or the namespace) at one site without the others
+     silently breaks rollback. As of #148 Phase 3 the keys and their
+     sites are:
+     - `pv_boots` (faulty-boot counter, #26): incremented in
+       `forceRollbackIfPendingTooLong()` at the top of setup();
+       reset in the `esp_ota_mark_app_valid_cancel_rollback()` block
+       at end of setup(), in the first-contact path
+       (`noteServerContactForOtaGate`), and on rollback.
+     - `unproven` (fresh-OTA flag, #148): **set only** in
+       `ota.cpp`'s `httpOtaCheckAndApply` before the post-flash
+       reboot; cleared in `noteServerContactForOtaGate` (first
+       contact) and on rollback (`otaResetForRollback`). It gates the
+       entire no-contact rollback path — see Invariant #4 in the
+       mark-valid-on-first-contact addendum.
+     - `nc_boots` (no-contact counter, #148): incremented in
+       `forceRollbackIfPendingTooLong()` for an unproven slot; reset
+       on first contact and on rollback.
+
+     The decision logic over these three keys is the pure state
+     machine in `ESP32-CAM/lib/ota_rollback`; the NVS reads/writes are
+     the glue in `ESP32-CAM.ino` + `ota.cpp`. If the NVS shape needs
+     to change, change every site in the same commit.
 
 **Costs:**
 
@@ -395,3 +412,73 @@ no weaker than the rest of the manifest under the current threat
 model. A future TLS + signed-manifest ADR will close both gaps
 together — they share an implementation seam (a signed envelope) and
 splitting them would force two migration cycles instead of one.
+
+## Mark-valid-on-first-contact addendum (#148 Phase 3)
+
+The original gate (above) validated a slot by **surviving `setup()`** —
+reaching `esp_ota_mark_app_valid_cancel_rollback()` at end-of-`setup()`. Issue
+#148's field incident ("ready-peach went silent for 3 h") exposed the gap: a
+freshly-OTA'd image that boots clean, completes `setup()`, but can **never
+reach the server** (broken TLS root bundle, malformed request shape, a Wi-Fi
+join bug that associates but never routes) validates itself and is **never
+rolled back**. It just runs mute — or, with the Phase 3 liveness watchdog,
+reboots every ~2 h forever via `ESP_RST_SW`, which the faulty-boot counter
+deliberately ignores. Surviving `setup()` is necessary but not sufficient proof
+of a healthy image.
+
+**Decision.** Validation now requires a real **server contact**, not merely
+surviving `setup()`:
+
+- The OTA writer (`ota.cpp`'s `httpOtaCheckAndApply`) sets a new NVS flag
+  `ota/unproven = 1` immediately before booting the just-flashed slot, and
+  zeroes the counters. This is the **only** site that sets the flag.
+- The first 2xx heartbeat or upload (`noteServerContactForOtaGate` in the
+  `.ino`, reached via the boot heartbeat, loop heartbeat, or upload) **clears
+  `unproven`** and zeroes the counters. It does **not** itself call
+  `esp_ota_mark_app_valid_cancel_rollback()` — that IDF call is permanent (a
+  VALID slot can no longer be reverted by
+  `esp_ota_mark_app_invalid_rollback_and_reboot()`), so it stays at
+  end-of-`setup()`, **after** the stages that can panic (camera init). Clearing
+  `unproven` early is safe: a slot that gets one good heartbeat and then panics
+  in `initEspCamera` never reaches end-of-`setup()`, so mark-valid never fires
+  and the faulty-boot counter (`pv_boots`) still reverts it — preserving the
+  "every stage that can panic has succeeded" mark-valid placement (the
+  "Auto-rollback for bricked binaries" bullet under **Enables** above). (An
+  earlier draft of this PR called
+  mark-valid on the boot heartbeat, *before* camera init; senior-review flagged
+  it as a P0 reintroduction of the brick-on-camera-panic hazard.)
+- A new counter `ota/nc_boots` counts consecutive boots of an unproven slot
+  that did **not** validate. The liveness watchdog (Phase 3 item 2) reboots a
+  mute slot every ~2 h, so this accumulates; at `HF_OTA_MAX_NOCONTACT_BOOTS`
+  (3) `forceRollbackIfPendingTooLong()` reverts the slot — ~6–8 h of total
+  radio silence. A Wi-Fi-broken slot (rebooted every 10 min by the WiFi-health
+  watchdog) reverts faster, closing the "reboots forever" hole that invariant
+  #1 warns about for the no-contact case too.
+
+The decision logic is the pure, native-tested state machine in
+[`ESP32-CAM/lib/ota_rollback`](../../ESP32-CAM/lib/ota_rollback/ota_rollback.h)
+(`test_native_ota_rollback`); the `.ino`/`ota.cpp` are NVS + `esp_ota` glue.
+
+**Invariant #4 (new): a proven/factory slot is immune to no-contact rollback.**
+The entire no-contact path is gated on `unproven`, which only the OTA writer
+sets. A factory/USB-flashed slot is `unproven = 0` from birth; a slot that has
+ever made contact is cleared to 0. So `nc_boots` can never increment for a
+proven slot — a multi-hour **server or Wi-Fi outage can never roll back good
+firmware**, no matter how long it lasts. The only residual false-rollback case
+is a fresh OTA pushed immediately before a total blackout that lasts longer
+than `HF_OTA_MAX_NOCONTACT_BOOTS` × the reboot interval with **zero** successful
+contacts; the revert is to the previously-good slot and is recoverable by the
+next OTA. The 6–8 h window makes a transient outage an unlikely cause.
+
+**Migration note.** The first #148 image is flashed by *pre-*#148 firmware,
+whose `httpOtaCheckAndApply` does not set `unproven` — so that first image boots
+`unproven = 0` and is validated the old way (survives `setup()`). The
+contact-gated protection takes effect for the *next* OTA, which is cut by #148
+firmware. No bricking risk in either direction; downgrades clear `unproven` on
+rollback.
+
+**Why no new `abort()` site (respects invariant #1).** An earlier sketch made
+the liveness watchdog `abort()` (→ `ESP_RST_PANIC`) on an unproven slot so the
+faulty counter would catch it. The shipped design instead counts unproven boots
+in `nc_boots` regardless of *why* they rebooted, so the watchdog stays a clean
+`ESP.restart()` and no `ESP.restart()`-vs-`abort()` invariant is touched.

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -86,6 +86,40 @@ write the lesson here so the next contributor doesn't repeat it.
 Format: short title + **What happened** + **Why it happened** +
 **How to avoid it next time**.
 
+### Surviving `setup()` is not proof of a healthy OTA image — mark-valid gated on first server contact (#148 Phase 3)
+
+**What happened.** The #26 OTA rollback gate validated a freshly-flashed slot
+by **surviving `setup()`** (`esp_ota_mark_app_valid_cancel_rollback()` at
+end-of-`setup()`), and the faulty-boot counter only counts panic/WDT/brownout
+reboots. So an OTA image that boots clean, completes `setup()`, but can **never
+reach the server** — broken TLS root bundle, malformed heartbeat, a Wi-Fi join
+bug that associates but never routes — validated itself and was **never rolled
+back**. It ran mute (or, once the Phase 3 liveness watchdog landed, rebooted
+every ~2 h via `ESP_RST_SW`, which the counter ignores by design). The original
+gate proved "the boot path doesn't crash," not "this image actually works."
+
+**Why it happened.** "Healthy" was modelled as "didn't panic during setup,"
+which is necessary but not sufficient — a mute image clears that bar. The
+faulty-reset gate (correctly) excludes clean reboots to avoid false rollbacks on
+transient WiFi outages (ADR-008 invariant #1), but that same exclusion means a
+clean-booting-but-mute image produces no faulty resets and so never accumulates
+toward rollback.
+
+**How to avoid it next time.** #148 Phase 3 redefines validation as **first
+successful server contact** (2xx heartbeat/upload), not surviving `setup()`. An
+`ota/unproven` NVS flag — set **only** by the OTA writer before booting a new
+slot — gates a second rollback trigger (`nc_boots`): an unproven slot that never
+phones home across `HF_OTA_MAX_NOCONTACT_BOOTS` boots reverts. The flag makes it
+**safe by construction**: a proven/factory slot is `unproven = 0` and immune, so
+a multi-hour outage never rolls back good firmware. Logic is pure + native-tested
+in [`lib/ota_rollback`](../../ESP32-CAM/lib/ota_rollback/ota_rollback.h)
+(`test_native_ota_rollback`). Lesson: a self-validation signal for a remote
+auto-rollback system must assert the thing the system exists to deliver
+(reaching the server), not a cheap proxy (not crashing); and gate any
+destructive recovery on a flag that only the relevant actor can set, so the
+recovery can't fire on the innocent majority. Full design: ADR-008's
+mark-valid-on-first-contact addendum.
+
 ### Modules went silently offline within ~1 h of restart — async WiFi reconnect + unconditional heartbeat-timer advance (#143, #149)
 
 **What happened.** During the #143 investigation, two field modules

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -533,6 +533,52 @@ issue-#42 breadcrumb) before OTA-ing the fleet. Do not roll back to `mining`
 
 ---
 
+## Bench OTA download stalls on Windows: `[OTA] binary read deadline exceeded at N/…`
+
+**Symptom.** While bench-testing the HTTP boot-pull OTA
+([manual-tests-ota.md T2](10-quality-requirements/manual-tests-ota.md)) on a
+**Windows + Docker Desktop** dev stack, the module finds the update but the
+binary download dies: serial shows `[OTA] update available: … -> … seq=N`
+followed ~120 s later by `[OTA] binary read deadline exceeded at 7001/1155744`
+(the byte count varies, always ≈ one initial TCP window, 7–13 KB). Manifest
+fetches, heartbeats, registration, and image **uploads** all work; downloading
+the same `firmware.app.bin` from the host with `curl`/`Invoke-WebRequest` is
+instant.
+
+**Cause.** Docker Desktop's Windows port-forwarder does not sustain bulk
+host→Wi-Fi-client streams to a slow LAN receiver: the first receive-window's
+worth of data arrives, then the stream stalls (window updates from the ESP
+appear to be lost in the forwarder). Small request/response flows and
+client→host bulk (uploads) are unaffected, which is why everything else
+looks healthy. Host-side downloads short-circuit via loopback and never
+traverse the forwarder, so they can't reproduce it.
+
+**Fix (bench workaround).** Take Docker out of the OTA download path: serve
+`homepage/public/` from a **native** process and point a stepping-stone build
+at it. Port `55555` already has an any-program inbound allow rule ("HiveHive
+ArduinoOTA"), so no elevation is needed:
+
+```powershell
+# 1) native server: GET /firmware.json + /firmware.app.bin from homepage/public,
+#    POST /new_module + /heartbeat forwarded to localhost:8002 (see the script
+#    used in PR #161's bench validation; any static server + proxy works)
+python c:\tmp\hf_bench_ota_server.py   # listens on 0.0.0.0:55555
+```
+
+```bash
+# 2) stepping-stone build whose INIT_URL points at the native server
+cd ESP32-CAM
+PLATFORMIO_BUILD_FLAGS='-DHF_INIT_URL_DEFAULT=\"http://<LAN-IP>:55555/new_module\" -DHF_UPLOAD_URL_DEFAULT=\"http://<LAN-IP>:8000/upload\"' \
+  pio run -e esp32cam -t upload --upload-port COM9
+```
+
+Through the native server the same 1.1 MB binary downloads and flashes in
+seconds. Production is unaffected (host-nginx serves the artifacts directly;
+no Docker forwarder in the path). Linux/macOS dev stacks have not shown the
+stall.
+
+---
+
 ## Useful commands reference
 
 ```bash


### PR DESCRIPTION
Draft. **Stacked on #160** (base is the item-1+2 branch) — this diff shows only the item-3 delta. Rebase down the stack as #159 → #160 merge.

Implements #148 Phase 3 **item 3** — gate OTA mark-valid on first server contact — the item deferred from #160 as field-bricking-risk. Reviewed twice (a P0 was found and fixed; see below).

## The gap

The #26 rollback gate validated a freshly-OTA'd slot by **surviving `setup()`**, and the faulty-boot counter only counts panic/WDT/brownout reboots. So an OTA image that boots clean but can **never reach the server** (broken TLS bundle, malformed request, dead Wi-Fi route) marked itself valid and never rolled back — it ran mute, or (with #160's liveness watchdog) rebooted every ~2 h via `ESP_RST_SW`, which the counter ignores by design.

## Design — `unproven` flag, safe by construction

- New pure, native-tested state machine `ESP32-CAM/lib/ota_rollback/` (`otaBootGate` / `otaOnFirstContact` / `otaOnSetupComplete` / `otaResetForRollback`). The `.ino`/`ota.cpp` are thin NVS + `esp_ota` glue.
- `ota.cpp` sets NVS `ota/unproven=1` before booting a new slot — **the only site that sets it**, so a factory/USB slot is never unproven.
- **First contact** (boot/loop heartbeat or upload) **clears `unproven`** + zeroes counters. The actual `esp_ota_mark_app_valid_cancel_rollback()` IDF call stays **at end-of-`setup()`, after camera init** (see P0 below).
- Second rollback trigger `nc_boots` (`HF_OTA_MAX_NOCONTACT_BOOTS=3`) reverts an unproven slot that never phones home; the liveness watchdog reboots a mute slot every ~2 h so it accumulates (~6–8 h to revert).

**Safety invariant (ADR-008 #4):** the no-contact path is gated entirely on `unproven`, so a proven/factory slot can **never** be reverted by it — a multi-hour server/Wi-Fi outage cannot roll back good firmware. No new `abort()` site; the faulty-reset gate is untouched.

## Review history (two rounds)

- **Round 1 — P0 (fixed):** the first draft called `esp_ota_mark_app_valid_cancel_rollback()` on the boot heartbeat, *before* `initEspCamera`. Marking a slot `ESP_OTA_IMG_VALID` is permanent — a later camera-init panic loop could no longer be reverted, reintroducing exactly the brick hazard #26 prevented. **Fix:** first contact now only clears the `unproven` flag; the IDF mark-valid call stays at end-of-`setup()` after camera init, so a camera-panic loop still reverts via `pv_boots`. A native test (`test_validated_then_panic_loop_still_rolls_back`) pins the sequence.
- **Round 2 — clean:** P0 confirmed structurally fixed; only ADR-008 doc nits remained, now addressed (invariant renumber #3→#4, the `"ota"` NVS multi-key contract documented).

## Verification & the hard caveat

- Pure lib **host-compiled with `g++ -std=c++17`** and all assertions pass (incl. the proven-immune and validated-then-panic-loop scenarios); native `test_native_ota_rollback` (11 assertions) + `test_native_loop_health` are the CI gate.
- ⚠️ **Firmware not compile-verified or flashed** (sandbox blocks PlatformIO). This is boot-critical rollback logic. **Mandatory bench matrix before ready / any `SEQUENCE` bump:**
  1. Good OTA validates on first boot heartbeat (slot marked valid at end-of-setup).
  2. **Camera-panic loop on a slot that got one good boot heartbeat still reverts after ~3 cycles** (the P0 regression test — the single most important bench check).
  3. Mute OTA (block the upload/heartbeat server-side) reverts after ~6–8 h.
  4. Panic-in-early-setup OTA reverts via `pv_boots` (unchanged #26 path).
  5. **Proven slot survives a simulated multi-hour outage without reverting.**
  6. Factory boot + pre-#148→#148 migration unaffected.

Docs: ADR-008 mark-valid-on-first-contact addendum + invariant #4, `ota-update-flow.md` rollback section, chapter-11 lesson. Part of #148 (Phase 3).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvtV9GURF7cNihGZehWL5h)_