### PR TITLE
feat(esp): liveness self-heal watchdog + NVS-cached geolocation (#148 Phase 3, 2 of 4)

### DIFF
--- a/ESP32-CAM/ESP32-CAM.ino
+++ b/ESP32-CAM/ESP32-CAM.ino
@@ -366,9 +366,26 @@ void setup() {
 
   hf::breadcrumbSet("setup:getGeolocation");
   stageStartMs = millis();
-  const bool gotFix = getGeolocation(&esp_config);
-  logf("[STAGE] getGeolocation took=%lums fix=%s",
-       millis() - stageStartMs, gotFix ? "ok" : "deferred");
+  // #148 Phase 3: a nest doesn't move, so once we've resolved a plausible fix
+  // we cache it in NVS and skip the heap-hungry boot-time Google TLS handshake
+  // on every subsequent boot (the geo path was a standing contributor to the
+  // longhorn heap leak, and re-running it each boot bought nothing). A cache
+  // hit counts as a fix; a miss (first ever boot, or post-reflash NVS wipe)
+  // falls through to the live call, and a fresh success is persisted.
+  bool gotFix;
+  if (loadCachedGeolocation(&esp_config.geolocation)) {
+    gotFix = true;
+    logf("[STAGE] getGeolocation skipped — NVS-cached fix lat=%.2f lng=%.2f acc=%.0f",
+         esp_config.geolocation.latitude, esp_config.geolocation.longitude,
+         esp_config.geolocation.accuracy);
+  } else {
+    gotFix = getGeolocation(&esp_config);
+    logf("[STAGE] getGeolocation took=%lums fix=%s",
+         millis() - stageStartMs, gotFix ? "ok" : "deferred");
+    if (gotFix) {
+      saveCachedGeolocation(esp_config.geolocation);
+    }
+  }
 
   Serial.print("Latitude: ");
   Serial.println(esp_config.geolocation.latitude, 6);

--- a/ESP32-CAM/ESP32-CAM.ino
+++ b/ESP32-CAM/ESP32-CAM.ino
@@ -55,6 +55,12 @@ int lastCaptureDay = -1;
 // the pure logic lives in lib/loop_health and is native-tested.
 hf::HeartbeatScheduler hbScheduler;
 hf::WifiHealthMonitor wifiHealth;
+// Liveness self-heal watchdog (#148 Phase 3): reboots the module if NO server
+// contact (2xx heartbeat or 2xx upload) succeeds for kNoContactRebootMs (2 h).
+// Catches the "WiFi up, loop alive, but every call silently hangs/fails"
+// zombie that wifiHealth (WiFi-down only) and the upload breaker (failed
+// uploads only) both miss. Pure logic in lib/loop_health, native-tested.
+hf::LivenessMonitor livenessMon;
 
 // App-side OTA rollback (#26 / manual T4). Counts consecutive boots in
 // PENDING_VERIFY state. Once the threshold is exceeded, calls
@@ -414,7 +420,16 @@ void setup() {
   // in docs/06-runtime-view/ota-update-flow.md's Rollback section.
   hf::breadcrumbSet("setup:sendHeartbeat:boot");
   stageStartMs = millis();
-  hbScheduler.recordResult(millis(), sendHeartbeat(&esp_config) == 0);
+  const bool bootHbOk = (sendHeartbeat(&esp_config) == 0);
+  hbScheduler.recordResult(millis(), bootHbOk);
+  // #148 Phase 3: a 2xx boot heartbeat already proved live server contact, so
+  // seed the liveness watchdog with it. Without this the watchdog's first
+  // knowledge is the loop-entry anchor, not the contact that actually
+  // happened — harmless today (loop entry re-anchors with a full 2 h window)
+  // but an honest anchor if kNoContactRebootMs is ever shortened.
+  if (bootHbOk) {
+    livenessMon.noteContact(millis());
+  }
   logf("[STAGE] sendHeartbeat:boot took=%lums", millis() - stageStartMs);
   /*
     Camera init AFTER all WiFi/network operations to avoid DMA conflicts
@@ -729,6 +744,26 @@ void loop() {
     ESP.restart();
   }
 
+  // Liveness self-heal reboot (#148 Phase 3). The guard above only fires when
+  // WiFi is *down*; this one catches the nastier mode where WiFi is associated
+  // and the loop is alive (WDT fed) but every server call silently hangs or
+  // fails, so the module is mute yet looks healthy locally. If NO 2xx
+  // heartbeat or upload has landed for kNoContactRebootMs (2 h) we restart to
+  // re-run setup()'s clean WiFi join + TLS handshake. livenessMon.noteContact()
+  // is called below on each successful heartbeat/upload; the first
+  // shouldReboot() call anchors the clock so a just-booted module gets a full
+  // 2 h window. Like the WiFi-health reboot this is a clean ESP.restart()
+  // (ESP_RST_SW) — a server-side outage must not feed the OTA faulty-boot
+  // rollback counter (a bad firmware *image* is handled by the mark-valid
+  // gate, not by this watchdog). Distinct breadcrumb so the post-reboot
+  // telemetry shows which guard fired.
+  if (livenessMon.shouldReboot(millis())) {
+    hf::breadcrumbSet("loop:livenessReboot");
+    Serial.println("[REBOOT] no server contact > 2 h — restarting to recover");
+    delay(500);
+    ESP.restart();
+  }
+
   // Geolocation deferred-retry tick (PR II / issue #89). Cheap call —
   // returns immediately unless the boot fix failed AND the 30-minute
   // backoff has elapsed. On a successful retry it queues the new fix
@@ -748,6 +783,12 @@ void loop() {
     hf::breadcrumbSet("loop:sendHeartbeat");
     const int hbRc = sendHeartbeat(&esp_config);
     hbScheduler.recordResult(millis(), hbRc == 0);
+    // #148 Phase 3: a 2xx heartbeat is the cheapest proof of live server
+    // contact — feed the liveness watchdog so a healthy hourly cadence keeps
+    // the no-contact timer perpetually fresh.
+    if (hbRc == 0) {
+      livenessMon.noteContact(millis());
+    }
   }
 
   // First capture immediately after boot. Retry every loop iteration on
@@ -760,6 +801,7 @@ void loop() {
     hf::breadcrumbSet("loop:captureAndUpload:first");
     if (captureAndUpload()) {
       firstCaptureDone = true;
+      livenessMon.noteContact(millis());  // #148 Phase 3: 2xx upload == live contact
     }
   }
 
@@ -782,6 +824,7 @@ void loop() {
         hf::breadcrumbSet("loop:captureAndUpload:noon");
         if (captureAndUpload()) {
           lastCaptureDay = timeinfo.tm_yday;
+          livenessMon.noteContact(millis());  // #148 Phase 3: 2xx upload == live contact
         }
       }
     }

--- a/ESP32-CAM/esp_init.cpp
+++ b/ESP32-CAM/esp_init.cpp
@@ -841,11 +841,82 @@ void tickGeolocationDeferredRetry(esp_config_t *esp_config) {
     g_pending_geolocation_fix = tmp;
     g_has_pending_fix_to_report = true;
     g_needs_geolocation_retry = false;  // success: stop retrying
+    // #148 Phase 3: persist so the next boot skips the TLS call entirely.
+    saveCachedGeolocation(tmp);
     Serial.printf("[getGeolocation] deferred retry SUCCESS (lat=%.6f lng=%.6f acc=%.1f) — will report on next heartbeat\n",
                   tmp.latitude, tmp.longitude, tmp.accuracy);
   } else {
     Serial.println("[getGeolocation] deferred retry failed — will try again in 30 minutes");
   }
+}
+
+/* NVS-CACHED GEOLOCATION (#148 Phase 3) */
+// Namespace/keys are separate from the "config"/"telemetry"/"ota" namespaces
+// so a future geo-cache clear can't disturb Wi-Fi creds or counters. Floats
+// are stored individually via putFloat (rather than putBytes(struct)) so the
+// stored shape is introspectable and robust to struct padding. Note this is
+// the codebase's first putFloat; the begin/end pairing follows the existing
+// "telemetry"/"config" Preferences precedent.
+static const char *kGeoNamespace = "geo";
+
+// Boot-count TTL for the cached fix (#148 Phase 3 review). Caching the fix
+// forever would silently remove the pre-change self-healing property: a module
+// that is physically RELOCATED but merely power-cycled (not reflashed) would
+// report its old coordinates indefinitely, and duckdb-service only patches a
+// fix FROM the (0,0) sentinel (see initNewModuleOnServer), so the deferred-
+// retry path cannot correct a stale non-(0,0) cache. Re-resolving every
+// kGeoCacheMaxBoots boots restores automatic self-correction (within ~2 weeks
+// given the 24 h daily reboot) while still skipping the heap-hungry Google TLS
+// call on the other ~13/14 boots. A crash-loop inflates boot_count and would
+// re-trigger the call sooner, but attemptGeolocation's 45 KB contiguous-heap
+// floor still defers it under memory pressure.
+static const uint32_t kGeoCacheMaxBoots = 14;
+
+bool loadCachedGeolocation(geolocation_t *out) {
+  if (!out) return false;
+  preferences.begin(kGeoNamespace, true);  // read-only
+  geolocation_t fix;
+  fix.latitude  = preferences.getFloat("lat", 0.0f);
+  fix.longitude = preferences.getFloat("lng", 0.0f);
+  fix.accuracy  = preferences.getFloat("acc", 0.0f);
+  const uint32_t cachedAtBoot = preferences.getUInt("boots", 0);
+  preferences.end();  // close "geo" BEFORE getBootCount() opens "telemetry" —
+                      // the shared global `preferences` allows only one open
+                      // namespace at a time (no nesting).
+  // A fresh/empty NVS reads back the (0,0,0) defaults, which fail
+  // isPlausibleFix → reported as a cache miss so the caller does the TLS call.
+  if (!hf::isPlausibleFix(fix.latitude, fix.longitude, fix.accuracy)) {
+    return false;
+  }
+  // Stale-cache TTL. Unsigned subtraction: if boot_count ever reads lower than
+  // the cached value (e.g. the "telemetry" namespace was wiped but "geo" was
+  // not), it wraps huge → treated as stale → re-resolve, which is the safe
+  // direction.
+  const uint32_t nowBoot = getBootCount();
+  if (nowBoot - cachedAtBoot >= kGeoCacheMaxBoots) {
+    Serial.printf("[geo] cached fix stale (%u boots old) — will re-resolve\n",
+                  (unsigned)(nowBoot - cachedAtBoot));
+    return false;
+  }
+  *out = fix;
+  return true;
+}
+
+void saveCachedGeolocation(const geolocation_t &fix) {
+  // Never cache the (0,0) sentinel or any implausible value — that would make
+  // every later boot skip the TLS call AND start from a bad fix.
+  if (!hf::isPlausibleFix(fix.latitude, fix.longitude, fix.accuracy)) {
+    return;
+  }
+  const uint32_t nowBoot = getBootCount();  // read BEFORE opening "geo" (no nesting)
+  preferences.begin(kGeoNamespace, false);
+  preferences.putFloat("lat", fix.latitude);
+  preferences.putFloat("lng", fix.longitude);
+  preferences.putFloat("acc", fix.accuracy);
+  preferences.putUInt("boots", nowBoot);  // stamp the boot at which we cached
+  preferences.end();
+  Serial.printf("[geo] cached fix to NVS (lat=%.2f lng=%.2f acc=%.0f) at boot %u\n",
+                fix.latitude, fix.longitude, fix.accuracy, (unsigned)nowBoot);
 }
 
 

--- a/ESP32-CAM/esp_init.h
+++ b/ESP32-CAM/esp_init.h
@@ -117,6 +117,22 @@ void setupWifiConnection(wifi_configuration_t *wifi_config);
 bool getGeolocation(esp_config_t *esp_config);
 void initNewModuleOnServer(esp_config_t *esp_config);
 
+// NVS-cached geolocation (#148 Phase 3). A nest does not move, but the
+// boot-time Google geolocation call is a heap-hungry TLS handshake that
+// previously re-ran on every boot (a standing contributor to the longhorn
+// heap leak). Once a plausible fix is resolved we persist it; subsequent
+// boots load it and skip the TLS call entirely. The cache lives in NVS and
+// is wiped by a full reflash (eraseAll), which is the documented
+// "reconfigure / relocate = reflash" path — so a relocated module
+// re-resolves its fix.
+//   loadCachedGeolocation — returns true and fills *out only if a PLAUSIBLE
+//     fix is stored (a fresh/empty NVS reads back the (0,0,0) sentinel, which
+//     fails isPlausibleFix → cache miss → caller does the TLS call).
+//   saveCachedGeolocation — persists a fix; no-op if it isn't plausible, so
+//     the (0,0) sentinel is never cached.
+bool loadCachedGeolocation(geolocation_t *out);
+void saveCachedGeolocation(const geolocation_t &fix);
+
 // Heartbeat-side geolocation recovery (PR II / issue #89). loop()
 // schedules retries every HF_GEOLOCATION_DEFERRED_RETRY_MS while the
 // boot fix is missing; on success the next heartbeat carries the

--- a/ESP32-CAM/lib/loop_health/loop_health.cpp
+++ b/ESP32-CAM/lib/loop_health/loop_health.cpp
@@ -34,4 +34,25 @@ void HeartbeatScheduler::recordResult(uint32_t nowMs, bool ok) {
   lastOk_ = ok;
 }
 
+void LivenessMonitor::noteContact(uint32_t nowMs) {
+  primed_ = true;
+  lastContactMs_ = nowMs;
+}
+
+bool LivenessMonitor::shouldReboot(uint32_t nowMs) {
+  if (!primed_) {
+    // First observation: anchor the clock instead of treating "no contact
+    // yet" as an infinitely-stale outage. A module that has only just booted
+    // therefore gets a full threshold window to establish its first contact,
+    // and the nowMs == 0 first-tick case does not instantly reboot. Mirrors
+    // WifiHealthMonitor's tracking_ anchoring.
+    primed_ = true;
+    lastContactMs_ = nowMs;
+    return false;
+  }
+  // Unsigned subtraction wraps correctly across the millis() rollover; the
+  // 24 h daily reboot means we never approach the ~49 day wrap anyway.
+  return (nowMs - lastContactMs_) > rebootAfterMs_;
+}
+
 }  // namespace hf

--- a/ESP32-CAM/lib/loop_health/loop_health.h
+++ b/ESP32-CAM/lib/loop_health/loop_health.h
@@ -40,6 +40,20 @@ constexpr uint32_t kHeartbeatIntervalMs = 60UL * 60UL * 1000UL;
 // is not hammered, while still beating the old full-hour gap by 12x.
 constexpr uint32_t kHeartbeatRetryMs = 5UL * 60UL * 1000UL;
 
+// 2 h: if NOTHING the module sends has reached the server for this long — no
+// successful heartbeat AND no successful image upload — force a recovery
+// reboot (issue #148 Phase 3). This is the gap the other two guards miss:
+// WifiHealthMonitor only fires when WiFi is *down*, and the upload circuit
+// breaker only counts *failed* uploads (which happen ~daily) — neither
+// catches a "WiFi up, loop alive, but every server call silently hangs or
+// fails" zombie, which otherwise stays mute until the 24 h daily reboot.
+// 2 h matches the dashboard's offline window and gives the hourly heartbeat
+// + 5 min retries two full cycles to make contact before we give up. The
+// reboot is ESP.restart() (ESP_RST_SW) — deliberately NOT a panic, so a mere
+// server-side outage cannot feed the OTA faulty-boot rollback counter (a bad
+// *firmware* image is handled by the mark-valid gate, not here).
+constexpr uint32_t kNoContactRebootMs = 2UL * 60UL * 60UL * 1000UL;
+
 // Tracks how long WiFi has been continuously disconnected and decides when
 // a recovery reboot is due. Stateless w.r.t. the clock: the caller passes
 // the current millis() value and the current connectivity each tick.
@@ -88,6 +102,36 @@ class HeartbeatScheduler {
   bool primed_ = false;       // has at least one attempt been recorded?
   uint32_t lastAttemptMs_ = 0;
   bool lastOk_ = false;
+};
+
+// Liveness self-heal watchdog (issue #148 Phase 3). Tracks the last time the
+// module had SUCCESSFUL contact with the server — a 2xx heartbeat OR a 2xx
+// image upload — and asks for a recovery reboot once that goes stale. This
+// catches the silent-hang failure mode (WiFi associated, task-WDT fed, loop
+// running, but every server call hangs/fails) that neither WifiHealthMonitor
+// (WiFi-down only) nor the upload circuit breaker (failed-uploads only, and
+// uploads are ~daily) detects. Stateless w.r.t. the clock, like the monitors
+// above: the caller injects millis() and reports each success.
+class LivenessMonitor {
+ public:
+  explicit LivenessMonitor(uint32_t rebootAfterMs = kNoContactRebootMs)
+      : rebootAfterMs_(rebootAfterMs) {}
+
+  // Report a successful server contact (sendHeartbeat() == 0, or a 2xx
+  // upload). Resets the staleness timer.
+  void noteContact(uint32_t nowMs);
+
+  // Call once per loop iteration. Returns true exactly when there has been NO
+  // successful contact for strictly longer than the threshold. The FIRST call
+  // anchors the clock (so a freshly-booted module that hasn't yet reached the
+  // server gets a full threshold window, and nowMs == 0 on the first tick does
+  // not instantly trip) — same bool-flag anchoring as WifiHealthMonitor.
+  bool shouldReboot(uint32_t nowMs);
+
+ private:
+  uint32_t rebootAfterMs_;
+  bool primed_ = false;        // has the clock been anchored / a contact seen?
+  uint32_t lastContactMs_ = 0; // millis() of the most recent successful contact
 };
 
 }  // namespace hf

--- a/ESP32-CAM/test/test_native_loop_health/test_loop_health.cpp
+++ b/ESP32-CAM/test/test_native_loop_health/test_loop_health.cpp
@@ -12,9 +12,11 @@
 #include "loop_health.h"
 
 using hf::HeartbeatScheduler;
+using hf::LivenessMonitor;
 using hf::WifiHealthMonitor;
 using hf::kHeartbeatIntervalMs;
 using hf::kHeartbeatRetryMs;
+using hf::kNoContactRebootMs;
 using hf::kWifiDownRebootMs;
 
 void setUp() {}
@@ -109,6 +111,86 @@ static void test_heartbeat_success_after_failure_restores_cadence(void) {
   TEST_ASSERT_TRUE(sched.shouldSend(100 + kHeartbeatIntervalMs + 1));
 }
 
+// ---- LivenessMonitor (issue #148 Phase 3) ---------------------------------
+
+static void test_liveness_first_tick_anchors_no_reboot(void) {
+  // A freshly-booted module that hasn't reached the server yet must NOT
+  // instantly reboot — the first shouldReboot() call anchors the clock and
+  // grants a full threshold window. nowMs == 0 first tick must not trip.
+  LivenessMonitor mon;
+  TEST_ASSERT_FALSE(mon.shouldReboot(0));
+  TEST_ASSERT_FALSE(mon.shouldReboot(kNoContactRebootMs));         // exactly 2 h
+  TEST_ASSERT_TRUE(mon.shouldReboot(kNoContactRebootMs + 1));      // 2 h + 1 ms
+}
+
+static void test_liveness_contact_resets_timer(void) {
+  LivenessMonitor mon;
+  mon.shouldReboot(0);                  // anchor at 0
+  mon.noteContact(60UL * 60UL * 1000UL);  // successful contact at 1 h
+  // 2 h after the *contact* (not the anchor) is the deadline.
+  TEST_ASSERT_FALSE(mon.shouldReboot(60UL * 60UL * 1000UL + kNoContactRebootMs));
+  TEST_ASSERT_TRUE(mon.shouldReboot(60UL * 60UL * 1000UL + kNoContactRebootMs + 1));
+}
+
+static void test_liveness_healthy_hourly_contact_never_reboots(void) {
+  // A healthy module contacts the server every hour, so the staleness timer
+  // is never older than ~1 h and a reboot is never requested.
+  LivenessMonitor mon;
+  for (uint32_t h = 0; h <= 48; ++h) {
+    const uint32_t t = h * 60UL * 60UL * 1000UL;
+    TEST_ASSERT_FALSE(mon.shouldReboot(t));
+    mon.noteContact(t);  // hourly 2xx heartbeat
+  }
+}
+
+static void test_liveness_contact_just_before_deadline_resets(void) {
+  // A contact arriving just before the 2 h mark must reset the window — a
+  // module making slow-but-real progress is not rebooted.
+  LivenessMonitor mon;
+  mon.noteContact(1000);
+  const uint32_t almost = 1000 + kNoContactRebootMs - 1;  // 1 ms before deadline
+  TEST_ASSERT_FALSE(mon.shouldReboot(almost));
+  mon.noteContact(almost);                                 // fresh contact
+  TEST_ASSERT_FALSE(mon.shouldReboot(almost + kNoContactRebootMs));     // new 2 h
+  TEST_ASSERT_TRUE(mon.shouldReboot(almost + kNoContactRebootMs + 1));
+}
+
+static void test_liveness_hung_after_contact_reboots(void) {
+  // The actual failure mode the watchdog exists for: the module makes contact
+  // (a 2xx heartbeat at 1 h), then every subsequent call silently hangs. Once
+  // 2 h have elapsed since that last contact, a reboot is requested.
+  LivenessMonitor mon;
+  mon.shouldReboot(0);                          // anchor at boot
+  mon.noteContact(60UL * 60UL * 1000UL);        // healthy 1 h heartbeat
+  const uint32_t lastContact = 60UL * 60UL * 1000UL;
+  // ...then silence. Still under 2 h since contact → no reboot.
+  TEST_ASSERT_FALSE(mon.shouldReboot(lastContact + kNoContactRebootMs));     // exactly 2 h
+  // Strictly past 2 h since the last contact → reboot.
+  TEST_ASSERT_TRUE(mon.shouldReboot(lastContact + kNoContactRebootMs + 1));
+}
+
+static void test_liveness_handles_millis_rollover(void) {
+  // loop_health.cpp claims "unsigned subtraction wraps correctly across the
+  // millis() rollover" — pin it. Contact lands shortly before the uint32_t
+  // wrap; the deadline falls just after wrap. The wrapped subtraction must
+  // still measure a true ~2 h gap, not a spurious ~49-day one.
+  LivenessMonitor mon;
+  const uint32_t nearWrap = 0xFFFFFFFFUL - 1000UL;  // ~1 s before rollover
+  mon.noteContact(nearWrap);
+  // 2 h after nearWrap wraps past 0. Exactly 2 h is not yet "longer than".
+  const uint32_t atDeadline = nearWrap + kNoContactRebootMs;       // wraps
+  const uint32_t pastDeadline = nearWrap + kNoContactRebootMs + 1; // wraps
+  TEST_ASSERT_FALSE(mon.shouldReboot(atDeadline));
+  TEST_ASSERT_TRUE(mon.shouldReboot(pastDeadline));
+}
+
+static void test_liveness_threshold_is_two_hours(void) {
+  // Pin the contract: the no-contact reboot window is 2 h, comfortably above
+  // the 1 h heartbeat cadence and equal to the dashboard's offline window.
+  TEST_ASSERT_EQUAL_UINT32(2UL * 60UL * 60UL * 1000UL, kNoContactRebootMs);
+  TEST_ASSERT_TRUE(kNoContactRebootMs > kHeartbeatIntervalMs);
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_wifi_connected_never_reboots);
@@ -121,5 +203,12 @@ int main(int, char**) {
   RUN_TEST(test_heartbeat_success_waits_full_interval);
   RUN_TEST(test_heartbeat_failure_uses_short_retry);
   RUN_TEST(test_heartbeat_success_after_failure_restores_cadence);
+  RUN_TEST(test_liveness_first_tick_anchors_no_reboot);
+  RUN_TEST(test_liveness_contact_resets_timer);
+  RUN_TEST(test_liveness_healthy_hourly_contact_never_reboots);
+  RUN_TEST(test_liveness_contact_just_before_deadline_resets);
+  RUN_TEST(test_liveness_hung_after_contact_reboots);
+  RUN_TEST(test_liveness_handles_millis_rollover);
+  RUN_TEST(test_liveness_threshold_is_two_hours);
   return UNITY_END();
 }

--- a/docs/06-runtime-view/esp-reliability.md
+++ b/docs/06-runtime-view/esp-reliability.md
@@ -156,6 +156,28 @@ all three fields → stored `NULL` → type-safe on a mixed fleet mid-OTA. This
 is Phase 1 of #148; the firmware self-heal / liveness-watchdog work
 (Phases 3–4) is tracked there.
 
+### 3a. Liveness self-heal watchdog (#148 Phase 3)
+
+[`hf::LivenessMonitor`](../../ESP32-CAM/lib/loop_health/loop_health.h), ticked
+from `loop()`, closes the gap between the two guards above. The WiFi-health
+reboot (§1) only fires when WiFi is **down**; the upload circuit breaker (§3)
+only counts **failed uploads** (and uploads are ~daily). Neither catches the
+mode behind #148's "ready-peach went silent for 3 h": WiFi associated, the
+task-WDT fed, `loop()` running, but every server call silently hangs or fails
+— a module that is mute yet looks healthy locally and is only recovered by the
+24 h daily reboot. `LivenessMonitor` tracks the last **successful** server
+contact (a 2xx heartbeat **or** a 2xx upload, fed via `noteContact()` in
+`loop()`); if none lands for `kNoContactRebootMs` (**2 h** — equal to the
+dashboard offline window, and two full hourly-heartbeat cycles) it requests an
+`ESP.restart()`. The first `shouldReboot()` call anchors the clock, so a
+freshly-booted module gets a full 2 h to make first contact and `nowMs == 0`
+on the first tick does not instantly trip. The reboot is a clean `ESP_RST_SW`
+(breadcrumb `loop:livenessReboot`), **not** a panic — a transient server-side
+outage must not feed the OTA faulty-boot rollback counter; a bad firmware
+*image* is handled by the mark-valid gate, not by this watchdog. Decision
+logic is pure and native-tested in
+[`test_native_loop_health`](../../ESP32-CAM/test/test_native_loop_health/test_loop_health.cpp).
+
 ### 4. Daily reboot (with capture-skip)
 
 After 24 hours of uptime the module restarts itself. Before
@@ -245,6 +267,7 @@ firmware grep `breadcrumbSet`):
 | `getGeolocation:wifi_scan` / `:http_post` / `:get_string`                                                | `ESP32-CAM/esp_init.cpp`'s `getGeolocation` per section            |
 | `initNewModuleOnServer:http_post` / `:get_string`                                                        | `ESP32-CAM/esp_init.cpp`'s `initNewModuleOnServer` per section     |
 | `loop:sendHeartbeat` / `:captureAndUpload:first` / `:captureAndUpload:noon` / `:sleep`                   | `ESP32-CAM/ESP32-CAM.ino`'s `loop`                                 |
+| `loop:wifiHealthReboot` / `loop:livenessReboot`                                                          | `ESP32-CAM/ESP32-CAM.ino`'s `loop` reboot guards (§1 WiFi-down, §3 no-contact #148) |
 | `postImage:connect` / `:write_headers` / `:write_body` / `:read_status` / `:read_headers` / `:read_body` | `ESP32-CAM/client.cpp`'s `postImage` per section                   |
 | `sendHeartbeat:connect` / `:write` / `:read_status`                                                      | `ESP32-CAM/client.cpp`'s `sendHeartbeat` per section               |
 

--- a/docs/08-crosscutting-concepts/auth.md
+++ b/docs/08-crosscutting-concepts/auth.md
@@ -145,6 +145,24 @@ operator typing coordinates. The API key is **not a HiveHive
 secret**; it is a Google Cloud Console key tied to a specific
 project's billing account.
 
+**The call runs roughly once per nest, not once per boot (#148 Phase 3).** A
+nest rarely moves, and the geolocation path is a heap-hungry TLS handshake
+that re-ran on every boot — a standing contributor to the `longhorn` heap
+leak. So the first plausible fix is cached in NVS (namespace `geo`, via
+`saveCachedGeolocation`) and `setup()` loads it through `loadCachedGeolocation`
+to skip the Google call on most boots. The (0,0) sentinel is never cached, so
+a first-ever boot still does the live lookup.
+
+Caching forever would remove the pre-change self-healing property (every boot
+used to re-resolve location). To keep a **relocated** module from reporting
+stale coordinates indefinitely — duckdb-service only patches a fix *from*
+(0,0), so the heartbeat recovery path cannot correct a stale non-(0,0) cache —
+the cache carries a **boot-count TTL** (`kGeoCacheMaxBoots`, currently 14): the
+fix is re-resolved roughly every 14 boots (~2 weeks given the 24 h daily
+reboot), so a relocated-and-power-cycled module self-corrects automatically
+within that window without a reflash. A full reflash (`eraseAll`) also wipes
+NVS and forces immediate re-resolution.
+
 **Key never lives in source.** The literal previously sat at the
 top of `getGeolocation`'s body and ended up public on GitHub
 ([issue #18](https://github.com/schutera/highfive/issues/18)).


### PR DESCRIPTION
Draft. Recreates #160, which was auto-closed when its base branch (the #159 branch) was deleted on #159's merge — GitHub closes stacked PRs whose base disappears and won't let a closed PR be retargeted or reopened. #159 is now in `main`, so this PR shows the same Phase-3 delta against `main` directly; the head branch and both commits are unchanged from #160.

Implements 2 of the 4 items in #148 Phase 3 (firmware robustness). The other two are deliberately handled outside this PR (see bottom).

## Item 2 — Liveness self-heal watchdog

The existing guards miss the failure mode behind #148's "ready-peach went silent for 3 h": WiFi associated, task-WDT fed, `loop()` running, but every server call silently hangs/fails. `WifiHealthMonitor` only fires on WiFi *down*; the upload circuit breaker only counts *failed uploads* (~daily). Neither catches a module that's mute yet looks healthy locally — it stays silent until the 24 h daily reboot.

New `hf::LivenessMonitor` (pure, native-tested in `test_native_loop_health`): tracks the last **successful** server contact (2xx heartbeat **or** 2xx upload, fed via `noteContact()` in `loop()` and seeded by the boot heartbeat) and reboots via `ESP.restart()` if none lands for `kNoContactRebootMs` (2 h). First `shouldReboot()` anchors the clock so a fresh boot gets a full window. The reboot is a clean `ESP_RST_SW` — **not** a panic — so a server-side outage can't feed the OTA faulty-boot rollback counter (a bad firmware *image* is the mark-valid gate's job, item 3 below).

## Item 1 — NVS-cache geolocation

`getGeolocation()` — a heap-hungry Google TLS handshake — re-ran on **every** boot, a standing contributor to the `longhorn` heap leak. Now the first plausible fix is cached in NVS (`geo` namespace) and `setup()` skips the call on subsequent boots.

**Self-correction preserved (review fix):** caching forever would silently remove the old every-boot re-resolution, stranding a relocated-but-power-cycled module on stale coords (duckdb only patches *from* `(0,0)`). So the cache carries a **boot-count TTL** (`kGeoCacheMaxBoots = 14`): re-resolves ~every 2 weeks given the daily reboot, self-correcting a moved module without a reflash. The `(0,0)` sentinel is never cached.

## Item 4 — heap hygiene: already satisfied

The pre-implementation audit found `digger` already clean: every `WiFiClientSecure`/`HTTPClient` is stack-scoped or keep-alive with `.stop()`/`.end()` on **all** error paths, 8 s bounded handshakes, and a 45 KB contiguous-heap floor before geo-TLS. No code change warranted.

## Item 3 — OTA mark-valid gating: intentionally NOT here

Gating mark-valid on first good contact interacts with this firmware's **manual** rollback scheme (`forceRollbackIfPendingTooLong` + the `pv_boots` counter, which only counts *faulty* resets) in a way that's easy to get wrong in either direction — never rolling back a bad image, or rolling back good firmware on a transient outage. That's field-bricking risk, and it must not ship without a bench flash-and-watch (impossible in this sandbox). Deferred to its own PR with a written design for the mark-valid ↔ `pv_boots` ↔ liveness-reboot interaction.

## Review & verification

Senior-reviewer run on the diff: no P0; the P1s (geo-cache staleness, missing post-anchor + millis()-wrap tests) and P2s are all addressed in this PR.

⚠️ **Firmware not compile-verified** — the sandbox network policy blocks PlatformIO platform downloads, so neither `pio run -e esp32cam` nor `pio test -e native` could run here. The new logic is concentrated in the host-testable `lib/loop_health` (CI runs its Unity tests) and reviewed by eye against existing symbols. **Bench `pio` build + native test + a flash-and-watch are required before any release / `SEQUENCE` bump.**

Part of #148 (Phase 3). References #149 (loop-health lib), #89 (geolocation deferred retry).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
