### PR TITLE
docs(esp): board-config matrix + Docker-networking fix (from #154 bench session)

### DIFF
--- a/docs/07-deployment-view/esp-flashing.md
+++ b/docs/07-deployment-view/esp-flashing.md
@@ -78,9 +78,14 @@ flash`** on upload.
 Check the strap with a read-only `esptool` probe before flashing:
 
 ```powershell
+$PORT = "COM13"   # set to your board's port (Device Manager -> Ports)
 # Use whichever Python has esptool — find it with: py -3.12 -m esptool version
-py -3.12 -m esptool --port COM13 --baud 115200 flash-id
+py -3.12 -m esptool --port $PORT --baud 115200 flash-id
 ```
+
+> esptool v4+ accepts both `flash-id` (hyphen) and the legacy `flash_id`
+> (underscore); other docs here use the underscore form via `esptool.py
+> <cmd>` — they're equivalent, not typos.
 
 The output line **`Flash voltage set by a strapping pin: 3.3V`** is what
 you want. If it says **`1.8V`**, eject any micro-SD card (and disconnect

--- a/docs/07-deployment-view/esp-flashing.md
+++ b/docs/07-deployment-view/esp-flashing.md
@@ -38,9 +38,55 @@ Skip this section if the module already runs HiveHive firmware (it will open the
 
 ### Hardware variants
 
-**ESP32-CAM-MB (motherboard)** — identified by a micro-USB port and "ESP32-CAM-MB" printed on the board. Has a built-in CH340 USB-serial chip. **No FTDI adapter needed.**
+Two dimensions vary between boards: the **form factor** (how you connect
+it) and the **USB-serial chip** (which Windows driver it needs). Identify
+both before flashing — a "completely new board" that won't enumerate is
+almost always one of the chip rows below, not a firmware problem.
 
-**Bare ESP32-CAM** — no USB port. Requires a separate USB-to-TTL adapter (FTDI FT232 or CH340, 3.3 V logic) wired to GND, 5 V, U0T→RX, U0R→TX, plus IO0→GND for flash mode.
+**Form factor**
+
+| Board                          | How to connect                                                                                                                                          |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ESP32-CAM-MB** (motherboard) | Micro-USB port, plug straight into the PC. Identified by the "ESP32-CAM-MB" label + micro-USB connector. No external adapter.                           |
+| **Bare ESP32-CAM**             | No USB port. Needs a separate USB-to-TTL adapter (FTDI FT232 or CH340, **3.3 V logic**) wired to GND, 5 V, U0T→RX, U0R→TX, plus IO0→GND for flash mode. |
+
+**USB-serial chip → Windows driver** (check Device Manager → Ports, or
+`Get-PnpDevice` — the chip name shows in the device description)
+
+| Chip on the board / adapter        | Windows driver                                       | If it doesn't enumerate                                                                                                                                                                                       |
+| ---------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CH340 / CH341**                  | Usually already installed (most MB boards ship this) | Install the WCH CH340 VCP driver.                                                                                                                                                                             |
+| **CP2102 / CP210x** (Silicon Labs) | Inbox on Win11; else Silicon Labs CP210x VCP         | Windows Update driver search.                                                                                                                                                                                 |
+| **FTDI FT232R** (and clones)       | **Not inbox** — FTDI VCP driver, from Windows Update | Device shows as `FT232R USB UART` with a **warning/Error** and **no COM port**. See the fix in [troubleshooting.md → "New board enumerates but no COM port appears"](../troubleshooting.md). Needs **admin**. |
+
+> Different units of the _same_ board model can carry different chips —
+> don't assume "MB board = CH340". The FT232R case is the one that bites
+> on a fresh Windows machine, because its driver is the only one not
+> shipped with Windows.
+
+### Verify flash voltage before flashing (GPIO12 / SD-card trap)
+
+The ESP32 reads **GPIO12 (MTDI) at reset** to set the internal flash
+regulator: **low/floating → 3.3 V** (correct for the AI-Thinker board's
+flash chip), **high → 1.8 V**. The board's **micro-SD slot shares
+GPIO12** (HS2_DATA2), so **an inserted SD card can pull GPIO12 high at
+reset**, browning out the flash at 1.8 V. Symptoms: ROM `flash read err`,
+endless boot loops before any firmware banner, `esptool` erases that
+claim success in "0.0 seconds", and **`MD5 of file does not match data in
+flash`** on upload.
+
+Check the strap with a read-only `esptool` probe before flashing:
+
+```powershell
+# Use whichever Python has esptool — find it with: py -3.12 -m esptool version
+py -3.12 -m esptool --port COM13 --baud 115200 flash-id
+```
+
+The output line **`Flash voltage set by a strapping pin: 3.3V`** is what
+you want. If it says **`1.8V`**, eject any micro-SD card (and disconnect
+anything wired to GPIO12) and re-probe — it must read 3.3 V before you
+erase or flash. Full symptom/fix:
+[troubleshooting.md → "flash read err / boot loop / MD5 mismatch"](../troubleshooting.md).
 
 ### Install PlatformIO
 
@@ -192,7 +238,7 @@ cd ESP32-CAM
 pio run -e esp32cam --target upload --upload-port <port>
 ```
 
-Find the port: **Device Manager → Ports → USB-SERIAL CH340 (COMx)** on Windows; `/dev/ttyUSB0` or `/dev/cu.usbserial-*` on Linux/Mac.
+Find the port: **Device Manager → Ports** on Windows — the entry names the chip (`USB-SERIAL CH340`, `Silicon Labs CP210x`, or `USB Serial Port` for FTDI), with its `COMx` in parentheses; `/dev/ttyUSB0` or `/dev/cu.usbserial-*` on Linux/Mac. If no `COMx` appears at all, the USB-serial driver isn't bound — see the "Hardware variants" driver table above.
 
 ### Boot normally after flashing
 

--- a/docs/08-crosscutting-concepts/hardware-notes.md
+++ b/docs/08-crosscutting-concepts/hardware-notes.md
@@ -36,6 +36,36 @@ preserved (it now marks the start of upload, just after the dark
 capture). Earlier firmware set the pulse on `captureAndUpload` entry,
 which lit the LED while the camera grabbed the frame.
 
+## USB-serial chip varies per board (Windows driver)
+
+The USB-serial chip is **not the same on every board**, and that decides
+which Windows driver is needed:
+
+| Chip          | Driver on Windows                                                                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CH340 / CH341 | Usually already installed (most MB boards)                                                                                                                    |
+| CP2102/CP210x | Inbox on Win11, else Silicon Labs VCP                                                                                                                         |
+| FTDI FT232R   | **Not inbox** — pulled from Windows Update; needs **admin** to install. Until bound, the device shows as `FT232R USB UART` with an error and **no COM port**. |
+
+Don't assume "ESP32-CAM-MB ⇒ CH340" — different units of the same model
+ship different chips. The full chip→driver matrix and the fix for the
+no-COM-port FTDI case live in
+[../07-deployment-view/esp-flashing.md](../07-deployment-view/esp-flashing.md)
+and [../troubleshooting.md](../troubleshooting.md).
+
+## Flash voltage strap (GPIO12) — keep the SD slot empty when flashing
+
+GPIO12 (MTDI) is read **at reset** to set the flash regulator: low/floating
+→ 3.3 V (correct for this board's flash chip), high → 1.8 V. The on-board
+**micro-SD slot shares GPIO12**, so **an inserted SD card pulls it high**
+and browns the flash out at 1.8 V — producing ROM `flash read err`, boot
+loops before any firmware banner, `esptool` erases that "succeed" in 0.0 s,
+and `MD5 ... does not match` on upload. Confirm with a read-only probe
+before flashing — `esptool ... flash-id` prints `Flash voltage set by a
+strapping pin: 3.3V` (must not be `1.8V`). Eject the SD card and re-probe
+if it reads 1.8 V. Symptom/fix:
+[../troubleshooting.md](../troubleshooting.md).
+
 ## Wi-Fi constraints
 
 - **2.4 GHz only.** The ESP32 does not support 5 GHz Wi-Fi. If your

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -86,6 +86,34 @@ write the lesson here so the next contributor doesn't repeat it.
 Format: short title + **What happened** + **Why it happened** +
 **How to avoid it next time**.
 
+### A documented "this is unaffected" claim cost a debug session — Docker Desktop's Windows forwarder stalls ESP **uploads** too (#154 bench session)
+
+**What happened.** A freshly flashed module booted healthy, joined Wi-Fi,
+and registered, but **never uploaded an image** (`imageCount` stuck at 0).
+Serial showed the capture succeeding (real ~40 KB JPEG) then
+`[HTTP] body write failed at 28937/40104 bytes`. The
+"Bench OTA download stalls on Windows" troubleshooting entry explicitly
+said image **uploads** were *unaffected* by the Docker Desktop Windows
+port-forwarder — so that entry was initially dismissed as unrelated, and
+time was spent chasing the camera/firmware instead.
+
+**Why it happened.** The forwarder stalls **any** bulk TCP stream to/from a
+slow remote Wi-Fi client after ~one receive-window — in *both* directions.
+The original entry's "uploads unaffected" line was an untested assumption
+(the OTA bench only exercised the download direction). Reproduction from the
+host can't catch it: host→own-LAN-IP short-circuits via loopback and never
+hits the forwarder's slow-remote-client path, so a host `curl` of a 164 KB
+image succeeds while the ESP's 40 KB upload stalls.
+
+**How to avoid it next time.** (1) Don't write "X is unaffected" in a
+troubleshooting entry unless X was actually tested — an untested negative
+claim actively misleads. (2) On Windows, the fix for **all** ESP↔stack bulk
+transfers is **WSL2 mirrored networking** (`networkingMode=mirrored` in
+`~/.wslconfig`), not per-path native proxies — and after switching modes you
+**must** `docker compose down && up` (resumed containers keep stale port
+proxies that break `localhost:8000`/`:8002` entirely). Full symptom + fix:
+[troubleshooting.md → "Bulk ESP↔stack transfers stall on Windows + Docker Desktop"](../troubleshooting.md).
+
 ### Surviving `setup()` is not proof of a healthy OTA image — mark-valid gated on first server contact (#148 Phase 3)
 
 **What happened.** The #26 OTA rollback gate validated a freshly-flashed slot

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -572,49 +572,95 @@ issue-#42 breadcrumb) before OTA-ing the fleet. Do not roll back to `mining`
 
 ---
 
-## Bench OTA download stalls on Windows: `[OTA] binary read deadline exceeded at N/…`
+## Bulk ESP↔stack transfers stall on Windows + Docker Desktop (OTA download **and** image upload)
 
-**Symptom.** While bench-testing the HTTP boot-pull OTA
-([manual-tests-ota.md T2](10-quality-requirements/manual-tests-ota.md)) on a
-**Windows + Docker Desktop** dev stack, the module finds the update but the
-binary download dies: serial shows `[OTA] update available: … -> … seq=N`
-followed ~120 s later by `[OTA] binary read deadline exceeded at 7001/1155744`
-(the byte count varies, always ≈ one initial TCP window, 7–13 KB). Manifest
-fetches, heartbeats, registration, and image **uploads** all work; downloading
-the same `firmware.app.bin` from the host with `curl`/`Invoke-WebRequest` is
-instant.
+**Symptom — two faces of one bug.**
 
-**Cause.** Docker Desktop's Windows port-forwarder does not sustain bulk
-host→Wi-Fi-client streams to a slow LAN receiver: the first receive-window's
-worth of data arrives, then the stream stalls (window updates from the ESP
-appear to be lost in the forwarder). Small request/response flows and
-client→host bulk (uploads) are unaffected, which is why everything else
-looks healthy. Host-side downloads short-circuit via loopback and never
-traverse the forwarder, so they can't reproduce it.
+- **OTA download:** while bench-testing the HTTP boot-pull OTA
+  ([manual-tests-ota.md T2](10-quality-requirements/manual-tests-ota.md)),
+  serial shows `[OTA] update available: … -> … seq=N` then ~120 s later
+  `[OTA] binary read deadline exceeded at 7001/1155744` (byte count varies,
+  always ≈ one TCP window).
+- **Image upload:** the module registers and heartbeats fine, captures a
+  real frame, but the upload dies mid-body — serial shows
+  `[HTTP] body write failed at 28937/40104 bytes` /
+  `Data error. Could not send the complete image` /
+  `upload failure streak: 1/5`, and the module's `imageCount` stays 0. The
+  failure offset varies run-to-run (~29–32 KB of a ~40 KB JPEG) but always
+  lands after roughly one TCP window.
 
-**Fix (bench workaround).** Take Docker out of the OTA download path: serve
-`homepage/public/` from a **native** process and point a stepping-stone build
-at it. Port `55555` already has an any-program inbound allow rule ("HiveHive
-ArduinoOTA"), so no elevation is needed:
+In both cases small request/response flows (manifest fetch, `/new_module`
+registration, `/heartbeat`) work, and the same transfer from the **host**
+(`curl` to `localhost` *or* to the host's own LAN IP) is instant — which is
+why the stack looks healthy.
+
+> **Correction (#154 bench session):** an earlier version of this entry
+> claimed "client→host bulk (uploads) are unaffected." That is **wrong** —
+> a ~40 KB image upload from a real Wi-Fi-connected ESP stalls at ~one
+> window exactly like the OTA download. Only *small* POSTs survive; anything
+> over ~one receive-window stalls in **either** direction. The host can't
+> reproduce it because host→own-LAN-IP short-circuits via loopback and never
+> exercises the forwarder's slow-remote-client path.
+
+**Cause.** Docker Desktop's default Windows **NAT networking** (gvisor/vpnkit
+port-forwarder) does not sustain a bulk TCP stream to/from a **slow remote
+Wi-Fi client**: one receive-window of data moves, then the window updates to
+the slow client are not relayed and the stream stalls. Linux/macOS dev stacks
+don't show it; production doesn't (host-nginx serves/terminates directly, no
+forwarder in the path).
+
+**Fix (recommended) — WSL2 mirrored networking.** Removes the forwarder
+entirely; containers share the host's interfaces, so a remote Wi-Fi client
+talks to them as it would to any host service. Fixes **both** the upload and
+the OTA download in one shot (needs Windows 11 + WSL ≥ 2.0):
 
 ```powershell
-# 1) native server: GET /firmware.json + /firmware.app.bin from homepage/public,
-#    POST /new_module + /heartbeat forwarded to localhost:8002 (see the script
-#    used in PR #161's bench validation; any static server + proxy works)
+# 1) Write %USERPROFILE%\.wslconfig (ASCII, no BOM) — create or append [wsl2]:
+"[wsl2]`nnetworkingMode=mirrored" | Out-File -Encoding ascii $env:USERPROFILE\.wslconfig
+
+# 2) Quit Docker Desktop, cycle WSL, relaunch Docker Desktop:
+Get-Process "Docker Desktop" -ErrorAction SilentlyContinue | Stop-Process -Force
+wsl --shutdown
+Start-Process "C:\Program Files\Docker\Docker\Docker Desktop.exe"
+
+# 3) Confirm the mode once the engine is back:
+wsl wslinfo --networking-mode    # must print: mirrored
+```
+
+> **Mandatory after switching modes: fully recreate the containers.**
+> Resumed containers keep **stale port proxies** under the new networking
+> mode — symptom: `localhost:8000`/`localhost:8002` (and the ESP) get
+> connection-refused even though `docker compose ps` shows them healthy.
+> `docker compose restart` is **not** enough; you must:
+>
+> ```bash
+> docker compose down && docker compose up -d
+> ```
+>
+> Then verify all four answer: `curl localhost:3002/api/health`,
+> `localhost:8000/health`, `localhost:8002/health`, `localhost:5173`.
+
+Reverting is symmetric: delete `~/.wslconfig` (or the `networkingMode` line),
+`wsl --shutdown`, restart Docker Desktop, `docker compose down && up -d`.
+
+**Fix (alternative, no WSL/Docker restart) — native stepping-stone for OTA
+only.** Take Docker out of just the OTA download path by serving
+`homepage/public/` from a native process on port `55555` (already has the
+"HiveHive ArduinoOTA" inbound allow rule):
+
+```powershell
 python c:\tmp\hf_bench_ota_server.py   # listens on 0.0.0.0:55555
 ```
 
 ```bash
-# 2) stepping-stone build whose INIT_URL points at the native server
 cd ESP32-CAM
 PLATFORMIO_BUILD_FLAGS='-DHF_INIT_URL_DEFAULT=\"http://<LAN-IP>:55555/new_module\" -DHF_UPLOAD_URL_DEFAULT=\"http://<LAN-IP>:8000/upload\"' \
   pio run -e esp32cam -t upload --upload-port COM9
 ```
 
-Through the native server the same 1.1 MB binary downloads and flashes in
-seconds. Production is unaffected (host-nginx serves the artifacts directly;
-no Docker forwarder in the path). Linux/macOS dev stacks have not shown the
-stall.
+This only rescues the OTA download (the `<LAN-IP>:8000` upload still goes
+through Docker, so it does **not** fix the image-upload stall — use mirrored
+networking for that).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -174,8 +174,10 @@ If `pnputil`/disable-enable doesn't pull it (offline, or WU driver search disabl
 **Fix.** Eject the micro-SD card (and disconnect anything wired to GPIO12), then confirm the strap with a read-only probe:
 
 ```powershell
-py -3.12 -m esptool --port COM13 --baud 115200 flash-id
+$PORT = "COM13"   # your board's port
+py -3.12 -m esptool --port $PORT --baud 115200 flash-id
 # Must report: Flash voltage set by a strapping pin: 3.3V   (not 1.8V)
+# (esptool v4+ also accepts the legacy `flash_id` spelling.)
 ```
 
 Once it reads **3.3 V**, erase + flash succeed normally (the erase now takes real seconds, and the upload's `Hash of data verified.`). Hardware background: [hardware-notes.md → "Flash voltage strap"](08-crosscutting-concepts/hardware-notes.md).
@@ -615,8 +617,16 @@ talks to them as it would to any host service. Fixes **both** the upload and
 the OTA download in one shot (needs Windows 11 + WSL ≥ 2.0):
 
 ```powershell
-# 1) Write %USERPROFILE%\.wslconfig (ASCII, no BOM) — create or append [wsl2]:
-"[wsl2]`nnetworkingMode=mirrored" | Out-File -Encoding ascii $env:USERPROFILE\.wslconfig
+# 1) Add networkingMode=mirrored to %USERPROFILE%\.wslconfig. DO NOT blindly
+#    overwrite — an existing .wslconfig often holds [wsl2] memory/processor/
+#    swap limits. Create it only if absent; otherwise edit by hand.
+$cfg = "$env:USERPROFILE\.wslconfig"
+if (Test-Path $cfg) {
+  Write-Host "Existing .wslconfig found — add 'networkingMode=mirrored' under its [wsl2] section by hand:"
+  notepad $cfg
+} else {
+  "[wsl2]`nnetworkingMode=mirrored" | Out-File -Encoding ascii $cfg   # ASCII = no BOM
+}
 
 # 2) Quit Docker Desktop, cycle WSL, relaunch Docker Desktop:
 Get-Process "Docker Desktop" -ErrorAction SilentlyContinue | Stop-Process -Force
@@ -649,10 +659,15 @@ only.** Take Docker out of just the OTA download path by serving
 "HiveHive ArduinoOTA" inbound allow rule):
 
 ```powershell
+# Native server: serves GET /firmware.json + /firmware.app.bin from
+# homepage/public, and proxies POST /new_module + /heartbeat to
+# localhost:8002 (any static server + proxy works; this is the script
+# used in PR #161's bench validation — not in the repo, an ad-hoc artifact).
 python c:\tmp\hf_bench_ota_server.py   # listens on 0.0.0.0:55555
 ```
 
 ```bash
+# Stepping-stone build whose INIT_URL points at the native server.
 cd ESP32-CAM
 PLATFORMIO_BUILD_FLAGS='-DHF_INIT_URL_DEFAULT=\"http://<LAN-IP>:55555/new_module\" -DHF_UPLOAD_URL_DEFAULT=\"http://<LAN-IP>:8000/upload\"' \
   pio run -e esp32cam -t upload --upload-port COM9

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -139,7 +139,46 @@ Status `204` confirms private-IP short-circuit; status `503` confirms the upstre
 
 ### Do I need an FTDI adapter to flash?
 
-Only if you have a **bare ESP32-CAM board** (no USB port). The **ESP32-CAM-MB** variant has a built-in CH340 USB-serial chip and a micro-USB port — plug it directly into your PC. You can identify it by the "ESP32-CAM-MB" label on the board and the micro-USB connector.
+Only if you have a **bare ESP32-CAM board** (no USB port). The **ESP32-CAM-MB** variant has a built-in USB-serial chip and a micro-USB port — plug it directly into your PC. You can identify it by the "ESP32-CAM-MB" label on the board and the micro-USB connector. The built-in chip is usually a CH340, but some units ship a CP210x or an FTDI FT232R — which one matters for the **Windows driver**, see the next two entries and the [chip→driver table in esp-flashing.md](07-deployment-view/esp-flashing.md).
+
+### New board enumerates but no COM port appears (FTDI FT232R)
+
+**Symptom.** You plug in a new board and no `COMx` shows up. Device Manager (or `Get-PnpDevice -PresentOnly | ? { $_.InstanceId -match 'VID_0403' }`) lists an **`FT232R USB UART`** with a warning triangle / `Error` status, and `esptool ... flash-id` fails with "could not open port / port doesn't exist".
+
+**Root cause.** The board's USB-serial chip is an **FTDI FT232R** (`VID_0403&PID_6001`), and the FTDI VCP driver is **not shipped with Windows** (unlike CH340/CP210x, which are inbox or auto-pulled). With no driver bound, Windows assigns no COM port. The previous board "just worked" because it was a CH340, whose driver was already installed.
+
+**Fix (needs admin).** Get the FTDI driver bound so the COM-port child device is created:
+
+```powershell
+# From an ADMIN PowerShell. Re-scan + force a driver (re)bind for the device.
+pnputil /scan-devices
+$inst = (Get-PnpDevice -PresentOnly | Where-Object { $_.InstanceId -match 'VID_0403&PID_6001' }).InstanceId
+Disable-PnpDevice -InstanceId $inst -Confirm:$false; Start-Sleep 2; Enable-PnpDevice -InstanceId $inst -Confirm:$false
+```
+
+Then confirm a COM port now exists (any shell):
+
+```powershell
+Get-PnpDevice -PresentOnly | Where-Object { $_.InstanceId -match 'VID_0403' } | Select-Object Status, Class, FriendlyName
+# Expect a second row: Class=Ports, FriendlyName='USB Serial Port (COMxx)'
+```
+
+If `pnputil`/disable-enable doesn't pull it (offline, or WU driver search disabled), open **Device Manager → the FT232R device → Update driver → Search automatically** (needs internet; Windows Update hosts the FTDI driver), or install the FTDI VCP driver from <https://ftdichip.com/drivers/vcp-drivers/>. There is no `winget` package for it.
+
+### `flash read err` / endless boot loop / esptool `MD5 ... does not match` (flash at 1.8 V — SD card on GPIO12)
+
+**Symptom.** A board boot-loops with ROM messages like `flash read err, 1000` / `ets_main.c 371`, or repeated `***ERROR*** A stack overflow in task` / `TG1WDT_SYS_RESET` **before any firmware banner prints**. `esptool erase-flash` claims success in "0.0 seconds" (a real erase takes ~14 s for 4 MB), and `pio run -t upload` fails verification with **`A fatal error occurred: MD5 of file does not match data in flash!`**.
+
+**Root cause.** The ESP32 reads **GPIO12 at reset** to set the flash regulator (low/floating → 3.3 V, high → 1.8 V). The micro-SD slot shares GPIO12, so **an inserted SD card pulls it high**, running the 3.3 V flash chip at 1.8 V. Flash reads/writes are then unreliable — hence the ROM read errors, fake erases, and MD5 mismatches.
+
+**Fix.** Eject the micro-SD card (and disconnect anything wired to GPIO12), then confirm the strap with a read-only probe:
+
+```powershell
+py -3.12 -m esptool --port COM13 --baud 115200 flash-id
+# Must report: Flash voltage set by a strapping pin: 3.3V   (not 1.8V)
+```
+
+Once it reads **3.3 V**, erase + flash succeed normally (the erase now takes real seconds, and the upload's `Hash of data verified.`). Hardware background: [hardware-notes.md → "Flash voltage strap"](08-crosscutting-concepts/hardware-notes.md).
 
 ### Flash mode — upload hangs at "Connecting…"
 


### PR DESCRIPTION
## Summary

Documentation-only branch capturing lessons from a real ESP32-CAM bring-up session (alongside #154 hardware testing). Two themes, both verified live on hardware:

### 1. Board-config matrix (commit 1)
A "new board won't work" bring-up hits two prerequisites that vary per board and weren't documented:

- **USB-serial chip → Windows driver.** CH340 / CP210x are inbox or auto-pulled; **FTDI FT232R is not** — a new FTDI board enumerates as `FT232R USB UART` in *Error* with **no COM port** until the FTDI VCP driver is installed (admin). Distinct from the CH340 boards that "just work".
- **GPIO12 / SD-card flash-voltage trap.** An inserted micro-SD card pulls GPIO12 high at reset → the 3.3 V flash runs at 1.8 V → ROM `flash read err`, boot loops before any banner, fake `0.0s` erases, and `esptool` MD5 mismatch on upload. Verify with `esptool flash-id` before flashing.

Authoritative matrix + voltage-check in [esp-flashing.md](docs/07-deployment-view/esp-flashing.md); two symptom→fix entries in [troubleshooting.md](docs/troubleshooting.md); compact cross-linked reference in [hardware-notes.md](docs/08-crosscutting-concepts/hardware-notes.md).

### 2. Docker Desktop Windows forwarder stalls ESP bulk transfers (commit 2)
Corrects a prior **false** claim in troubleshooting.md that client→host image uploads were unaffected by the Docker Desktop Windows port-forwarder. A real ~40 KB upload from a Wi-Fi ESP stalls at ~one TCP window (`body write failed at 28937/40104`) exactly like the OTA download — the forwarder breaks bulk streams to/from a slow remote client in **both** directions; only small POSTs survive.

- Rewrites the entry to cover both symptoms and documents **WSL2 mirrored networking** as the systemic fix (resolves upload *and* OTA download), including the mandatory `docker compose down && up` afterward (resumed containers keep stale port proxies that 000 on :8000/:8002).
- Adds a [chapter-11 lesson](docs/11-risks-and-technical-debt/README.md): an untested "X is unaffected" claim misled the debug session; host `curl` can't reproduce (loopback short-circuit).

## Verification (all live this session)
- FTDI driver install fixed a no-COM-port board → `USB Serial Port (COM13)`.
- Flash voltage 1.8 V → 3.3 V (SD eject) → real 14 s erase + `Hash of data verified` (was fake 0.0 s + MD5 mismatch).
- Mirrored networking → a real ESP upload that stalled at ~32 KB now completes (`status: 200 Success`); the module's `imageCount` went 0 → 6.

## Review
Senior-reviewer pass done; both P1s addressed (the `.wslconfig` snippet no longer clobbers an existing file; esptool `flash-id`/`flash_id` equivalence noted). `make check-citations` clean (pre-push hook passed). Draft pending your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
