### PR TITLE
fix: build.sh links dio_qspi so release firmware keeps PSRAM (#163)

### DIFF
--- a/ESP32-CAM/build.sh
+++ b/ESP32-CAM/build.sh
@@ -3,7 +3,16 @@ set -euo pipefail
 
 SKETCH_DIR="$(cd "$(dirname "$0")" && pwd)"
 BUILD_DIR="${SKETCH_DIR}/build"
-FQBN="esp32:esp32:esp32cam"
+# FlashMode=dio is load-bearing for PSRAM (#163). The bare FQBN takes the core's
+# global default build.boot=qio, which links the qio_qspi precompiled libs +
+# a qio bootloader — but we flash in dio mode (FLASH_MODE=dio below), and that
+# lib/flash-mode mismatch makes esp_psram_init() fail at boot (PSRAM: found=0,
+# degraded VGA capture). The boards.txt FlashMode.dio menu sets BOTH
+# build.flash_mode=dio AND build.boot=dio, so the dio_qspi libs + dio bootloader
+# match the dio flash — exactly what the pio build (board JSON flash_mode=dio)
+# does, which is why pio always reported found=1. Verified on bench (COM13,
+# AI-Thinker, ESP32-D0WD-V3): qio_qspi -> found=0, dio_qspi -> found=1.
+FQBN="esp32:esp32:esp32cam:FlashMode=dio"
 
 # VERSION is the single writer for the firmware version macro. Same value
 # is injected into the firmware binary as -DFIRMWARE_VERSION and written
@@ -61,9 +70,12 @@ fi
 # Set HF_ALLOW_NO_GEO_KEY=1 to build keyless on purpose (a compile check
 # that is never flashed). The local `pio run -e esp32cam` smoke env does
 # not require the key (CI may still pass GEO_API_KEY to it as a secret on
-# main; that's the pipeline's choice, not build.sh's). We never
-# print the value — only its length — so this script can run in CI without
-# leaking the secret into build logs.
+# main; that's the pipeline's choice, not build.sh's). We never print the
+# value directly — only its length. The one place it could leak is the
+# `arduino-cli compile --verbose` output (the resolved g++ lines embed
+# -DGEO_API_KEY="<key>"), so that pipeline pipes through a sed redactor
+# before stdout/tee — see the compile invocation below. Net: this script
+# runs in CI and writes build/compile.log without leaking the secret.
 # Strip ALL whitespace from both sources (not just outer) so the env-var
 # and file paths cannot diverge on a stray trailing newline (the common
 # shape of a CI secret written via `echo "$KEY" > file`) OR an embedded
@@ -154,13 +166,40 @@ echo ""
 # so both build paths emit byte-identical partitions.bin. arduino-cli
 # takes the preset name without .csv; platformio.ini needs the .csv suffix
 # because PIO resolves the framework's built-in from tools/partitions/.
+# App macros go into compiler.{c,cpp}.extra_flags, NOT build.extra_flags (#163).
+# In the ESP32 core, boards.txt carries the PSRAM defines in build.defines
+# (-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue
+# -mfix-esp32-psram-cache-strategy=memw), but the compile recipe never references
+# {build.defines} directly — it reaches the compiler only because platform.txt
+# threads it *through* the default build.extra_flags (... {build.defines} ...).
+# Overriding build.extra_flags to inject our macros therefore silently dropped
+# BOARD_HAS_PSRAM (and -DESP32, CORE_DEBUG_LEVEL, ARDUINO_USB_CDC_ON_BOOT).
+# compiler.{c,cpp}.extra_flags are empty by default and appended by the recipe
+# alongside build.extra_flags, so they add our macros without clobbering the
+# board's build.defines. Set both c and cpp so .c lib files and the .ino/.cpp
+# sketch units all see the macros. (NB: restoring BOARD_HAS_PSRAM was necessary
+# but did NOT by itself fix PSRAM: found=0 — the FlashMode=dio FQBN above is the
+# actual found=0 fix. See the #163 lesson in chapter 11.)
+# --verbose dumps the resolved g++ command lines; the post-compile guards below
+# grep compile.log to prove BOARD_HAS_PSRAM reached g++ and the dio_qspi libs
+# were linked.
+#
+# mkdir the output dir first: `tee` opens compile.log at pipeline startup,
+# concurrently with arduino-cli — on a fresh clone (or after `rm -rf build/`)
+# the dir doesn't exist yet and `tee` aborts the whole build under pipefail
+# before arduino-cli's --output-dir would have created it.
+mkdir -p "${BUILD_DIR}"
 arduino-cli compile \
   --fqbn "${FQBN}" \
   --output-dir "${BUILD_DIR}" \
   --libraries "${SKETCH_DIR}/lib" \
-  --build-property "build.extra_flags=-DFIRMWARE_VERSION=\"${VERSION}\" -DGEO_API_KEY=\"${GEO_API_KEY}\" -DFIRMWARE_SEQUENCE=${SEQUENCE}${DEV_URL_FLAGS}" \
+  --verbose \
+  --build-property "compiler.c.extra_flags=-DFIRMWARE_VERSION=\"${VERSION}\" -DGEO_API_KEY=\"${GEO_API_KEY}\" -DFIRMWARE_SEQUENCE=${SEQUENCE}${DEV_URL_FLAGS}" \
+  --build-property "compiler.cpp.extra_flags=-DFIRMWARE_VERSION=\"${VERSION}\" -DGEO_API_KEY=\"${GEO_API_KEY}\" -DFIRMWARE_SEQUENCE=${SEQUENCE}${DEV_URL_FLAGS}" \
   --build-property "build.partitions=min_spiffs" \
-  "${SKETCH_DIR}"
+  "${SKETCH_DIR}" 2>&1 \
+  | sed -E 's/(GEO_API_KEY=)[^[:space:]]*/\1<redacted>/g' \
+  | tee "${BUILD_DIR}/compile.log"
 
 # Post-compile guard. The contract: FIRMWARE_VERSION must land in the
 # binary as a plain C string of the bee name (e.g. the bytes "carpenter"),
@@ -185,6 +224,32 @@ if ! grep -aFq "${VERSION}" "${BUILD_DIR}/ESP32-CAM.ino.bin"; then
   exit 1
 fi
 echo "Verified: FIRMWARE_VERSION=${VERSION} is in the binary as a plain string."
+
+# PSRAM guard 1/2 — the compile-time define (#163). build.extra_flags carries
+# {build.defines} (-DBOARD_HAS_PSRAM + the two psram cache-fix flags) from
+# boards.txt; if a future refactor overrides build.extra_flags again it silently
+# drops them. Necessary but NOT sufficient (see guard 2). Assert it reached g++.
+if ! grep -q -- '-DBOARD_HAS_PSRAM' "${BUILD_DIR}/compile.log"; then
+  echo "ERROR: -DBOARD_HAS_PSRAM never reached the compiler — release binary would run without PSRAM (issue #163)" >&2
+  exit 1
+fi
+echo "Verified: -DBOARD_HAS_PSRAM reached the compiler."
+
+# PSRAM guard 2/2 — the memory_type must match the flash mode (#163). This is the
+# guard that actually catches the bug that shipped: -DBOARD_HAS_PSRAM alone is not
+# enough. The ESP32 core links precompiled libs + a bootloader from
+# {compiler.sdk.path}/{build.memory_type}, where build.memory_type={build.boot}_qspi.
+# The bare FQBN defaults to build.boot=qio -> qio_qspi libs, but we flash in dio
+# mode (FLASH_MODE=dio) — that lib/flash-mode mismatch makes esp_psram_init() fail
+# at boot (found=0, degraded VGA). The FlashMode=dio FQBN above pins build.boot=dio
+# -> dio_qspi, matching the flash mode (and matching pio, which always reported
+# found=1). Bench-proven on COM13 (AI-Thinker, ESP32-D0WD-V3): qio_qspi -> found=0,
+# dio_qspi -> found=1. Assert the dio_qspi libs were linked and qio_qspi was not.
+if ! grep -aq -- '/dio_qspi' "${BUILD_DIR}/compile.log" || grep -aq -- '/qio_qspi' "${BUILD_DIR}/compile.log"; then
+  echo "ERROR: build did not link the dio_qspi memory_type (expected dio_qspi to match the dio flash mode; a qio_qspi link makes PSRAM init fail at boot — issue #163)" >&2
+  exit 1
+fi
+echo "Verified: linked dio_qspi memory_type (matches dio flash mode)."
 
 # Build the single merged binary for web flashing. arduino-cli (unlike the
 # old Arduino IDE flow) does NOT produce ESP32-CAM.ino.merged.bin on its
@@ -263,6 +328,17 @@ fi
 FLASH_MODE="${FLASH_MODE:-dio}"
 FLASH_FREQ="${FLASH_FREQ:-80m}"
 FLASH_SIZE="${FLASH_SIZE:-4MB}"
+
+# FLASH_MODE must stay dio (#163). The FQBN pins FlashMode=dio, which compiles
+# the bootloader + links the dio_qspi libs; merging the image with a non-dio
+# flash header would re-create the exact qio/dio mismatch that broke PSRAM
+# (the dio_qspi guard above can't catch a divergence here — it only sees the
+# link, not the merge header). FLASH_FREQ/FLASH_SIZE are safe to override
+# (frequency/size don't touch memory_type); flash MODE is not.
+if [ "${FLASH_MODE}" != "dio" ]; then
+  echo "ERROR: FLASH_MODE=${FLASH_MODE} but the FQBN pins FlashMode=dio — a non-dio merge header re-creates the PSRAM-breaking qio/dio mismatch (issue #163). Leave FLASH_MODE=dio." >&2
+  exit 1
+fi
 
 # Resolve a working interpreter. On Linux/macOS this is python3. On
 # Windows-from-python.org it is `python`. We MUST validate each

--- a/ESP32-CAM/platformio.ini
+++ b/ESP32-CAM/platformio.ini
@@ -62,6 +62,10 @@ build_flags =
     ${env.build_flags}
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
+; -mfix-esp32-psram-cache-strategy=memw matches boards.txt's esp32cam.build.defines
+; (and the build.sh/arduino-cli path). Without it the two build paths disagreed on
+; the PSRAM cache workaround — see #163.
+    -mfix-esp32-psram-cache-strategy=memw
 ; Pre-build hook injects two macros so the PlatformIO build path agrees
 ; with build.sh:
 ;   -DFIRMWARE_VERSION="<value>"  read from ESP32-CAM/VERSION

--- a/docs/07-deployment-view/firmware-release.md
+++ b/docs/07-deployment-view/firmware-release.md
@@ -75,6 +75,42 @@ GEO_API_KEY=...` or the gitignored `ESP32-CAM/GEO_API_KEY` file. A
    tag in step 5. `build.sh` warns on stderr if `SEQUENCE` is **lower**
    than the previously-published manifest (an accidental downgrade).
 
+   **Bench-verify PSRAM before publishing (#163).** `build.sh` is the
+   release path, and a build-config regression (a wrong `memory_type`, or a
+   dropped `-DBOARD_HAS_PSRAM`) makes the binary boot with PSRAM off and
+   upload degraded VGA/DRAM images with nothing failing loudly. `build.sh`
+   now greps its verbose `build/compile.log` and aborts unless **both**
+   `-DBOARD_HAS_PSRAM` reached g++ **and** the `dio_qspi` libs were linked —
+   but those guards are necessary, not sufficient: only flashing the release
+   binary and reading `-- PSRAM: found=1` over serial proves it (restoring
+   the define alone did **not** fix `found=0` in #163). So flash the
+   just-built merged image to **one** bench module and confirm. In
+   PowerShell, with the board on `COM9`:
+
+   ```powershell
+   python -m esptool --chip esp32 --port COM9 write_flash 0x0 ESP32-CAM/build/ESP32-CAM.ino.merged.bin
+   ```
+
+   > If `python -m esptool` errors with `module 'esptool' has no attribute
+'_main'` (a mismatched pip `esptool` shadowing the vendored one — the
+   > same trap `build.sh` guards against), flash with the bundled binary
+   > instead: `& "$env:LOCALAPPDATA\Arduino15\packages\esp32\tools\esptool_py\*\esptool.exe" --chip esp32 --port COM9 write_flash 0x0 ESP32-CAM/build/ESP32-CAM.ino.merged.bin`.
+
+   The `-- PSRAM:` line is printed by `initEspCamera`, which runs **only
+   after the module is configured and joined to Wi-Fi** — and flashing the
+   full merged image at `0x0` wipes the NVS `configured` flag, so a
+   freshly-flashed module boots into AP mode (`ESP32-Access-Point`,
+   http://192.168.4.1) and never reaches camera init. **Onboard it via the
+   AP first** (see [esp-flashing.md](esp-flashing.md)), then capture:
+
+   ```powershell
+   python scripts/esp_capture.py COM9 60          # after onboarding; expect "-- PSRAM: found=1"
+   python scripts/esp_reset.py COM9; python scripts/esp_capture.py COM9 60   # repeat a couple of boots
+   ```
+
+   If any boot reports `found=0`, **do not publish** — rebuild and re-verify
+   (see [risks ch. 11 → "`build.sh` release binaries ran without PSRAM"](../11-risks-and-technical-debt/README.md#lessons-learned)).
+
 3. **Publish the artifacts to prod.** The three files are **gitignored
    build outputs** (the `*.bin` glob and the explicit
    `homepage/public/firmware.json` line in [.gitignore](../../.gitignore)),

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -86,6 +86,64 @@ write the lesson here so the next contributor doesn't repeat it.
 Format: short title + **What happened** + **Why it happened** +
 **How to avoid it next time**.
 
+### `build.sh` release binaries ran without PSRAM — the FQBN's missing `FlashMode=dio` linked `qio_qspi` libs against a `dio`-flashed image (#163)
+
+**What happened.** A `build.sh`-built (release-path) firmware booted reporting
+`-- PSRAM: found=0 size=0 bytes` and `initEspCamera` fell back to `FRAMESIZE_VGA` +
+`CAMERA_FB_IN_DRAM` + `jpeg_quality 15` (warm-up frames ~10–13 KB). Every
+`pio run -e esp32cam` binary on the **same** board reported
+`found=1 size=4192123 bytes` (frames ~22–37 KB). Because `build.sh` is the OTA
+release path, every field module would silently upload degraded images after the
+next OTA, with nothing failing loudly.
+
+**The false lead (a real bug, but not this symptom's cause).** First diagnosis:
+`build.sh`'s `--build-property "build.extra_flags=…app macros…"` wholesale-replaced
+the ESP32 core's default `build.extra_flags`, which is the only thing that threads
+`{build.defines}` — i.e. `-DBOARD_HAS_PSRAM` + the two psram cache-fix flags — into
+the compile recipe (`platform.txt`'s `recipe.cpp.o.pattern` references
+`{build.extra_flags}`, never `{build.defines}` directly). That genuinely dropped
+`BOARD_HAS_PSRAM` (and `-DESP32`, `CORE_DEBUG_LEVEL`, `ARDUINO_USB_CDC_ON_BOOT`), so
+it was fixed by moving app macros to the empty-by-default `compiler.c.extra_flags` /
+`compiler.cpp.extra_flags` slots. **But flashing the define-fixed binary still gave
+`found=0`.** A compile-flag audit passed; the symptom didn't move. This is the
+lesson's core: _the define reaching the compiler was necessary but not sufficient,
+and only a bench flash + serial check exposed that._
+
+**The real cause (bench-isolated).** With the defines now identical between the two
+builds, the only remaining difference was `build.memory_type`: **pio linked
+`dio_qspi`, `build.sh` linked `qio_qspi`.** The core's link/compile recipe pulls
+precompiled libraries _and the bootloader_ from
+`{compiler.sdk.path}/{build.memory_type}`, where
+`build.memory_type={build.boot}_qspi` (`platform.txt`, core 2.0.17). A bare FQBN
+(`esp32:esp32:esp32cam`) takes the global default `build.boot=qio` → `qio_qspi`. But
+`build.sh` flashes in **dio** mode (`FLASH_MODE=dio`), and pio's board JSON pins
+`flash_mode=dio` → `dio_qspi`. So `build.sh` ran a `qio`-compiled bootloader + libs
+against a `dio`-flashed chip; that flash-mode/lib mismatch makes `esp_psram_init()`
+fail at boot. The `boards.txt` `FlashMode.dio` menu (`esp32cam.menu.FlashMode.dio`, core 2.0.17) sets **both**
+`build.flash_mode=dio` _and_ `build.boot=dio`, so selecting it via the FQBN makes the
+libs, bootloader, and flash mode all agree — matching pio, which is why pio always
+reported `found=1`. Bench-proven on COM13 (AI-Thinker, ESP32-D0WD-V3):
+`qio_qspi → found=0`, `dio_qspi → found=1`.
+
+**How to avoid it next time.**
+
+1. **A passing compile-flag/define audit does not prove runtime behaviour.** Only a
+   bench flash of the _release_ binary + a serial check (`-- PSRAM: found=1`) proves
+   PSRAM (or any boot-time hardware bring-up) actually works. Infer-from-the-binary
+   was wrong here once already this session.
+2. `build.sh` now pins `FQBN=esp32:esp32:esp32cam:FlashMode=dio` and grows **two**
+   permanent guards over its `--verbose` `build/compile.log`: (a) `-DBOARD_HAS_PSRAM`
+   reached g++, and (b) the linked memory_type is `dio_qspi` (not `qio_qspi`) so it
+   matches the dio flash mode. Guard (b) is the one that catches this class of bug.
+3. When a sketch's `arduino-cli` FQBN omits the IDE menu selections (FlashMode,
+   PSRAM, PartitionScheme…), it silently inherits core defaults that may not match
+   the board's intent or the flash parameters you pass to `esptool merge_bin`. Make
+   the menu selections explicit in the FQBN and keep them consistent with `FLASH_MODE`.
+4. Inject app macros via `compiler.{c,cpp}.extra_flags`, never by overriding
+   `build.extra_flags` (which clobbers `{build.defines}`).
+5. The release runbook (`docs/07-deployment-view/firmware-release.md`) now flashes one
+   bench module and confirms `found=1` before publishing.
+
 ### Seeded "JPEGs" are undecodable random bytes — a pixels-rendered assertion can never pass against default fixtures (#154 phase 1)
 
 **What happened.** The new `module-latest-capture.spec.ts` asserted the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -135,6 +135,36 @@ Status `204` confirms private-IP short-circuit; status `503` confirms the upstre
 
 ---
 
+### Bulk-deleting a module's images (cleanup after a capture-loop flood) — and the Windows parallel-`curl` trap
+
+**Symptom / task.** A module sent thousands of images (e.g. a stuck capture loop) and you need to delete all but a known-good handful, for **one** module only. There is **no bulk-delete endpoint** — you loop the per-file admin route `DELETE /api/images/<filename>` (it removes the DuckDB row _and_ the on-disk file; idempotent — an already-gone file returns `404`, which is success).
+
+**Two gotchas this earns:**
+
+1. **Matching gallery screenshots to server rows: filename is LOCAL time, `uploaded_at` is UTC.** The firmware names files in device-local time (`createFileName` in `ESP32-CAM/client.cpp`, TZ `CET-1CEST` set in `ESP32-CAM/esp_init.cpp`), so `esp_capture_20260613_120013.jpg` (12:00:13 CEST) is the same image the admin gallery shows as `uploaded_at` `10:00:14` UTC — a 1–2 h offset. Match on **date + filename**, not on the displayed clock. (Older rows may also carry a `<mac>_` filename prefix; the convention changed mid-history — never strip/assume it, read the real `filename` from `GET /api/images`.)
+2. **On Windows, do NOT fan out parallel `curl.exe` processes** (e.g. `xargs -P 8`). They return HTTP `000` (connection-level failure) and delete **nothing** — silent no-op. Use a **single** `curl` process with connection keep-alive, reading a `-K` config file of `url = "…"` lines. One process, reused TLS connection, reliable, ~10–20 req/s. (The duckdb writer serialises on a lock anyway, so parallelism buys nothing.)
+
+**Recipe (PowerShell).** Build the keep-list, derive the delete-list from the public listing, then drive one keep-alive `curl`:
+
+```powershell
+$mac = "b0696ef23a08"
+$key = "<HIGHFIVE_API_KEY>"   # prod admin key; sent as X-Admin-Key, never logged
+$base = "https://highfive.schutera.com"
+# 1. Pull the full row list (public read; omit limit = all rows)
+curl.exe -s "$base/api/images?module_id=$mac" -o images.json
+# 2. In a scratch .py: load images.json, subtract your keep-set of filenames,
+#    write one `url = "https://.../api/images/<filename>"` line per delete
+#    into cfg.txt, prefixed by:  request = "DELETE"  /  header = "X-Admin-Key: <key>"
+# 3. One process, connection reuse, capture status per request:
+curl.exe -s -K cfg.txt -o $null -w "%{http_code}`n" --retry 2 | Sort-Object | Group-Object
+# 4. Verify: total must equal your keep count
+curl.exe -s "$base/api/images?module_id=$mac&limit=1"
+```
+
+Expect only `200` (deleted) and `404` (already gone) — any `000`/`5xx` means the run isn't reaching the server, stop and investigate. **The UI count self-corrects:** the dashboard/admin "IMAGES" value is the live `real_image_count` ([`backend/src/database.ts`](../backend/src/database.ts)'s `fetchAndAssemble`), not the increment-only `module_configs.image_count`, so it drops as you delete — no separate counter fix needed.
+
+---
+
 ## ESP32-CAM hardware
 
 ### Do I need an FTDI adapter to flash?
@@ -208,6 +238,34 @@ cd ESP32-CAM
 build step, step 2 of the wizard 404s on the OTA URL. If you've never
 flashed firmware on this checkout, run `build.sh` first; on shared
 checkouts, regenerate after every firmware change.
+
+### Serial shows `-- PSRAM: found=0` on a `build.sh` / OTA binary (but `pio` builds report `found=1`)
+
+The board has working PSRAM, but a `build.sh`-built binary boots with it off
+and `initEspCamera` falls back to `FRAMESIZE_VGA` + `CAMERA_FB_IN_DRAM` +
+`jpeg_quality 15` (degraded ~10–13 KB frames). `pio run -e esp32cam` on the same
+board is fine (`found=1`, ~22–37 KB frames). Root cause: the `build.sh` FQBN
+omitted `FlashMode=dio`, so arduino-cli took the core default `build.boot=qio`
+and linked the `qio_qspi` precompiled libs + bootloader — but `build.sh` flashes
+in **dio** mode (`FLASH_MODE=dio`). That `qio` libs / `dio` flash mismatch makes
+`esp_psram_init()` fail at boot. pio pins `flash_mode=dio` → `dio_qspi`, so it
+always worked. Fix (already in `build.sh`): FQBN
+`esp32:esp32:esp32cam:FlashMode=dio`, which sets both `build.flash_mode=dio` and
+`build.boot=dio` → `dio_qspi` libs matching the dio flash. Confirm the build
+linked the right memory_type:
+
+```powershell
+Select-String -Path ESP32-CAM/build/compile.log -Pattern '/dio_qspi' | Select-Object -First 1   # expect a hit
+Select-String -Path ESP32-CAM/build/compile.log -Pattern '/qio_qspi' | Select-Object -First 1   # expect NOTHING
+```
+
+`build.sh` now aborts the build unless `dio_qspi` was linked (and `-DBOARD_HAS_PSRAM`
+reached g++ — a separate, also-required guard). Note: a clean compile-flag audit is
+**not** sufficient proof — restoring `-DBOARD_HAS_PSRAM` alone did not fix `found=0`;
+only flashing the release binary and reading `-- PSRAM: found=1` over serial does.
+Full background:
+[risks ch. 11 → "`build.sh` release binaries ran without PSRAM"](11-risks-and-technical-debt/README.md#lessons-learned)
+(#163).
 
 ### ArduinoOTA LAN push fails on Windows ("No response from the ESP")
 


### PR DESCRIPTION
## Summary

`build.sh` (the OTA **release** path) produced binaries that boot
`-- PSRAM: found=0` and fall back to `FRAMESIZE_VGA` + `CAMERA_FB_IN_DRAM`
+ `jpeg_quality 15` (degraded ~10–13 KB frames), while `pio run -e esp32cam`
on the same board reports `found=1` (~22–37 KB frames). Every field module
would silently upload degraded images after an OTA. Addresses #163.

## Root cause (bench-isolated on COM13, AI-Thinker ESP32-D0WD-V3)

The ESP32 core links precompiled libs **and the bootloader** from
`{compiler.sdk.path}/{build.memory_type}`, where `build.memory_type={build.boot}_qspi`.
The bare FQBN `esp32:esp32:esp32cam` takes the core default `build.boot=qio`
→ **`qio_qspi`**, but `build.sh` flashes in **dio** mode (`FLASH_MODE=dio`).
That `qio`-libs / `dio`-flash mismatch makes `esp_psram_init()` fail at boot.
pio pins `flash_mode=dio` → **`dio_qspi`**, which is why it always worked.

A first hypothesis — that overriding `build.extra_flags` dropped
`-DBOARD_HAS_PSRAM` — was a **real latent bug but not this symptom's cause**:
restoring the define still gave `found=0`. Only the bench flash exposed the
memory_type mismatch. That meta-lesson ("a green compile-flag audit does not
prove runtime behaviour") is captured in ch11.

## The fix

- **FQBN `esp32:esp32:esp32cam:FlashMode=dio`** — sets both `build.flash_mode=dio`
  and `build.boot=dio` → `dio_qspi` libs/bootloader matching the dio flash.
- App macros moved to `compiler.{c,cpp}.extra_flags` (no longer clobbers
  `{build.defines}`); `platformio.ini` gains `-mfix-esp32-psram-cache-strategy=memw`
  to match `boards.txt`.
- **Two build guards** over the compile log: `-DBOARD_HAS_PSRAM` reached g++,
  and `dio_qspi` was linked (`qio_qspi` absent) — the second catches this bug.
- A `FLASH_MODE!=dio` guard so the merge header can't diverge from the FQBN.
- `mkdir` the output dir before the verbose `tee` (fresh-clone breaker).
- **Redact `GEO_API_KEY` from `--verbose` log/stdout** (escaped + literal quote
  forms) so the key never reaches build logs/CI.

## Verification (bench, same physical board)

| build | PSRAM | frames |
| --- | --- | --- |
| pio (reference) | `found=1` / 4192123 B | 22–37 KB |
| build.sh `qio_qspi` (before) | `found=0` | 10–13 KB |
| **build.sh `dio_qspi` (this PR)** | **`found=1` / 4192123 B** | **21–35 KB** |

- Clean rebuild exit 0; all 3 guards print `Verified:`.
- Secret-leak check: `0` plaintext key occurrences in `compile.log` **and**
  stdout (every `GEO_API_KEY=` is `<redacted>`); pre-push `check-no-hardcoded-api-keys` OK.
- `pio test -e native`: 253/253.
- Reviewed by `senior-reviewer` over 3 rounds; the round-3 P0 (redaction regex
  missed arduino-cli's backslash-escaped key form) is fixed and re-verified.

## Note: unrelated entry preserved

`docs/troubleshooting.md` also carries a **pre-existing, unrelated** working-tree
entry (bulk-deleting images / Windows parallel-`curl` trap). It is not part of the
#163 fix; preserved here rather than discarded.

## Shipping this to the field — a SEPARATE OTA release (needs prod-host access)

This PR fixes `build.sh`; the fleet still runs the **broken** `blueberry`/seq 8
(`app_md5=76a4f45d…`). The corrected binary has different bytes
(`app_md5=f41c2b2d…`), so a **new release** is required — same version/sequence
won't trigger an OTA. The publish step needs SSH to the prod host, which the
build machine doesn't have. After merging, on a machine with prod access:

```bash
# 1. Bump (codename cross-checked unused vs git log VERSION + git tag prod-*)
printf leafcutter > ESP32-CAM/VERSION      # any never-used bee codename
printf 9          > ESP32-CAM/SEQUENCE      # 8 -> 9
# 2. Build (needs GEO_API_KEY); note the printed app_md5
bash ESP32-CAM/build.sh
# 3. (optional) bench-verify found=1 per the release runbook
# 4. Publish to prod host, then rebuild the frontend image there:
#    scp homepage/public/firmware.{bin,app.bin,json} <prod>:.../homepage/public/
#    ssh <prod> 'cd <repo> && docker compose -f docker-compose.prod.yml up -d --build frontend'
# 5. Verify served:
curl -s https://highfive.schutera.com/firmware.json   # expect version=leafcutter, sequence=9
# 6. Record: commit the bump on main + annotated tag prod-leafcutter (with app_md5), push
```

Full procedure: [firmware-release.md](docs/07-deployment-view/firmware-release.md).
Leaving #163 open until the release actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)