### PR TITLE
feat: admin endpoint + UI to tail server process logs (closes #171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Admin & observability
+
+- **Admin server-log endpoint + viewer (#171).** New `GET /api/admin/logs?service=backend|duckdb-service|image-service&lines=N` (admin-gated) tails a service's own recent stdout/stderr, and a **Server Logs** card on `/admin` renders it with a service switcher. Each service keeps an in-memory ring fed by a stdout/stderr tee (mirrors the ESP `logbuf`); the backend serves its own ring and proxies to the Flask services' internal `/logs`, forwarding `X-Admin-Key` (now set on all three services in the UI/prod compose). Chosen over mounting the Docker socket (host-root exposure) — see [ADR-021](docs/09-architecture-decisions/adr-021-admin-server-log-ring.md). Caveats: in-memory (resets on restart), per-process, nginx not covered.
+
 ### ESP32-CAM firmware
 
 - **Remote visibility into hourly-heartbeat failures (#172).** A _failed_ heartbeat never reaches the server (no 2xx), so the #148 diagnostic fields only ever described the boot heartbeat — in #170 the boot heartbeat returned `200` while every hourly heartbeat reboot-looped the fleet, invisible without a serial capture. `sendHeartbeat` now carries `last_hb_fail_code` / `last_hb_fail_count`: a failure streak accumulated across a session in RTC memory (new `ESP32-CAM/lib/hb_failure/`, native-tested), peeked onto each heartbeat body and cleared on the next 2xx — so the boot heartbeat after a `livenessReboot` reports _why_ the prior session's heartbeats failed. Threads through duckdb-service → backend `HeartbeatSnapshot` → a **possible reboot loop** banner in the dashboard's `HeartbeatDiagnostics` card. Older firmware omits both → `NULL` (type-safe mixed fleet). Takes effect once shipped as the #170 roll-forward (higher `SEQUENCE`).

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,8 +2,10 @@ import express from 'express';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import { tryParseModuleId } from '@highfive/contracts';
+import type { ServerLogsResponse } from '@highfive/contracts';
 import { db } from './database';
-import { verifyApiKey } from './auth';
+import { verifyApiKey, getApiKey } from './auth';
+import { getRecentLogLines } from './logRing';
 import {
   SESSION_COOKIE,
   issueSessionToken,
@@ -572,5 +574,65 @@ app.get('/api/modules/:id/logs', requireAdmin, async (req, res) => {
   } catch (error) {
     console.error('[GET /api/modules/:id/logs]', { id, error: String(error) });
     res.status(502).json({ error: 'image-service unreachable' });
+  }
+});
+
+// Admin-only: tail of a server process's own recent stdout/stderr (#171).
+// Gated by `requireAdmin` (session cookie OR X-Admin-Key — like
+// /api/admin/weather/backfill). The backend serves its own in-memory ring
+// directly (logRing.ts); the two Flask services expose an internal `/logs`
+// we proxy to, forwarding the machine credential so their published dev ports
+// (duckdb :8002, image :8000) can't leak logs. `nginx` is not a valid service
+// here — it has no app ring (host/file concern, out of scope). See ADR-021.
+const LOG_SERVICES = ['backend', 'duckdb-service', 'image-service'] as const;
+const LOG_LINES_CAP = 1000;
+const LOG_LINES_DEFAULT = 200;
+
+app.get('/api/admin/logs', requireAdmin, async (req, res) => {
+  const service = String(req.query.service ?? '');
+  if (!(LOG_SERVICES as readonly string[]).includes(service)) {
+    res.status(400).json({
+      error: `invalid service; expected one of: ${LOG_SERVICES.join(', ')}`,
+    });
+    return;
+  }
+
+  // Clamp lines to [1, cap]; a missing/non-numeric value takes the default.
+  const rawLines = Number(req.query.lines);
+  const lines = Number.isFinite(rawLines)
+    ? Math.max(1, Math.min(Math.floor(rawLines), LOG_LINES_CAP))
+    : LOG_LINES_DEFAULT;
+
+  if (service === 'backend') {
+    const { lines: out, truncated } = getRecentLogLines(lines);
+    const payload: ServerLogsResponse = { service: 'backend', lines: out, truncated };
+    res.json(payload);
+    return;
+  }
+
+  // Proxy to the named Flask service's internal /logs, forwarding the machine
+  // credential. DUCKDB_URL / IMAGE_SERVICE_URL are the same internal bases the
+  // other proxy routes use.
+  const base = service === 'duckdb-service' ? DUCKDB_URL : IMAGE_SERVICE_URL;
+  try {
+    const upstream = await fetch(`${base}/logs?lines=${lines}`, {
+      headers: { 'X-Admin-Key': getApiKey() },
+    });
+    if (!upstream.ok) {
+      res.status(502).json({ error: `Failed to fetch ${service} logs` });
+      return;
+    }
+    const payload = (await upstream.json()) as ServerLogsResponse;
+    // Don't forward a drifted wire shape typed as valid: a service that
+    // changed its /logs envelope should surface as a clear 502, not as
+    // `undefined` fields reaching the UI.
+    if (!payload || typeof payload.service !== 'string' || !Array.isArray(payload.lines)) {
+      res.status(502).json({ error: `malformed logs response from ${service}` });
+      return;
+    }
+    res.json(payload);
+  } catch (error) {
+    console.error('[GET /api/admin/logs]', { service, error: String(error) });
+    res.status(502).json({ error: `${service} unreachable` });
   }
 });

--- a/backend/src/logRing.ts
+++ b/backend/src/logRing.ts
@@ -1,0 +1,80 @@
+// In-memory ring of the backend's own recent stdout/stderr lines (#171).
+//
+// A stdout/stderr *tee*: every write is recorded into a bounded ring AND
+// passed through to the real stream, so `docker logs` / PM2 still see
+// everything unchanged. This captures `console.*` (which write to
+// stdout/stderr) and any direct `process.stdout.write` — i.e. exactly what an
+// operator sees in the container log today. Same idea as the ESP `logbuf`
+// ring. `GET /api/admin/logs?service=backend` reads this directly.
+//
+// Caveats (see ADR-021): in-memory, so it resets on process restart (only
+// holds lines since startup) and is per-process (a future multi-worker prod
+// would have one ring per worker).
+
+const MAX_RING_LINES = 2000;
+
+const ring: string[] = [];
+let installed = false;
+
+// A write may not end on a newline, so hold the trailing fragment per stream
+// until the next write completes the line.
+const carry: Record<'out' | 'err', string> = { out: '', err: '' };
+
+function pushLine(line: string): void {
+  ring.push(line);
+  if (ring.length > MAX_RING_LINES) {
+    ring.splice(0, ring.length - MAX_RING_LINES);
+  }
+}
+
+function record(which: 'out' | 'err', chunk: unknown): void {
+  const text =
+    typeof chunk === 'string' ? chunk : Buffer.isBuffer(chunk) ? chunk.toString('utf8') : '';
+  if (!text) return;
+  const combined = carry[which] + text;
+  const parts = combined.split('\n');
+  // The last element is the (possibly empty) incomplete tail — carry it over.
+  carry[which] = parts.pop() ?? '';
+  for (const line of parts) pushLine(line);
+}
+
+/**
+ * Wrap process.stdout/stderr `write` so each completed line is also stored in
+ * the ring. Idempotent. Call once, as early as possible at process start.
+ */
+export function installLogRing(): void {
+  if (installed) return;
+  installed = true;
+  for (const [stream, which] of [
+    [process.stdout, 'out'],
+    [process.stderr, 'err'],
+  ] as const) {
+    const original = stream.write.bind(stream);
+    stream.write = ((chunk: unknown, ...args: unknown[]): boolean => {
+      try {
+        record(which, chunk);
+      } catch {
+        // Capture must never break real logging.
+      }
+      // Preserve the original variadic (chunk, encoding?, cb?) signature.
+      return (original as (...a: unknown[]) => boolean)(chunk, ...args);
+    }) as typeof stream.write;
+  }
+}
+
+/**
+ * The most recent `n` captured lines, chronological (oldest→newest), and
+ * whether the ring held more than were returned.
+ */
+export function getRecentLogLines(n: number): { lines: string[]; truncated: boolean } {
+  const count = Math.max(0, Math.min(n, ring.length));
+  const lines = count === 0 ? [] : ring.slice(ring.length - count);
+  return { lines, truncated: ring.length > lines.length };
+}
+
+/** Test-only: clear the ring and partial-line carry. */
+export function __resetLogRingForTest(): void {
+  ring.length = 0;
+  carry.out = '';
+  carry.err = '';
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,7 +3,14 @@ import { app } from './app';
 import { getApiKey } from './auth';
 import { duckdbHealth } from './duckdbClient';
 import { isProduction } from './env';
+import { installLogRing } from './logRing';
 import { DEFAULT_PORT, resolvePort } from './port';
+
+// Tee stdout/stderr into the in-memory ring so the admin server-logs endpoint
+// (#171) can tail the backend's own output. Imports above have no log output;
+// all real logging is runtime (below + request handlers), so installing here
+// captures it. Idempotent. See logRing.ts / ADR-021.
+installLogRing();
 
 const { port: PORT, warned: portUnsetWarning } = resolvePort(process.env.PORT);
 if (portUnsetWarning) {

--- a/backend/tests/admin-server-logs.test.ts
+++ b/backend/tests/admin-server-logs.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+
+// Mock db so the app import doesn't trigger real fetches.
+vi.mock('../src/database', () => ({
+  db: {
+    listModules: vi.fn().mockResolvedValue([]),
+    getModuleDetail: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+// Control the backend's own ring without touching real stdout.
+vi.mock('../src/logRing', () => ({
+  installLogRing: vi.fn(),
+  getRecentLogLines: vi.fn(() => ({
+    lines: ['backend line 1', 'backend line 2'],
+    truncated: false,
+  })),
+}));
+
+import { app } from '../src/app';
+import { getRecentLogLines } from '../src/logRing';
+
+const KEY = 'hf_dev_key_2026';
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('GET /api/admin/logs (#171)', () => {
+  it('returns 401 without an admin credential', async () => {
+    const res = await request(app).get('/api/admin/logs?service=backend');
+    expect(res.status).toBe(401);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on a missing service and does not call upstream', async () => {
+    const res = await request(app).get('/api/admin/logs').set('X-Admin-Key', KEY);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/invalid service/i);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on a non-allow-listed service (e.g. nginx)', async () => {
+    const res = await request(app).get('/api/admin/logs?service=nginx').set('X-Admin-Key', KEY);
+    expect(res.status).toBe(400);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('serves the backend ring directly (no upstream fetch)', async () => {
+    const res = await request(app).get('/api/admin/logs?service=backend').set('X-Admin-Key', KEY);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      service: 'backend',
+      lines: ['backend line 1', 'backend line 2'],
+      truncated: false,
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('proxies duckdb-service logs, forwarding X-Admin-Key and the lines param', async () => {
+    const payload = { service: 'duckdb-service', lines: ['db line'], truncated: false };
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    });
+
+    const res = await request(app)
+      .get('/api/admin/logs?service=duckdb-service&lines=50')
+      .set('X-Admin-Key', KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(payload);
+    const [url, opts] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toMatch(/\/logs\?lines=50$/);
+    expect((opts as { headers: Record<string, string> }).headers['X-Admin-Key']).toBe(KEY);
+  });
+
+  it('clamps lines above the cap to 1000 and a non-numeric value to the default 200', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ service: 'image-service', lines: [], truncated: false }),
+    });
+
+    await request(app)
+      .get('/api/admin/logs?service=image-service&lines=99999')
+      .set('X-Admin-Key', KEY);
+    await request(app)
+      .get('/api/admin/logs?service=image-service&lines=abc')
+      .set('X-Admin-Key', KEY);
+
+    const calls = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    expect(String(calls[0][0])).toMatch(/lines=1000$/);
+    expect(String(calls[1][0])).toMatch(/lines=200$/);
+  });
+
+  it('returns 502 when the upstream service is unreachable', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('ECONNREFUSED'),
+    );
+    const res = await request(app)
+      .get('/api/admin/logs?service=duckdb-service')
+      .set('X-Admin-Key', KEY);
+    expect(res.status).toBe(502);
+    expect(res.body.error).toMatch(/unreachable/i);
+  });
+
+  it('returns 502 when the upstream responds non-2xx', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+    const res = await request(app)
+      .get('/api/admin/logs?service=image-service')
+      .set('X-Admin-Key', KEY);
+    expect(res.status).toBe(502);
+    // The backend ring mock should not have been consulted for a proxied service.
+    expect(getRecentLogLines).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/logRing.test.ts
+++ b/backend/tests/logRing.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { installLogRing, getRecentLogLines, __resetLogRingForTest } from '../src/logRing';
+
+// installLogRing wraps process.stdout/stderr.write (idempotent) and passes
+// every write through, so test output still appears; the ring also records it.
+installLogRing();
+
+beforeEach(() => {
+  __resetLogRingForTest();
+});
+
+describe('logRing (#171)', () => {
+  it('captures complete lines written to stdout', () => {
+    process.stdout.write('hf-test alpha\n');
+    process.stdout.write('hf-test bravo\n');
+    const { lines } = getRecentLogLines(10);
+    expect(lines).toContain('hf-test alpha');
+    expect(lines).toContain('hf-test bravo');
+  });
+
+  it('buffers a partial line until the newline arrives', () => {
+    process.stdout.write('hf-test par');
+    expect(getRecentLogLines(10).lines).not.toContain('hf-test partial');
+    process.stdout.write('tial\n');
+    expect(getRecentLogLines(10).lines).toContain('hf-test partial');
+  });
+
+  it('returns only the most recent n lines and flags truncation', () => {
+    for (let i = 0; i < 5; i++) process.stdout.write(`hf-test line ${i}\n`);
+    const { lines, truncated } = getRecentLogLines(2);
+    expect(lines).toEqual(['hf-test line 3', 'hf-test line 4']);
+    expect(truncated).toBe(true);
+  });
+
+  it('reports not-truncated when n covers the whole ring', () => {
+    process.stdout.write('hf-test only\n');
+    const { lines, truncated } = getRecentLogLines(100);
+    expect(lines).toEqual(['hf-test only']);
+    expect(truncated).toBe(false);
+  });
+
+  it('also captures stderr writes', () => {
+    process.stderr.write('hf-test err line\n');
+    expect(getRecentLogLines(10).lines).toContain('hf-test err line');
+  });
+
+  it('passes the write through (returns the underlying write result, not undefined)', () => {
+    const ret = process.stdout.write('hf-test passthrough\n');
+    expect(typeof ret).toBe('boolean');
+  });
+
+  it('evicts the oldest lines once the ring is over its cap', () => {
+    const N = 2100; // > MAX_RING_LINES (2000)
+    for (let i = 0; i < N; i++) process.stdout.write(`hf-cap ${i}\n`);
+    const { lines } = getRecentLogLines(N);
+    expect(lines.length).toBeLessThan(N); // bounded — not unbounded growth
+    expect(lines).toContain(`hf-cap ${N - 1}`); // newest kept
+    expect(lines).not.toContain('hf-cap 0'); // oldest evicted
+  });
+});

--- a/contracts/src/index.ts
+++ b/contracts/src/index.ts
@@ -365,3 +365,22 @@ export interface MeasurementTimeSeries {
   end: string; // ISO 8601 (UTC), exclusive
   buckets: MeasurementBucket[];
 }
+
+// Admin-gated server process logs (#171). Each service keeps a bounded
+// in-memory ring of its own recent stdout/stderr lines (a stdout tee, same
+// idea as the ESP `logbuf`), exposed for `GET /api/admin/logs?service=…&lines=N`.
+// `nginx` is deliberately absent — it has no app process to host a ring, so
+// its logs stay a host/file concern (out of scope for v1). See ADR-021.
+export type ServerLogService = 'backend' | 'duckdb-service' | 'image-service';
+
+export interface ServerLogsResponse {
+  service: ServerLogService;
+  // Raw captured stdout/stderr lines, chronological (oldest→newest), like
+  // `tail`. In-memory only: resets on process restart, so this is "since the
+  // process started", not a full history.
+  lines: string[];
+  // True when the ring held more lines than were returned (clipped to the
+  // requested `lines`, itself capped server-side). Lets the UI show a
+  // "showing last N" hint without a separate count.
+  truncated: boolean;
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -71,6 +71,10 @@ services:
     environment:
       - DUCKDB_PATH=/data/app.duckdb
       - DUCKDB_SERVICE_URL=http://duckdb-service:8000
+      # Must match the backend's key so the #171 server-logs proxy (backend
+      # forwards X-Admin-Key) authenticates against this service's internal
+      # /logs gate.
+      - HIGHFIVE_API_KEY=${HIGHFIVE_API_KEY:?HIGHFIVE_API_KEY must be set in .env.production (see .env.production.example)}
     volumes:
       - duckdb_data:/data
     restart: unless-stopped
@@ -99,6 +103,8 @@ services:
       - '127.0.0.1:8002:8000'
     environment:
       - SEED_DATA=false
+      # Must match the backend's key for the #171 server-logs proxy.
+      - HIGHFIVE_API_KEY=${HIGHFIVE_API_KEY:?HIGHFIVE_API_KEY must be set in .env.production (see .env.production.example)}
     volumes:
       - duckdb_data:/data
     restart: unless-stopped

--- a/docs/05-building-block-view/backend.md
+++ b/docs/05-building-block-view/backend.md
@@ -17,15 +17,16 @@ auth-gated JSON API. Stateless read-through projection on top of
 Auth (since #142 / ADR-019): **public** = no credential; **admin** =
 `requireAdmin` (session cookie from `POST /api/admin/login`, or `X-Admin-Key`).
 
-| Endpoint                        | Auth   | Purpose                                                                                                                                                                |
-| ------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET /api/health`               | public | Liveness check (`{"status":"ok"}`)                                                                                                                                     |
-| `POST /api/admin/login`         | public | Validates the admin password, sets the `hf_admin_session` cookie                                                                                                       |
-| `GET /api/modules`              | public | List all modules + their nests + latest progress                                                                                                                       |
-| `GET /api/modules/:id`          | public | One module + its detail                                                                                                                                                |
-| `PATCH /api/modules/:id/name`   | admin  | Sets or clears the operator-settable `display_name` override. Proxies to `duckdb-service /modules/<id>/display_name`. 409 on collision                                 |
-| `GET /api/modules/:id/logs`     | admin  | Proxies to `image-service /modules/<mac>/logs` for admin telemetry inspection                                                                                          |
-| `GET /api/modules/:id/activity` | public | Bucketed image-upload counts for the dashboard weather-correlation chart. Proxies `duckdb-service /modules/<id>/activity_timeseries` and maps `module_id` → `moduleId` |
+| Endpoint                        | Auth   | Purpose                                                                                                                                                                                                                          |
+| ------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/health`               | public | Liveness check (`{"status":"ok"}`)                                                                                                                                                                                               |
+| `POST /api/admin/login`         | public | Validates the admin password, sets the `hf_admin_session` cookie                                                                                                                                                                 |
+| `GET /api/modules`              | public | List all modules + their nests + latest progress                                                                                                                                                                                 |
+| `GET /api/modules/:id`          | public | One module + its detail                                                                                                                                                                                                          |
+| `PATCH /api/modules/:id/name`   | admin  | Sets or clears the operator-settable `display_name` override. Proxies to `duckdb-service /modules/<id>/display_name`. 409 on collision                                                                                           |
+| `GET /api/modules/:id/logs`     | admin  | Proxies to `image-service /modules/<mac>/logs` for admin telemetry inspection                                                                                                                                                    |
+| `GET /api/admin/logs`           | admin  | Tail of a service's own stdout/stderr (#171). Serves the backend's in-process ring; proxies to `duckdb-service` / `image-service` internal `/logs`. See [ADR-021](../09-architecture-decisions/adr-021-admin-server-log-ring.md) |
+| `GET /api/modules/:id/activity` | public | Bucketed image-upload counts for the dashboard weather-correlation chart. Proxies `duckdb-service /modules/<id>/activity_timeseries` and maps `module_id` → `moduleId`                                                           |
 
 Full request/response shapes in [docs/api-reference.md](../api-reference.md).
 

--- a/docs/05-building-block-view/duckdb-service.md
+++ b/docs/05-building-block-view/duckdb-service.md
@@ -140,13 +140,13 @@ Per-module time-series store (issue #110). Append-only event table; see
 [ADR-016](../09-architecture-decisions/adr-016-per-module-measurements-store.md)
 for the schema rationale (no PK, no FK, `value DOUBLE`).
 
-| Attribute  | Data Type   | Required | Description                                         |
-| ---------- | ----------- | -------- | --------------------------------------------------- |
-| module_mac | VARCHAR(20) | Yes      | Canonical module id (no FK; out-of-order safe)      |
-| ts         | TIMESTAMP   | Yes      | UTC; producers stamp explicitly                     |
-| metric     | VARCHAR(40) | Yes      | `battery_pct`, future: `temperature_c`, …           |
-| value      | DOUBLE      | Yes      | Numeric reading; `AVG(value)` aggregates on read    |
-| source     | VARCHAR(40) | Yes      | `esp-heartbeat`, `esp-heartbeat-backfill`, …        |
+| Attribute  | Data Type   | Required | Description                                      |
+| ---------- | ----------- | -------- | ------------------------------------------------ |
+| module_mac | VARCHAR(20) | Yes      | Canonical module id (no FK; out-of-order safe)   |
+| ts         | TIMESTAMP   | Yes      | UTC; producers stamp explicitly                  |
+| metric     | VARCHAR(40) | Yes      | `battery_pct`, future: `temperature_c`, …        |
+| value      | DOUBLE      | Yes      | Numeric reading; `AVG(value)` aggregates on read |
+| source     | VARCHAR(40) | Yes      | `esp-heartbeat`, `esp-heartbeat-backfill`, …     |
 
 Indices:
 
@@ -172,6 +172,13 @@ aggregate, shares window helpers with `activity_timeseries` via
 ### GET /health
 
 Checks whether the service and the database are accessible.
+
+### GET /logs
+
+Internal admin-gated tail of this service's own recent stdout/stderr (#171) — an
+in-memory ring fed by a stdout tee (`services/log_ring.py`), not the DB. Requires
+`X-Admin-Key`; the backend's `GET /api/admin/logs?service=duckdb-service` proxies
+here. See [ADR-021](../09-architecture-decisions/adr-021-admin-server-log-ring.md).
 
 ### POST /new_module
 

--- a/docs/05-building-block-view/image-service.md
+++ b/docs/05-building-block-view/image-service.md
@@ -49,6 +49,13 @@ image-service/
 
 # 3. API Endpoint
 
+## GET /logs
+
+Internal admin-gated tail of this service's own recent stdout/stderr (#171) — an
+in-memory ring fed by a stdout tee (`services/log_ring.py`). Requires
+`X-Admin-Key`; the backend's `GET /api/admin/logs?service=image-service` proxies
+here. See [ADR-021](../09-architecture-decisions/adr-021-admin-server-log-ring.md).
+
 ## POST /upload
 
 The central entry point. Called by Hive modules whenever a new image is captured.

--- a/docs/08-crosscutting-concepts/api-contracts.md
+++ b/docs/08-crosscutting-concepts/api-contracts.md
@@ -330,6 +330,30 @@ wire JSON are deliberately close enough that the proxy is one
 `.map((b) => ({ timestamp, value, sampleCount }))` and not a
 field-by-field transform.
 
+## `ServerLogsResponse` — admin server-log tail (#171)
+
+Served by `GET /api/admin/logs?service=…&lines=N` (backend). Distinct from the
+per-module ESP telemetry (`TelemetryEntry`): this is a service's **own**
+stdout/stderr. The backend reads its own in-memory ring directly and proxies to
+`duckdb-service` / `image-service` internal `/logs` (forwarding `X-Admin-Key`).
+The type lives in `contracts/src/index.ts`:
+
+```ts
+export type ServerLogService = 'backend' | 'duckdb-service' | 'image-service';
+
+export interface ServerLogsResponse {
+  service: ServerLogService;
+  lines: string[]; // raw stdout/stderr lines, chronological (oldest→newest)
+  truncated: boolean; // ring held more than were returned
+}
+```
+
+Unlike the other wire shapes here there is **no snake → camel mapping**: the
+Flask `/logs` routes emit exactly these keys (`service`/`lines`/`truncated`), so
+the backend proxies the JSON through verbatim and only the `backend` branch
+constructs it locally. `nginx` is intentionally not a `ServerLogService` (no app
+ring). Design + caveats: [ADR-021](../09-architecture-decisions/adr-021-admin-server-log-ring.md).
+
 ## `ImageUploadsPage` — admin gallery pagination
 
 Served by `GET /api/images` (backend), which proxies

--- a/docs/09-architecture-decisions/README.md
+++ b/docs/09-architecture-decisions/README.md
@@ -29,6 +29,7 @@ and link backwards.
 | [018](adr-018-captive-portal-wifi-only.md)                  | Captive portal is Wi-Fi-only; identity / URLs / camera defaulted in firmware    | Accepted |
 | [019](adr-019-admin-session-no-bundle-secret.md)            | Admin auth is a server-side session cookie; no secret in the homepage bundle    | Accepted |
 | [020](adr-020-coordinate-generalization.md)                 | Module coordinates are generalized to ~1 km (2 dp) for every caller             | Accepted |
+| [021](adr-021-admin-server-log-ring.md)                     | Admin server logs via an in-process stdout/stderr ring, not the Docker socket   | Accepted |
 
 ## When to create an ADR
 

--- a/docs/09-architecture-decisions/adr-021-admin-server-log-ring.md
+++ b/docs/09-architecture-decisions/adr-021-admin-server-log-ring.md
@@ -1,0 +1,78 @@
+# ADR-021: Admin server logs via an in-process stdout/stderr ring, not the Docker socket
+
+## Status
+
+Accepted ([#171](https://github.com/schutera/highfive/issues/171)). Spun out of the
+[#170](https://github.com/schutera/highfive/issues/170) investigation, which needed
+server-side visibility the per-module telemetry sidecars (`GET /api/modules/:id/logs`)
+do not provide.
+
+## Context
+
+There was no way to read the services' **own** process logs (backend,
+`duckdb-service`, `image-service` stdout/stderr) without shell access to the host.
+For a server-side failure — a 5xx spike, a wedged proxy, a duckdb write error, an
+image-service stall — that meant flying blind. #171 adds an admin-gated endpoint to
+tail recent server logs (`GET /api/admin/logs?service=…&lines=N`) plus an admin UI.
+
+The hard part is **where the logs come from**, and it differs per environment:
+
+- **Dev** runs under `docker compose`: each service logs to its container stdout, and
+  the backend container has no Docker socket and no shared log volume.
+- **Prod** is documented two ways (drift tracked in chapter 11): full Docker
+  (`docker compose logs`) or PM2 (backend → `./logs/*.log`, nginx → `/var/log/nginx`).
+
+No single host-level source works across all of these without new infrastructure.
+
+## Decision
+
+Each service keeps a **bounded in-memory ring of its own recent stdout/stderr lines**
+and exposes it; the backend aggregates.
+
+- Capture is a **stdout/stderr tee** installed at process start
+  ([`backend/src/logRing.ts`](../../backend/src/logRing.ts),
+  [`duckdb-service/services/log_ring.py`](../../duckdb-service/services/log_ring.py),
+  [`image-service/services/log_ring.py`](../../image-service/services/log_ring.py)): every
+  write is appended to a capped ring **and passed through** to the real stream, so
+  `docker logs`/PM2 still see everything. This faithfully captures `print(...)` /
+  `console.*` — exactly what an operator sees in the container log today. Same idea as
+  the ESP `lib/logbuf` ring.
+- The two Flask services expose an internal `GET /logs?lines=N`; the backend serves its
+  own ring directly and **proxies** to them for
+  `service=duckdb-service`/`image-service`.
+- **Auth.** The public `GET /api/admin/logs` is gated by `requireAdmin` (session cookie
+  OR `X-Admin-Key`), like `/api/admin/weather/backfill`. The internal Flask `/logs`
+  routes additionally require `X-Admin-Key == HIGHFIVE_API_KEY` (constant-time compare),
+  forwarded by the backend, because `duckdb-service:8002` and `image-service:8000` are
+  published on the dev host and **logs can leak request metadata** — they must not be
+  readable unauthenticated. This requires `HIGHFIVE_API_KEY` to resolve to the same value
+  in all three services (dev: shared `.env`; UI + prod compose: set explicitly on each).
+- **The ring faithfully captures whatever any code prints** — including any credential a log
+  line chooses to emit (e.g. `server.ts` prints the dev admin key to stdout at startup, so
+  it appears in `service=backend`). This is bounded by the admin gate on the endpoint and by
+  that banner being suppressed in production, but it is a reason the endpoint must stay
+  admin-only and a reason not to `console.log`/`print` secrets.
+
+### Alternatives rejected
+
+- **Mount the Docker socket** into the backend and shell out to `docker logs`. Simplest,
+  gives full container logs incl. nginx, zero per-service code — but it exposes the Docker
+  socket (≈ host root) on an internet-facing service, needs the docker CLI in the image,
+  and matches only the Docker prod track, not PM2. The security cost is unacceptable for a
+  diagnostic convenience.
+- **Shared log-file volume** that every service + nginx writes to. File-based (matches PM2
+  `./logs` and nginx `/var/log`), no socket — but it touches every service's logging
+  config and compose volume plumbing, and dev/prod paths diverge.
+
+## Consequences
+
+- Portable: identical in dev and prod, app-level, no infra coupling, no socket exposure.
+- **In-memory:** the ring resets on process restart, so it only holds lines since the
+  process started. Acceptable for a "tail recent activity" diagnostic; not an audit log.
+- **Per-process:** a future multi-worker prod (e.g. gunicorn) would return only the
+  serving worker's ring. Dev and the current `python app.py` / single-process backend are
+  unaffected. Revisit if the services move to multiple workers.
+- **nginx is not covered** (no app process to host a ring). Its access/error logs remain a
+  host/file concern — a follow-up if needed (e.g. a host-side reader), out of scope here.
+- New shared-secret coupling: the Flask services now need `HIGHFIVE_API_KEY`; the UI and
+  prod compose files set it on all three services (it was previously backend-only).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -50,8 +50,8 @@ The homepage bundle carries **no** secret.
 
 `requireAdmin` gates `DELETE /api/modules/:id`,
 `DELETE /api/images/:filename`, `PATCH /api/modules/:id/name`,
-`POST /api/modules/:id/measurements`, `POST /api/admin/weather/backfill`, and
-`GET /api/modules/:id/logs`; it returns `401` when neither credential is
+`POST /api/modules/:id/measurements`, `POST /api/admin/weather/backfill`,
+`GET /api/modules/:id/logs`, and `GET /api/admin/logs`; it returns `401` when neither credential is
 valid. Companion routes: `POST /api/admin/logout` (clears the cookie) and
 `GET /api/admin/session` → `{ "authenticated": boolean }`.
 
@@ -247,6 +247,37 @@ Diagnostic mechanism for issue #42 — see
 The telemetry section in the dashboard is hidden unless the URL has
 `?admin=1`; see [06-runtime-view/esp-reliability.md](06-runtime-view/esp-reliability.md) for the
 end-to-end admin flow.
+
+## 1.5b Server process logs (admin)
+
+```
+GET /api/admin/logs?service=backend|duckdb-service|image-service&lines=N
+Headers: Cookie: hf_admin_session=…   # or  X-Admin-Key: <HIGHFIVE_API_KEY>
+```
+
+Tails a service's **own** recent stdout/stderr — distinct from §1.5 (per-module
+ESP telemetry). Each service keeps an in-memory ring of its log lines (a stdout
+tee); the backend serves its own ring and proxies to the two Flask services'
+internal `/logs`, forwarding the machine credential. `service` must be one of
+the three names (others, incl. `nginx`, return `400`). `lines` defaults to
+`200` and is clamped to `[1, 1000]`. Returns `401` without a valid admin
+credential, `502` if a proxied service is unreachable. Design + caveats
+(in-memory, per-process, nginx not covered): [ADR-021](09-architecture-decisions/adr-021-admin-server-log-ring.md).
+
+```json
+{
+  "service": "duckdb-service",
+  "lines": [
+    "[heartbeat] mac=aabbccddeeff battery=None rssi=-67 …",
+    "127.0.0.1 - - [16/Jun/2026 00:04:42] \"POST /heartbeat HTTP/1.1\" 200 -"
+  ],
+  "truncated": false
+}
+```
+
+`lines` is chronological (oldest→newest, like `tail`); `truncated` is `true`
+when the ring held more than were returned. The TypeScript contract is
+`ServerLogsResponse` in [`contracts/src/index.ts`](../contracts/src/index.ts).
 
 ## 1.5 User location hint (dashboard map)
 

--- a/duckdb-service/app.py
+++ b/duckdb-service/app.py
@@ -5,17 +5,26 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from db.schema import init_db
 from routes.admin_weather import admin_weather_bp
 from routes.health import health_bp
+from routes.logs import logs_bp
 from routes.measurements import measurements_bp
 from routes.modules import modules_bp
 from routes.nests import nests_bp
 from routes.progress import progress_bp
 from routes.heartbeats import heartbeats_bp
 from services.backup import run_backup
+from services.log_ring import install as install_log_ring
 from services.silence_watcher import check_silence
 from services.weather_worker import run_weather_fetch
 
+# Tee stdout/stderr into the in-memory ring (#171) so the admin server-logs
+# endpoint can tail this service's output. Runs before the app serves traffic;
+# print() re-resolves sys.stdout per call and Flask/werkzeug log handlers are
+# constructed lazily at app.run, so capture is complete. See services/log_ring.py.
+install_log_ring()
+
 app = Flask(__name__)
 app.register_blueprint(health_bp)
+app.register_blueprint(logs_bp)
 app.register_blueprint(modules_bp)
 app.register_blueprint(nests_bp)
 app.register_blueprint(progress_bp)

--- a/duckdb-service/routes/logs.py
+++ b/duckdb-service/routes/logs.py
@@ -1,0 +1,47 @@
+"""Internal admin-gated server-log tail for duckdb-service (#171).
+
+Returns this service's own recent stdout/stderr (the `log_ring` tee). The
+backend's `GET /api/admin/logs?service=duckdb-service` proxies here, forwarding
+the `X-Admin-Key` machine credential. The route is auth-gated because the
+service's port is published on the dev host (`:8002`) and logs can leak request
+metadata. See ADR-021.
+"""
+
+import hmac
+import os
+
+from flask import Blueprint, jsonify, request
+
+from services.log_ring import get_recent
+
+logs_bp = Blueprint("logs", __name__)
+
+SERVICE_NAME = "duckdb-service"
+_DEV_FALLBACK_KEY = "hf_dev_key_2026"
+_LINES_CAP = 1000
+_LINES_DEFAULT = 200
+
+
+def _resolve_key() -> str:
+    # Mirror backend/src/auth.ts: env HIGHFIVE_API_KEY (trimmed) or the public
+    # dev fallback. Both services resolve the same value, so the backend's
+    # forwarded X-Admin-Key matches.
+    return (os.getenv("HIGHFIVE_API_KEY") or "").strip() or _DEV_FALLBACK_KEY
+
+
+@logs_bp.get("/logs")
+def get_logs():
+    provided = request.headers.get("X-Admin-Key", "")
+    if not hmac.compare_digest(provided, _resolve_key()):
+        return jsonify({"error": "unauthorized"}), 401
+
+    try:
+        n = int(request.args.get("lines", _LINES_DEFAULT))
+    except (TypeError, ValueError):
+        n = _LINES_DEFAULT
+    n = max(1, min(n, _LINES_CAP))
+
+    lines, truncated = get_recent(n)
+    return jsonify(
+        {"service": SERVICE_NAME, "lines": lines, "truncated": truncated}
+    ), 200

--- a/duckdb-service/services/log_ring.py
+++ b/duckdb-service/services/log_ring.py
@@ -1,0 +1,93 @@
+"""In-memory ring of this service's recent stdout/stderr lines (#171).
+
+A stdout/stderr *tee* installed at startup: every write is appended to a
+bounded deque AND passed through to the real stream, so ``docker logs`` / PM2
+still see everything unchanged. Captures ``print(...)`` (which re-resolves
+``sys.stdout`` on every call) and anything else written to the wrapped
+streams -- i.e. what the container log shows. Same idea as the ESP ``logbuf``
+ring. Read via this service's internal admin-gated ``GET /logs``.
+
+Caveats (see ADR-021): in-memory, so it resets on process restart (only holds
+lines since startup) and is per-process. ``install()`` runs at import time in
+``app.py`` (after the import block, before the app serves traffic), so the
+Flask/werkzeug log handlers — constructed lazily at ``app.run`` / first request
+— bind to the tee.
+"""
+
+import sys
+import threading
+from collections import deque
+
+_MAX_RING_LINES = 2000
+_ring: "deque[str]" = deque(maxlen=_MAX_RING_LINES)
+_lock = threading.Lock()
+_installed = False
+_tees: "list[_TeeStream]" = []  # installed tee instances (for test carry reset)
+
+
+class _TeeStream:
+    """Wraps a real text stream; mirrors complete lines into the ring."""
+
+    def __init__(self, real):
+        self._real = real
+        self._carry = ""
+
+    def write(self, text):
+        n = self._real.write(text)
+        try:
+            self._capture(text)
+        except Exception:
+            # Capture must never break real logging.
+            pass
+        return n
+
+    def _capture(self, text):
+        if not isinstance(text, str) or not text:
+            return
+        combined = self._carry + text
+        parts = combined.split("\n")
+        # The last element is the (possibly empty) incomplete tail.
+        self._carry = parts.pop()
+        if parts:
+            with _lock:
+                _ring.extend(parts)
+
+    def flush(self):
+        self._real.flush()
+
+    def __getattr__(self, name):
+        # Delegate everything else (fileno, isatty, encoding, …) to the real
+        # stream so the tee is transparent to Flask/werkzeug.
+        return getattr(self._real, name)
+
+
+def install():
+    """Wrap sys.stdout/sys.stderr. Idempotent; call once at process start."""
+    global _installed
+    if _installed:
+        return
+    _installed = True
+    out = _TeeStream(sys.stdout)
+    err = _TeeStream(sys.stderr)
+    _tees.extend((out, err))
+    sys.stdout = out
+    sys.stderr = err
+
+
+def get_recent(n):
+    """Return (lines, truncated): the most recent ``n`` lines oldest→newest,
+    and whether the ring held more than were returned."""
+    with _lock:
+        items = list(_ring)
+    n = max(0, min(n, len(items)))
+    lines = items[len(items) - n :] if n else []
+    return lines, len(items) > len(lines)
+
+
+def _reset_for_test():
+    with _lock:
+        _ring.clear()
+    # Also clear any installed tee's partial-line carry so a half-line from a
+    # previous test can't bleed into the next.
+    for tee in _tees:
+        tee._carry = ""

--- a/duckdb-service/tests/test_logs.py
+++ b/duckdb-service/tests/test_logs.py
@@ -1,0 +1,71 @@
+"""Tests for the internal admin-gated GET /logs server-log tail (#171)."""
+
+import io
+
+from services import log_ring
+
+VALID_KEY = "hf_dev_key_2026"  # dev fallback resolved when HIGHFIVE_API_KEY unset
+
+
+def test_tee_captures_complete_lines_and_passes_through():
+    log_ring._reset_for_test()
+    sink = io.StringIO()
+    tee = log_ring._TeeStream(sink)
+    tee.write("alpha\n")
+    tee.write("partial")  # no newline yet — buffered, not a line
+    lines, _ = log_ring.get_recent(10)
+    assert "alpha" in lines
+    assert "partial" not in lines
+    tee.write(" done\n")
+    lines, _ = log_ring.get_recent(10)
+    assert "partial done" in lines
+    # The real stream still saw every byte (tee, not intercept).
+    assert sink.getvalue() == "alpha\npartial done\n"
+
+
+def test_get_recent_clamps_and_flags_truncation():
+    log_ring._reset_for_test()
+    for i in range(5):
+        log_ring._ring.append(f"line {i}")
+    lines, truncated = log_ring.get_recent(2)
+    assert lines == ["line 3", "line 4"]
+    assert truncated is True
+
+
+def test_ring_caps_at_max_and_evicts_oldest():
+    log_ring._reset_for_test()
+    total = log_ring._MAX_RING_LINES + 10
+    for i in range(total):
+        log_ring._ring.append(f"L{i}")
+    lines, truncated = log_ring.get_recent(total)
+    assert len(lines) == log_ring._MAX_RING_LINES  # bounded
+    assert lines[0] == "L10"  # first 10 evicted
+    assert lines[-1] == f"L{total - 1}"  # newest kept
+    assert truncated is False  # asked for >= ring size
+
+
+def test_logs_requires_admin_key(client):
+    log_ring._reset_for_test()
+    assert client.get("/logs").status_code == 401
+    assert client.get("/logs", headers={"X-Admin-Key": "wrong"}).status_code == 401
+
+
+def test_logs_returns_ring_with_valid_key(client):
+    log_ring._reset_for_test()
+    log_ring._ring.append("duckdb marker line")
+    resp = client.get("/logs?lines=50", headers={"X-Admin-Key": VALID_KEY})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["service"] == "duckdb-service"
+    assert "duckdb marker line" in body["lines"]
+    assert body["truncated"] is False
+
+
+def test_logs_route_honours_lines_and_reports_truncation(client):
+    log_ring._reset_for_test()
+    for i in range(5):
+        log_ring._ring.append(f"row {i}")
+    resp = client.get("/logs?lines=2", headers={"X-Admin-Key": VALID_KEY})
+    body = resp.get_json()
+    assert body["lines"] == ["row 3", "row 4"]
+    assert body["truncated"] is True

--- a/homepage/src/__tests__/ServerLogsPanel.test.tsx
+++ b/homepage/src/__tests__/ServerLogsPanel.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import type { ServerLogsResponse } from '@highfive/contracts';
+
+import ServerLogsPanel from '../components/ServerLogsPanel';
+import { api } from '../services/api';
+
+// Pins the #171 admin server-logs view against the real ServerLogsResponse
+// wire shape (CLAUDE.md rule 3 — realistic fixture, not a guessed object).
+// api.getServerLogs is the single boundary, spied so no real fetch fires.
+
+const backendLogs: ServerLogsResponse = {
+  service: 'backend',
+  lines: ['🐝 HighFive Backend API running on http://localhost:3002', '[GET /api/modules] 200'],
+  truncated: false,
+};
+
+const duckdbLogs: ServerLogsResponse = {
+  service: 'duckdb-service',
+  lines: ['[heartbeat] mac=aabbccddeeff battery=None', '127.0.0.1 - "GET /health" 200'],
+  truncated: true,
+};
+
+beforeEach(() => {
+  vi.spyOn(api, 'getServerLogs').mockResolvedValue(backendLogs);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ServerLogsPanel (#171)', () => {
+  it('loads the backend ring on mount and renders its lines', async () => {
+    render(<ServerLogsPanel />);
+    await waitFor(() => expect(api.getServerLogs).toHaveBeenCalledWith('backend', 200));
+    const out = await screen.findByTestId('server-logs-output');
+    expect(out.textContent).toContain('HighFive Backend API running');
+    expect(out.textContent).toContain('[GET /api/modules] 200');
+  });
+
+  it('refetches the selected service when the dropdown changes', async () => {
+    (api.getServerLogs as ReturnType<typeof vi.fn>).mockImplementation(async (service: string) =>
+      service === 'duckdb-service' ? duckdbLogs : backendLogs,
+    );
+    render(<ServerLogsPanel />);
+    await screen.findByText(/HighFive Backend API running/);
+
+    fireEvent.change(screen.getByTestId('log-service-select'), {
+      target: { value: 'duckdb-service' },
+    });
+
+    await waitFor(() => expect(api.getServerLogs).toHaveBeenCalledWith('duckdb-service', 200));
+    const out = await screen.findByTestId('server-logs-output');
+    expect(out.textContent).toContain('[heartbeat] mac=aabbccddeeff');
+    // truncated → the "showing most recent N" hint renders.
+    expect(screen.getByText(/Showing the most recent/)).toBeTruthy();
+  });
+
+  it('shows an error message when the fetch fails', async () => {
+    (api.getServerLogs as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+    render(<ServerLogsPanel />);
+    expect(await screen.findByText(/Failed to fetch backend logs/)).toBeTruthy();
+  });
+});

--- a/homepage/src/components/ServerLogsPanel.tsx
+++ b/homepage/src/components/ServerLogsPanel.tsx
@@ -1,0 +1,107 @@
+import { useState, useEffect, useCallback } from 'react';
+import { api } from '../services/api';
+import type { ServerLogService } from '../services/api';
+
+// Admin-only server-log viewer (#171). Tails a service's own recent
+// stdout/stderr via GET /api/admin/logs (the app-level ring in each service).
+// English-only, like the rest of AdminPage (operator-facing, no i18n consumer
+// in this page — see AdminPage's existing note). See ADR-021.
+const SERVICES: ServerLogService[] = ['backend', 'duckdb-service', 'image-service'];
+const DEFAULT_LINES = 200;
+const MAX_LINES = 1000;
+
+export default function ServerLogsPanel() {
+  const [service, setService] = useState<ServerLogService>('backend');
+  const [lines, setLines] = useState(DEFAULT_LINES);
+  const [log, setLog] = useState<string[]>([]);
+  const [truncated, setTruncated] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.getServerLogs(service, lines);
+      setLog(res.lines);
+      setTruncated(res.truncated);
+    } catch (err) {
+      setError(
+        err instanceof Error && err.message === 'unauthorized'
+          ? 'Session expired — reload and log in again.'
+          : `Failed to fetch ${service} logs. Is the service running?`,
+      );
+      setLog([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [service, lines]);
+
+  // Reload whenever the selected service changes (and on mount).
+  useEffect(() => {
+    load();
+  }, [service]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 mb-8 overflow-hidden">
+      <div className="px-6 py-4 border-b border-gray-200 flex flex-wrap items-center gap-3 justify-between">
+        <h2 className="text-lg font-semibold text-gray-800">Server Logs</h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <label htmlFor="log-service" className="text-sm text-gray-600">
+            Service
+          </label>
+          <select
+            id="log-service"
+            data-testid="log-service-select"
+            value={service}
+            onChange={(e) => setService(e.target.value as ServerLogService)}
+            className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm bg-white focus:ring-2 focus:ring-amber-500 focus:border-amber-500 outline-none"
+          >
+            {SERVICES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <input
+            type="number"
+            min={1}
+            max={MAX_LINES}
+            value={lines}
+            onChange={(e) =>
+              setLines(Math.max(1, Math.min(MAX_LINES, Number(e.target.value) || DEFAULT_LINES)))
+            }
+            className="w-20 border border-gray-300 rounded-lg px-2 py-1.5 text-sm focus:ring-2 focus:ring-amber-500 focus:border-amber-500 outline-none"
+            aria-label="Number of lines"
+          />
+          <button
+            onClick={load}
+            disabled={loading}
+            className="px-3 py-1.5 bg-amber-500 hover:bg-amber-600 disabled:opacity-60 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+          >
+            {loading ? 'Loading…' : 'Refresh'}
+          </button>
+        </div>
+      </div>
+
+      <div className="p-4">
+        {error && <p className="text-red-600 text-sm mb-2">{error}</p>}
+        {truncated && !error && (
+          <p className="text-xs text-gray-400 mb-2">Showing the most recent {log.length} lines.</p>
+        )}
+        {!error && log.length === 0 && !loading ? (
+          <p className="text-sm text-gray-400">
+            No log lines captured yet (rings reset on restart).
+          </p>
+        ) : (
+          <pre
+            data-testid="server-logs-output"
+            className="bg-gray-900 text-gray-100 text-xs font-mono rounded-lg p-3 overflow-auto max-h-[28rem] whitespace-pre-wrap break-words"
+          >
+            {log.join('\n')}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/homepage/src/pages/AdminPage.tsx
+++ b/homepage/src/pages/AdminPage.tsx
@@ -475,6 +475,7 @@ export default function AdminPage() {
             <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
               <label className="text-sm font-medium text-gray-700">Filter by module:</label>
               <select
+                data-testid="module-filter-select"
                 value={selectedModule}
                 onChange={(e) => setSelectedModule(e.target.value)}
                 className="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:ring-2 focus:ring-amber-500 focus:border-amber-500 outline-none min-w-[200px]"

--- a/homepage/src/pages/AdminPage.tsx
+++ b/homepage/src/pages/AdminPage.tsx
@@ -5,6 +5,7 @@ import type { ImageUpload } from '../services/api';
 import type { Module } from '@highfive/contracts';
 import RenameModuleModal from '../components/RenameModuleModal';
 import ImageLightbox from '../components/ImageLightbox';
+import ServerLogsPanel from '../components/ServerLogsPanel';
 import { hasPlausibleLocation } from '../lib/location';
 import { displayLabel } from '../lib/displayLabel';
 import { formatUploadedAt } from '../lib/formatUploadedAt';
@@ -270,7 +271,7 @@ export default function AdminPage() {
               <span>HighFive</span>
             </Link>
             <span className="text-gray-300">|</span>
-            <h1 className="text-xl font-semibold text-gray-800">Admin &mdash; Image Inspector</h1>
+            <h1 className="text-xl font-semibold text-gray-800">Admin Console</h1>
           </div>
           <div className="flex items-center gap-4">
             <Link
@@ -463,6 +464,10 @@ export default function AdminPage() {
             </div>
           )}
         </div>
+
+        {/* Server process logs (#171) — admin-only tail of each service's
+            own stdout/stderr ring. */}
+        <ServerLogsPanel />
 
         {/* Image Filter & Stats */}
         <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-8">

--- a/homepage/src/services/api.ts
+++ b/homepage/src/services/api.ts
@@ -4,12 +4,15 @@ import type {
   MeasurementTimeSeries,
   Module,
   ModuleDetail,
+  ServerLogService,
+  ServerLogsResponse,
   TelemetryEntry,
   UserLocation,
 } from '@highfive/contracts';
 import { parseModuleId } from '@highfive/contracts';
 
 export type { TelemetryEntry } from '@highfive/contracts';
+export type { ServerLogService, ServerLogsResponse } from '@highfive/contracts';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3002/api';
 
@@ -201,6 +204,25 @@ class ApiService {
     }
     if (!response.ok) {
       throw new Error(`Failed to fetch logs for module ${id}`);
+    }
+    return response.json();
+  }
+
+  /**
+   * Admin-only: tail of a server process's own recent stdout/stderr (#171).
+   * Maps to `GET /api/admin/logs?service=…&lines=N`, gated by the admin
+   * session cookie (`credentials: 'include'`). Throws `'unauthorized'` on
+   * 401/403 so the caller can prompt for login. `lines` is clamped
+   * server-side (cap 1000). See ADR-021.
+   */
+  async getServerLogs(service: ServerLogService, lines: number = 200): Promise<ServerLogsResponse> {
+    const url = `${this.baseUrl}/admin/logs?service=${encodeURIComponent(service)}&lines=${lines}`;
+    const response = await fetch(url, { headers: this.getHeaders(), credentials: 'include' });
+    if (response.status === 401 || response.status === 403) {
+      throw new Error('unauthorized');
+    }
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${service} logs`);
     }
     return response.json();
   }

--- a/image-service/app.py
+++ b/image-service/app.py
@@ -1,4 +1,5 @@
 import glob
+import hmac
 import json
 import os
 import random
@@ -10,9 +11,17 @@ from pydantic import ValidationError
 
 from services.discord import send_discord_message
 from services.duckdb import DuckDBService
+from services.log_ring import get_recent as _get_recent_logs
+from services.log_ring import install as install_log_ring
 from services.module_id import ModuleId
 from services.sidecar import LogSidecarEnvelope
 from services.upload_pipeline import UploadPipeline, UploadRequest
+
+# Tee stdout/stderr into the in-memory ring (#171) so the admin server-logs
+# endpoint can tail this service's output. Runs before the app serves traffic;
+# print() re-resolves sys.stdout per call and Flask/werkzeug log handlers are
+# constructed lazily at app.run, so capture is complete. See services/log_ring.py.
+install_log_ring()
 
 app = Flask(__name__)
 
@@ -69,6 +78,40 @@ def health():
     duckdb-service's /health for that check.
     """
     return jsonify({"ok": True, "service": "image-service"}), 200
+
+
+# Internal admin-gated server-log tail (#171). Returns this service's own
+# recent stdout/stderr (the log_ring tee). The backend's
+# GET /api/admin/logs?service=image-service proxies here, forwarding the
+# X-Admin-Key machine credential. Auth-gated because this port is published on
+# the dev host (:8000) and logs can leak request metadata. See ADR-021.
+_LOGS_DEV_FALLBACK_KEY = "hf_dev_key_2026"
+_LOGS_LINES_CAP = 1000
+_LOGS_LINES_DEFAULT = 200
+
+
+def _logs_resolve_key() -> str:
+    # Mirror backend/src/auth.ts: env HIGHFIVE_API_KEY (trimmed) or the public
+    # dev fallback, so the backend's forwarded X-Admin-Key matches.
+    return (os.getenv("HIGHFIVE_API_KEY") or "").strip() or _LOGS_DEV_FALLBACK_KEY
+
+
+@app.get("/logs")
+def get_logs():
+    provided = request.headers.get("X-Admin-Key", "")
+    if not hmac.compare_digest(provided, _logs_resolve_key()):
+        return jsonify({"error": "unauthorized"}), 401
+
+    try:
+        n = int(request.args.get("lines", _LOGS_LINES_DEFAULT))
+    except (TypeError, ValueError):
+        n = _LOGS_LINES_DEFAULT
+    n = max(1, min(n, _LOGS_LINES_CAP))
+
+    lines, truncated = _get_recent_logs(n)
+    return jsonify(
+        {"service": "image-service", "lines": lines, "truncated": truncated}
+    ), 200
 
 
 @app.post("/upload")

--- a/image-service/services/log_ring.py
+++ b/image-service/services/log_ring.py
@@ -1,0 +1,93 @@
+"""In-memory ring of this service's recent stdout/stderr lines (#171).
+
+A stdout/stderr *tee* installed at startup: every write is appended to a
+bounded deque AND passed through to the real stream, so ``docker logs`` / PM2
+still see everything unchanged. Captures ``print(...)`` (which re-resolves
+``sys.stdout`` on every call) and anything else written to the wrapped
+streams -- i.e. what the container log shows. Same idea as the ESP ``logbuf``
+ring. Read via this service's internal admin-gated ``GET /logs``.
+
+Caveats (see ADR-021): in-memory, so it resets on process restart (only holds
+lines since startup) and is per-process. ``install()`` runs at import time in
+``app.py`` (after the import block, before the app serves traffic), so the
+Flask/werkzeug log handlers — constructed lazily at ``app.run`` / first request
+— bind to the tee.
+"""
+
+import sys
+import threading
+from collections import deque
+
+_MAX_RING_LINES = 2000
+_ring: "deque[str]" = deque(maxlen=_MAX_RING_LINES)
+_lock = threading.Lock()
+_installed = False
+_tees: "list[_TeeStream]" = []  # installed tee instances (for test carry reset)
+
+
+class _TeeStream:
+    """Wraps a real text stream; mirrors complete lines into the ring."""
+
+    def __init__(self, real):
+        self._real = real
+        self._carry = ""
+
+    def write(self, text):
+        n = self._real.write(text)
+        try:
+            self._capture(text)
+        except Exception:
+            # Capture must never break real logging.
+            pass
+        return n
+
+    def _capture(self, text):
+        if not isinstance(text, str) or not text:
+            return
+        combined = self._carry + text
+        parts = combined.split("\n")
+        # The last element is the (possibly empty) incomplete tail.
+        self._carry = parts.pop()
+        if parts:
+            with _lock:
+                _ring.extend(parts)
+
+    def flush(self):
+        self._real.flush()
+
+    def __getattr__(self, name):
+        # Delegate everything else (fileno, isatty, encoding, …) to the real
+        # stream so the tee is transparent to Flask/werkzeug.
+        return getattr(self._real, name)
+
+
+def install():
+    """Wrap sys.stdout/sys.stderr. Idempotent; call once at process start."""
+    global _installed
+    if _installed:
+        return
+    _installed = True
+    out = _TeeStream(sys.stdout)
+    err = _TeeStream(sys.stderr)
+    _tees.extend((out, err))
+    sys.stdout = out
+    sys.stderr = err
+
+
+def get_recent(n):
+    """Return (lines, truncated): the most recent ``n`` lines oldest→newest,
+    and whether the ring held more than were returned."""
+    with _lock:
+        items = list(_ring)
+    n = max(0, min(n, len(items)))
+    lines = items[len(items) - n :] if n else []
+    return lines, len(items) > len(lines)
+
+
+def _reset_for_test():
+    with _lock:
+        _ring.clear()
+    # Also clear any installed tee's partial-line carry so a half-line from a
+    # previous test can't bleed into the next.
+    for tee in _tees:
+        tee._carry = ""

--- a/image-service/tests/test_logs.py
+++ b/image-service/tests/test_logs.py
@@ -1,0 +1,70 @@
+"""Tests for the internal admin-gated GET /logs server-log tail (#171)."""
+
+import io
+
+from services import log_ring
+
+VALID_KEY = "hf_dev_key_2026"  # dev fallback resolved when HIGHFIVE_API_KEY unset
+
+
+def test_tee_captures_complete_lines_and_passes_through():
+    log_ring._reset_for_test()
+    sink = io.StringIO()
+    tee = log_ring._TeeStream(sink)
+    tee.write("alpha\n")
+    tee.write("partial")  # no newline yet — buffered, not a line
+    lines, _ = log_ring.get_recent(10)
+    assert "alpha" in lines
+    assert "partial" not in lines
+    tee.write(" done\n")
+    lines, _ = log_ring.get_recent(10)
+    assert "partial done" in lines
+    assert sink.getvalue() == "alpha\npartial done\n"
+
+
+def test_get_recent_clamps_and_flags_truncation():
+    log_ring._reset_for_test()
+    for i in range(5):
+        log_ring._ring.append(f"line {i}")
+    lines, truncated = log_ring.get_recent(2)
+    assert lines == ["line 3", "line 4"]
+    assert truncated is True
+
+
+def test_ring_caps_at_max_and_evicts_oldest():
+    log_ring._reset_for_test()
+    total = log_ring._MAX_RING_LINES + 10
+    for i in range(total):
+        log_ring._ring.append(f"L{i}")
+    lines, truncated = log_ring.get_recent(total)
+    assert len(lines) == log_ring._MAX_RING_LINES  # bounded
+    assert lines[0] == "L10"  # first 10 evicted
+    assert lines[-1] == f"L{total - 1}"  # newest kept
+    assert truncated is False  # asked for >= ring size
+
+
+def test_logs_requires_admin_key(client):
+    log_ring._reset_for_test()
+    assert client.get("/logs").status_code == 401
+    assert client.get("/logs", headers={"X-Admin-Key": "wrong"}).status_code == 401
+
+
+def test_logs_returns_ring_with_valid_key(client):
+    log_ring._reset_for_test()
+    log_ring._ring.append("image marker line")
+    resp = client.get("/logs?lines=50", headers={"X-Admin-Key": VALID_KEY})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["service"] == "image-service"
+    assert "image marker line" in body["lines"]
+    assert body["truncated"] is False
+
+
+def test_logs_route_honours_lines_and_reports_truncation(client):
+    log_ring._reset_for_test()
+    for i in range(5):
+        log_ring._ring.append(f"row {i}")
+    resp = client.get("/logs?lines=2", headers={"X-Admin-Key": VALID_KEY})
+    body = resp.get_json()
+    assert body["lines"] == ["row 3", "row 4"]
+    assert body["truncated"] is True

--- a/tests/ui/docker-compose.ui.yml
+++ b/tests/ui/docker-compose.ui.yml
@@ -35,6 +35,10 @@ services:
       - '0.0.0.0:9002:8000'
     environment:
       DEBUG: 'false'
+      # Must match the backend's key so the #171 server-logs proxy (backend
+      # forwards X-Admin-Key) authenticates against this service's internal
+      # /logs gate.
+      HIGHFIVE_API_KEY: hf_test_key
       # UI tests want the seeded modules (Garten 12 with leafcutter nests
       # etc.) as a deterministic backdrop for module-panel rendering and
       # side-list ordering. seed_ui_fixtures.py adds the Null-Island
@@ -67,6 +71,8 @@ services:
       DEBUG: 'false'
       DUCKDB_PATH: /data/app.duckdb
       DUCKDB_SERVICE_URL: http://duckdb-service:8000
+      # Must match the backend's key for the #171 server-logs proxy.
+      HIGHFIVE_API_KEY: hf_test_key
     volumes:
       - duckdb_ui_data:/data
     depends_on:

--- a/tests/ui/tests/admin-image-pagination.spec.ts
+++ b/tests/ui/tests/admin-image-pagination.spec.ts
@@ -59,7 +59,10 @@ test.describe('admin image gallery pagination', () => {
     // 2) Drive the browser. Filter to the gallery module so the counts
     //    are deterministic regardless of other seeded modules' uploads.
     await page.goto('/admin');
-    await page.getByRole('combobox').selectOption(GALLERY_MAC);
+    // Scope to the module-filter select by test-id: the admin page now also
+    // renders the #171 Server Logs service dropdown, so a bare
+    // getByRole('combobox') matches two elements (strict-mode violation).
+    await page.getByTestId('module-filter-select').selectOption(GALLERY_MAC);
 
     // Count the image CELLS (one button per loaded row), not the <img>
     // itself: AdminPage's onError handler replaces a failed thumbnail's

--- a/tests/ui/tests/admin-server-logs.spec.ts
+++ b/tests/ui/tests/admin-server-logs.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import type { ServerLogsResponse } from '@highfive/contracts';
+
+// Pins the #171 admin server-logs view (CLAUDE.md rule #4 / ADR-014): mounts
+// the production-built homepage against the real backend, which serves its own
+// in-memory ring directly and proxies to the Flask services' internal /logs.
+// Vitest+jsdom (ServerLogsPanel.test.tsx) pins the client round-trip, but only
+// this layer proves the admin-gated route, the cross-service proxy auth
+// (backend forwards X-Admin-Key), and SPA rendering actually work end-to-end.
+
+const ADMIN_PASSWORD = 'hf_test_key'; // matches docker-compose.ui.yml HIGHFIVE_API_KEY
+const API = 'http://localhost:4002';
+
+test.describe('admin server logs (#171)', () => {
+  test.beforeEach(async ({ page }) => {
+    const login = await page.request.post(`${API}/api/admin/login`, {
+      data: { password: ADMIN_PASSWORD },
+    });
+    expect(login.ok()).toBeTruthy();
+  });
+
+  test('endpoint returns each service ring; UI renders the tail and switches services', async ({
+    page,
+  }) => {
+    // 1) Wire-shape round trip against the real backend for all three
+    //    services. `backend` reads its own ring; the other two are proxied
+    //    with the forwarded machine credential — a 401 here would mean the
+    //    cross-service key wiring is broken.
+    for (const service of ['backend', 'duckdb-service', 'image-service'] as const) {
+      const resp = await page.request.get(`${API}/api/admin/logs?service=${service}&lines=50`);
+      expect(resp.ok()).toBeTruthy();
+      const body = (await resp.json()) as ServerLogsResponse;
+      expect(body.service).toBe(service);
+      expect(Array.isArray(body.lines)).toBeTruthy();
+      expect(typeof body.truncated).toBe('boolean');
+    }
+
+    // A non-allow-listed service is rejected, not proxied.
+    const bad = await page.request.get(`${API}/api/admin/logs?service=nginx`);
+    expect(bad.status()).toBe(400);
+
+    // 2) Drive the browser: the panel defaults to `backend` and loads on
+    //    mount. The backend logs its startup banner through the ring, so the
+    //    output is non-empty.
+    await page.goto('/admin');
+    const output = page.getByTestId('server-logs-output');
+    await expect(output).toBeVisible();
+    await expect(output).not.toBeEmpty();
+
+    // 3) Switch to duckdb-service → the panel refetches and renders that
+    //    service's ring (proves the proxy path through the UI).
+    await page.getByTestId('log-service-select').selectOption('duckdb-service');
+    await expect
+      .poll(async () => (await output.textContent())?.length ?? 0, { timeout: 10_000 })
+      .toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What & why

There was no way to read the services' **own** process logs (backend, `duckdb-service`, `image-service` stdout/stderr) without shell access to the host. The admin API exposes per-**module** ESP telemetry (`GET /api/modules/:id/logs`) but nothing for the services themselves — so any server-side failure (5xx spike, wedged proxy, duckdb write error, image-service stall) left us blind. Spun out of the #170 investigation.

This adds an admin-gated `GET /api/admin/logs?service=backend|duckdb-service|image-service&lines=N` plus a **Server Logs** card on `/admin`.

## Approach — app-level log rings (ADR-021)

Each service tees its own stdout/stderr into a bounded in-memory ring (passing every write through, so `docker logs`/PM2 are unchanged) and exposes an internal `/logs`. The backend serves its own ring directly and **proxies** to the two Flask services, forwarding the `X-Admin-Key` machine credential. Same idea as the ESP `lib/logbuf`.

Rejected (see [ADR-021](docs/09-architecture-decisions/adr-021-admin-server-log-ring.md)): **Docker socket** (host-root exposure on an internet-facing service) and a **shared log-file volume** (touches every service's logging config; dev/prod path drift).

**Security:** the public route is `requireAdmin` (session cookie OR `X-Admin-Key`). The internal Flask `/logs` are reachable on published dev ports, so they require `X-Admin-Key == HIGHFIVE_API_KEY` (constant-time) — the key is now set on all three services in the UI + prod compose (dev shares `.env`).

## What changed, by layer

| Layer | Change |
|---|---|
| **contracts** | `ServerLogService` + `ServerLogsResponse` |
| **backend** | `logRing.ts` stdout/stderr tee; `GET /api/admin/logs` (allow-list, `[1,1000]` clamp, proxy w/ forwarded key + response-shape guard, 502 on upstream failure) |
| **duckdb-service / image-service** | `log_ring.py` tee + admin-gated `/logs` (constant-time key check) |
| **homepage** | `ServerLogsPanel` admin card + `api.getServerLogs` |
| **compose** | `HIGHFIVE_API_KEY` on all three services (UI + prod) |
| **tests** | backend logRing unit + endpoint, duckdb/image pytest, homepage vitest, Playwright spec |
| **docs** | ADR-021, api-reference, api-contracts, building-block notes, CHANGELOG |

## Testing

- backend: 176 pass · `tsc` build clean
- homepage: 168 pass · `vite` build clean
- duckdb-service: 191 pass · image-service: 67 pass · ruff clean
- `make check-citations`: 0 problems
- **End-to-end on the dev stack:** all three rings return; gates verified — no-key `401`, `service=nginx` `400`, wrong-key `401`, and internal `:8002/logs` returns `401` without the key / `200` with it (no leak on the published dev port).
- Playwright spec `tests/ui/tests/admin-server-logs.spec.ts` runs in CI.

## Review

`senior-reviewer` verdict: **mergeable, no P0s.** Addressed: the P1 (Python `_reset_for_test` didn't clear the installed tee's partial-line carry — now tracked + reset) and the P2s (eviction-at-cap tests in all three languages, backend pass-through assertion, proxy-response shape guard, corrected `install()`-placement docstrings, an ADR note that the ring captures any credential code logs).

## Caveats (documented in ADR-021)

In-memory (resets on restart; "since process start", not an audit log); per-process (a future multi-worker prod returns the serving worker's ring); nginx not covered (no app ring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
