### PR TITLE
docs: fix stale host.cpp citation in hardware-notes Access-point table (closes #137)

### DIFF
--- a/docs/08-crosscutting-concepts/hardware-notes.md
+++ b/docs/08-crosscutting-concepts/hardware-notes.md
@@ -8,11 +8,11 @@ For symptom-based diagnosis, see
 
 ## Access point
 
-| Setting  | Value                           |
-| -------- | ------------------------------- |
-| SSID     | `ESP32-Access-Point`            |
-| Password | `esp-12345`                     |
-| Source   | `ESP32-CAM/host.cpp` lines 9–10 |
+| Setting  | Value                                                 |
+| -------- | ----------------------------------------------------- |
+| SSID     | `ESP32-Access-Point`                                  |
+| Password | `esp-12345`                                           |
+| Source   | `HOST_SSID` / `HOST_PASSWORD` in `ESP32-CAM/host.cpp` |
 
 Old documentation (now removed) called it `HiveHive-Access-Point`. It
 never had that name in the code.


### PR DESCRIPTION
## What

The hardware-notes **Access point** table cited `ESP32-CAM/host.cpp` lines 9–10
as the source for the AP SSID/PSK, but `HOST_SSID` / `HOST_PASSWORD` are at
lines 13–14 (include lines were added above them). Switched to the symbol-form
citation CLAUDE.md prefers so it can't drift again. (prettier re-aligned the
table column on commit — hence the ±5 lines for a one-cell change.)

## Why this completes #137

The onboarding Wi-Fi/Bluetooth-coexistence mitigation that #137 asked for —
the Step 3 wizard "pair from your phone" callout (EN + DE, with a both-locale
test), the `esp32-onboarding` skill note, the `troubleshooting.md` entry, and
the `hardware-notes.md` coexistence section — already shipped in PR #159. The
issue stayed open only because #159's title referenced it without an auto-close
keyword. This is the final doc-citation polish; the issue is closed out on merge.

While confirming #137 was complete I byte-checked the Step 3 English string —
`mouse/keyboard` is correct (an apparent "typo" seen earlier was a tooling
display artifact, `U+002F`), so no copy change was needed.

## Test
- `bash scripts/check-doc-citations.sh` → **7 OK, 0 problems**
- `homepage` vitest → **192/192 pass** (incl. the both-locale Step 3 callout test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)