### PR TITLE
fix: Python 3.10 compat — timezone.utc + onnxruntime 1.23.2 (unbreaks prod)

### DIFF
--- a/duckdb-service/services/log_ring.py
+++ b/duckdb-service/services/log_ring.py
@@ -33,7 +33,7 @@ import sys
 import threading
 import time
 from collections import deque
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from logging.handlers import TimedRotatingFileHandler
 
 _MAX_RING_ENTRIES = 2000
@@ -68,7 +68,7 @@ _subscribers: "set[queue.Queue]" = set()
 
 def _now_iso() -> str:
     # Millisecond precision, 'Z' suffix — matches the LogEntry contract.
-    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 def _push(level: str, msg: str) -> dict:
@@ -167,7 +167,7 @@ class _PruningTimedHandler(TimedRotatingFileHandler):
             self.stream.close()
             self.stream = None
         base = self.baseFilename
-        stamp = datetime.now(UTC).strftime("%Y-%m-%d_%H-%M-%S")
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H-%M-%S")
         dfn = f"{base}.{stamp}"
         idx = 1
         while os.path.exists(dfn):  # multiple rolls within the same second

--- a/image-service/requirements.txt
+++ b/image-service/requirements.txt
@@ -9,4 +9,6 @@ pydantic==2.12.5
 # numpy the box math; headless keeps the image slim and avoids libGL.
 opencv-python-headless==4.10.0.84
 numpy==1.26.4
-onnxruntime==1.27.0
+# 1.23.2 is the highest onnxruntime with a CPython 3.10 wheel; the prod host runs
+# Python 3.10 (see PR #191 / the 3.10 ceiling). Bump once the host is on 3.11+.
+onnxruntime==1.23.2

--- a/image-service/services/log_ring.py
+++ b/image-service/services/log_ring.py
@@ -33,7 +33,7 @@ import sys
 import threading
 import time
 from collections import deque
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from logging.handlers import TimedRotatingFileHandler
 
 _MAX_RING_ENTRIES = 2000
@@ -68,7 +68,7 @@ _subscribers: "set[queue.Queue]" = set()
 
 def _now_iso() -> str:
     # Millisecond precision, 'Z' suffix — matches the LogEntry contract.
-    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 def _push(level: str, msg: str) -> dict:
@@ -167,7 +167,7 @@ class _PruningTimedHandler(TimedRotatingFileHandler):
             self.stream.close()
             self.stream = None
         base = self.baseFilename
-        stamp = datetime.now(UTC).strftime("%Y-%m-%d_%H-%M-%S")
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H-%M-%S")
         dfn = f"{base}.{stamp}"
         idx = 1
         while os.path.exists(dfn):  # multiple rolls within the same second


### PR DESCRIPTION
## What

`from datetime import UTC` / `datetime.now(UTC)` in both
`duckdb-service/services/log_ring.py` and `image-service/services/log_ring.py`
requires **Python 3.11+** — the `UTC` alias was only added to `datetime` in 3.11.

## Why it matters

The production host runs **Python 3.10**. Deploying `aac9c78` (current `main`)
crashed **both** python services at import time: `log_ring.install()` runs at
import in `app.py`, so the `ImportError` takes the service down before it serves
any traffic. Prod has been held on the prior known-good revision until this lands.

## Fix

Replace `UTC` with the equivalent `timezone.utc` (available since 3.2). Behavior
is identical on 3.11+ and now works on 3.10:

- `_now_iso()` → millisecond ISO string with a `Z` suffix
- log-rotation filename stamp `%Y-%m-%d_%H-%M-%S`

Both copies of `log_ring.py` are kept byte-identical.

## Verification (run on Python 3.10.12, same minor as prod)

- ✅ `py_compile` of both files
- ✅ full `compileall` sweep of every python service/tooling dir — no other
  3.11-only **syntax** anywhere
- ✅ grepped `origin/main` for other 3.11-isms (`tomllib`, `StrEnum`,
  `ExceptionGroup`, `except*`, `asyncio.TaskGroup`, `typing.Self`,
  `datetime.UTC`) — none outside these two files
- ✅ stamp output confirmed byte-identical to the old `UTC` form
- `fromisoformat` call sites (`measurements.py`, `weather_worker.py`) already
  guard for pre-3.11 input — left as-is

## Also in this PR: onnxruntime pinned for Python 3.10

`image-service/requirements.txt` pinned `onnxruntime==1.27.0`, which has **no
cp310 wheel** (pip offers max `1.23.2` on Python 3.10) — so installing
image-service's requirements would fail on the 3.10 prod host. This PR pins it to
**`onnxruntime==1.23.2`** (the highest cp310 wheel), verified to load and run the
exported `hole_detector.onnx` on Python 3.10.12. Bump back up once the host moves
to Python 3.11+. Server-side inference only — the ESP runs no models
([ADR-028](https://github.com/schutera/highfive/blob/main/docs/09-architecture-decisions/adr-028-ml-inference-server-side-only.md)).

Introduced in `8938899` (part of #180, which closed #178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
