### PR TITLE
fix(backend): retry duckdb health at boot + warn on unset DUCKDB_SERVICE_URL

### DIFF
--- a/backend/src/duckdbClient.ts
+++ b/backend/src/duckdbClient.ts
@@ -1,5 +1,15 @@
-export const DUCKDB_URL =
-  process.env.DUCKDB_SERVICE_URL ?? "http://127.0.0.1:8002";
+// `DUCKDB_SERVICE_URL` is the in-compose address (http://duckdb-service:8000).
+// The default below is the docker host-port mapping (8002:8000) for a backend
+// running on the host against a composed duckdb-service. A bare-metal/pm2
+// deploy (duckdb-service on :8000 directly) MUST set the env var explicitly —
+// see ecosystem.config.js. We track the fallback so startup can warn loudly
+// instead of silently pointing at the wrong port.
+const envDuckdbUrl = process.env.DUCKDB_SERVICE_URL?.trim();
+
+/** True when DUCKDB_SERVICE_URL was unset/blank and we fell back to the default. */
+export const duckdbUrlFromDefault = !envDuckdbUrl;
+
+export const DUCKDB_URL = envDuckdbUrl || "http://127.0.0.1:8002";
 
 export async function duckdbHealth(): Promise<{ ok: boolean; db?: string }> {
   const res = await fetch(`${DUCKDB_URL}/health`);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,7 +1,8 @@
 import 'dotenv/config';
+import { setTimeout as delay } from 'node:timers/promises';
 import { app } from './app';
 import { getApiKey } from './auth';
-import { duckdbHealth } from './duckdbClient';
+import { DUCKDB_URL, duckdbHealth, duckdbUrlFromDefault } from './duckdbClient';
 import { isProduction } from './env';
 import { log } from './log';
 import { installLogRing, initLogPersistence, writeStdout } from './logRing';
@@ -25,12 +26,43 @@ if (portUnsetWarning) {
   );
 }
 
+if (duckdbUrlFromDefault) {
+  log.warn(
+    `[startup] DUCKDB_SERVICE_URL unset — defaulting to ${DUCKDB_URL}. ` +
+      `Set it explicitly in production (pm2: ecosystem.config.js; ` +
+      `compose: DUCKDB_SERVICE_URL=http://duckdb-service:8000).`,
+  );
+}
+
+// The API and duckdb-service are started together (pm2/compose), so a single
+// health probe at boot races the service binding its port: it logs a
+// misleading "not reachable" that then sits at the top of the admin log panel
+// (#171) for the whole process lifetime. Retry briefly before deciding. The
+// check is advisory — we start serving regardless of the result.
+const DUCKDB_HEALTH_BOOT_RETRIES = 10;
+const DUCKDB_HEALTH_BOOT_RETRY_DELAY_MS = 500;
+
 async function bootstrap() {
-  try {
-    const health = await duckdbHealth();
+  let health: { ok: boolean; db?: string } | undefined;
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= DUCKDB_HEALTH_BOOT_RETRIES; attempt++) {
+    try {
+      health = await duckdbHealth();
+      break;
+    } catch (err) {
+      lastErr = err;
+      if (attempt < DUCKDB_HEALTH_BOOT_RETRIES) {
+        await delay(DUCKDB_HEALTH_BOOT_RETRY_DELAY_MS);
+      }
+    }
+  }
+  if (health) {
     log.info(`🗄 DuckDB service reachable: ${JSON.stringify(health)}`);
-  } catch (err) {
-    log.warn(`⚠ DuckDB service not reachable: ${String(err)}`);
+  } else {
+    log.warn(
+      `⚠ DuckDB service not reachable after ${DUCKDB_HEALTH_BOOT_RETRIES} attempts ` +
+        `(${DUCKDB_URL}): ${String(lastErr)}`,
+    );
   }
 
   app.listen(PORT, () => {


### PR DESCRIPTION
## Symptom

The admin server-logs panel shows, seemingly as a live outage:

```
⚠ DuckDB service not reachable: TypeError: fetch failed … ECONNREFUSED 127.0.0.1:8000
    at async duckdbHealth (…/duckdbClient.js)
    at async bootstrap (…/server.js)
```

…even though `duckdb-service` is up and `/health` returns `200`.

## Root cause — a startup race, not an outage

`bootstrap()` in `server.ts` probes `duckdbHealth()` **once, immediately at boot**. The API and `duckdb-service` are started together (pm2/compose), so the probe fires ~1s before duckdb finishes binding its port → `ECONNREFUSED`. It's caught and **non-fatal** (the API serves anyway), but:

- it's logged once at boot, and
- the #171 in-memory log ring retains boot lines for the whole process lifetime, so that single **stale** warning sits at the top of the admin panel and reads like a current failure.

Verified on prod: `highfive-api` and `duckdb-service` last started **2026-06-26 23:00:24 / :25 UTC** — 1 second apart; `/health` is `200` now, service has not restarted since.

## Changes

1. **Retry the boot health probe** (`server.ts`) — `bootstrap()` now retries `duckdbHealth()` up to **10 × 500ms** before logging "not reachable". It still starts serving regardless (the check is advisory). A normal boot resolves on attempt 1–2; a genuinely-down service still surfaces the warning after ~5s.
2. **Warn when `DUCKDB_SERVICE_URL` is unset** (`duckdbClient.ts` → `server.ts`) — mirrors the existing `PORT`-unset warning. Makes a real misconfiguration loud instead of silently pointing at the wrong port. Also trims / treats blank as unset.

## Deliberately NOT changed

- The `http://127.0.0.1:8002` **default is kept** — `8002` is the documented Docker host-port mapping (`duckdb-service` is `8002:8000`), correct for a backend running on the host against a composed duckdb. A bare-metal/pm2 box (duckdb directly on `:8000`) sets `DUCKDB_SERVICE_URL` explicitly, which `ecosystem.config.js` already does. Changing the default to `8000` would break the compose convention; the new startup warning addresses the silent-fallback footgun instead.

## Verification

- `tsc --noEmit` is **clean for both changed files**. (Other files in the tree report errors only from a stale `@highfive/contracts` build and a missing `rotating-file-stream` dep in this host's `node_modules` — pre-existing environment drift, unrelated to this change; CI installs/builds both.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
