### PR TITLE
fix(duckdb): stamp silence-watcher clock in UTC so ages survive TZ

### DIFF
--- a/docs/09-architecture-decisions/adr-005-silence-watcher-in-duckdb-service.md
+++ b/docs/09-architecture-decisions/adr-005-silence-watcher-in-duckdb-service.md
@@ -18,8 +18,8 @@ The watcher needs three things:
 1. **Liveness state for every module.** It computes the freshest of
    `module_configs.last_seen_at`, the latest `image_uploads.uploaded_at`
    per module, and the latest `module_heartbeats.received_at` per
-   module. The `SELECT` block is at `silence_watcher.py:38-52`; the
-   per-row liveness max is at `silence_watcher.py:60-65`. Pre-PR-B
+   module. Both the three-signal `SELECT` block and the per-row
+   liveness max live in `silence_watcher.py`'s `check_silence`. Pre-PR-B
    (issue #97), `module_configs.updated_at` did double duty as both
    row-metadata and liveness signal; the watcher now reads the
    dedicated `last_seen_at` column.
@@ -27,7 +27,7 @@ The watcher needs three things:
    re-fire for `REALERT_INTERVAL_S` seconds"** — done with a single
    nullable `last_silence_alert_at TIMESTAMP` column on
    `module_configs` (`duckdb-service/db/schema.py:26`). Set on alert
-   (`silence_watcher.py:73`), cleared on recovery (`silence_watcher.py:83`).
+   and cleared on recovery inside `silence_watcher.py`'s `check_silence`.
    No separate alerts table.
 3. **A periodic trigger.** It runs as a background thread inside
    `duckdb-service`'s Flask process.

--- a/docs/11-risks-and-technical-debt/README.md
+++ b/docs/11-risks-and-technical-debt/README.md
@@ -130,6 +130,53 @@ write the lesson here so the next contributor doesn't repeat it.
 Format: short title + **What happened** + **Why it happened** +
 **How to avoid it next time**.
 
+### Silence watcher compared UTC-naive rows against a container-local clock (the "chapter-11 entry to follow" promised in `record_image`)
+
+**What happened.** `duckdb-service/services/silence_watcher.py`'s
+`check_silence` (the 15-minute APScheduler job behind the Discord
+module-down / module-back alerts) computed every liveness age from
+naive-local `datetime.now()`, while the timestamps it compares
+against are deliberately stamped UTC-naive by their writers
+(`routes/heartbeats.py`'s `received_at`, `record_image`'s
+`uploaded_at`). The two clocks agree only because the
+`python:3.x-slim` base image defaults to UTC. A prod-ops
+`TZ=Europe/Berlin` override on the container would inflate every
+age by 1-2 h against the 3 h `SILENCE_THRESHOLD_S` and fire a false
+"down" alert for every healthy module heard from more than 1-2 h
+ago (a TZ behind UTC would instead suppress real outage alerts by
+the same margin). The re-alert spacing against `REALERT_INTERVAL_S`
+and the `last_silence_alert_at` write-back skew the same way. Found
+latent; no TZ-flipped container has been staged.
+
+**Why it happened.** This is the reader-side twin of the
+"`image_uploads.uploaded_at` stamped in container-local time" entry
+below. That incident fixed the writer and prescribed grepping the
+*writers* for bare `datetime.now()` when adding a timezone-aware
+reader; nobody swept the existing *readers* that do timestamp
+arithmetic against the UTC-naive columns. The silence watcher
+pre-dated the UTC discipline and kept its naive-local clock.
+`record_image`'s in-source comment flagged the residual risk and
+promised a "chapter-11 entry to follow"; this entry closes that
+promise.
+
+**How to avoid it next time.** The UTC-naive discipline cuts both
+ways: any bare `datetime.now()` that feeds arithmetic against DB
+timestamps is wrong by default in this codebase, whether it writes
+the column or reads it. When fixing one side of a writer/reader
+pair, grep the other side in the same PR
+(`grep -rn "datetime.now()" duckdb-service/` and check each hit for
+a `tz` argument). The fix mirrors the writers:
+`datetime.now(timezone.utc).replace(tzinfo=None)` (not
+`datetime.now(UTC)`; the 3.10 floor forbids it, see the CI-matrix
+entry below). The regression is pinned by
+`tests/test_silence_watcher.py`, which flips the process TZ to a
+fixed UTC+2 zone via `time.tzset()` and asserts a module seen 1.5 h
+ago stays quiet. Still-open follow-ups, deliberately not in the fix
+PR: `add_module`'s `last_seen_at = NOW()` (DuckDB session-local)
+and the schema's `DEFAULT CURRENT_TIMESTAMP` columns are the
+remaining container-local timestamp sources to audit if a
+TZ-flipped container is ever staged.
+
 ### CI tested only Python 3.11, but the repo names its runtime three different ways — a 3.11-only `datetime.UTC` crashed both services on deploy (#180, #192)
 
 **What happened.** Commit `8938899` added `from datetime import UTC` / `datetime.now(UTC)`

--- a/duckdb-service/routes/modules.py
+++ b/duckdb-service/routes/modules.py
@@ -547,7 +547,8 @@ def record_image():
             # `TZ=Europe/Berlin` on the container in prod would put
             # writes 1-2 hours past the reader's window upper bound.
             # The schema's `DEFAULT CURRENT_TIMESTAMP` carries the same
-            # naive-local risk; chapter-11 entry to follow.
+            # naive-local risk; see chapter 11 "Silence watcher compared
+            # UTC-naive rows against a container-local clock".
             now_utc = (
                 datetime.now(timezone.utc)
                 .replace(tzinfo=None)

--- a/duckdb-service/services/silence_watcher.py
+++ b/duckdb-service/services/silence_watcher.py
@@ -9,7 +9,7 @@ heartbeat. Whichever is freshest wins. (Pre-#97 split this read
 see chapter 11 "updated_at semantic overload".)
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from db.connection import lock, get_conn
 from services.discord import send_discord_message
@@ -30,7 +30,17 @@ def _fmt_age(seconds: float) -> str:
 
 
 def check_silence():
-    now = datetime.now()
+    # UTC, NOT naive-local. Every timestamp this loop compares against is
+    # stamped UTC-naive by its writer (`received_at` in routes/heartbeats.py,
+    # `record_image`'s `uploaded_at`), so the clock must be UTC-naive too.
+    # Naive-local `datetime.now()` agrees only because the python:3.x-slim
+    # image defaults to UTC; a TZ=Europe/Berlin container would inflate every
+    # age by 1-2 h against SILENCE_THRESHOLD_S and fire false "down" alerts
+    # (and skew the re-alert spacing and `last_silence_alert_at` writes below
+    # the same way). See `record_image` in routes/modules.py and chapter 11
+    # "Silence watcher compared UTC-naive rows against a container-local
+    # clock".
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     silence_alerts = []
     recovery_alerts = []
 

--- a/duckdb-service/tests/conftest.py
+++ b/duckdb-service/tests/conftest.py
@@ -47,6 +47,7 @@ def _purge_service_modules() -> None:
         "routes._bucketing",
         "routes",
         "services.discord",
+        "services.silence_watcher",
         "services.weather_worker",
         "services",
         "db.schema",

--- a/duckdb-service/tests/test_silence_watcher.py
+++ b/duckdb-service/tests/test_silence_watcher.py
@@ -1,0 +1,194 @@
+"""Tests for the silence watcher (``services/silence_watcher.py``).
+
+The watcher compares ``now`` against timestamps that every writer stamps
+UTC-naive (``routes/heartbeats.py`` stamps ``received_at`` with
+``datetime.now(timezone.utc).replace(tzinfo=None)``; ``record_image``
+does the same for ``uploaded_at``). Pre-fix, ``check_silence`` used
+naive-local ``datetime.now()``, which agrees with those rows only while
+the process TZ is UTC (the ``python:3.x-slim`` default). Under a UTC+2
+process TZ every computed age inflated by 2 h, so a module heard from
+1.5 h ago crossed the 3 h ``SILENCE_THRESHOLD_S`` and fired a false
+"down" alert; a TZ behind UTC would instead suppress real alerts. These
+tests pin the UTC-naive clock discipline under a non-UTC process TZ.
+
+The TZ fixture uses ``Etc/GMT-2`` (a fixed UTC+2 zone under the POSIX
+inverted-sign convention, no DST) rather than ``Europe/Berlin`` so the
+offset is deterministic year-round. ``time.tzset`` is POSIX-only, so
+these tests skip on Windows; CI's ubuntu runners exercise them.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import time
+import types
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+TEST_MAC = "aabbccddeeff"
+
+
+# ---------- helpers ----------
+
+
+def _utc_naive_now() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _seed_module(fresh_db, last_seen_at, last_silence_alert_at=None):
+    """Insert a module row with explicit timestamps. The live write paths
+    stamp their timestamps at now(), so a backdated liveness signal can
+    only be seeded by writing the row directly (same rationale as
+    ``test_heartbeats_endpoint.py``'s ``_insert_heartbeats``). Values are
+    UTC-naive, exactly like the production writers'. ``last_seen_at`` is
+    passed explicitly so the column's ``DEFAULT CURRENT_TIMESTAMP`` (which
+    carries its own naive-local risk) never enters the picture."""
+    con = fresh_db.connection.get_conn()
+    try:
+        con.execute(
+            "INSERT INTO module_configs "
+            "(id, name, lat, lng, first_online, last_seen_at, "
+            "last_silence_alert_at) "
+            "VALUES (?, 'Watched', 47.79, 9.62, '2026-05-01', ?, ?)",
+            (TEST_MAC, last_seen_at, last_silence_alert_at),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _fetch_alert_stamp(fresh_db):
+    con = fresh_db.connection.get_conn()
+    try:
+        row = con.execute(
+            "SELECT last_silence_alert_at FROM module_configs WHERE id = ?",
+            (TEST_MAC,),
+        ).fetchone()
+        return row[0]
+    finally:
+        con.close()
+
+
+# ---------- fixtures ----------
+
+
+@pytest.fixture
+def watcher(fresh_db, monkeypatch):
+    """Import the watcher AFTER ``fresh_db`` so its import-time
+    ``from db.connection import lock, get_conn`` binds to the test DB,
+    then replace its bound ``send_discord_message`` with a spy. The
+    module does ``from services.discord import send_discord_message``,
+    so the patch targets the watcher's own namespace, where the name is
+    looked up."""
+    module = importlib.import_module("services.silence_watcher")
+    calls: list[str] = []
+    monkeypatch.setattr(module, "send_discord_message", calls.append)
+    return types.SimpleNamespace(check_silence=module.check_silence, calls=calls)
+
+
+@pytest.fixture
+def utc_plus_2_tz():
+    """Run the test under a fixed UTC+2 process TZ, restoring the
+    original TZ (and re-running tzset) on teardown."""
+    if not hasattr(time, "tzset"):
+        pytest.skip("time.tzset is POSIX-only; the TZ cannot be flipped in-process")
+    original = os.environ.get("TZ")
+    os.environ["TZ"] = "Etc/GMT-2"
+    time.tzset()
+    yield
+    if original is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = original
+    time.tzset()
+
+
+# ---------- the TZ regression (the reason this file exists) ----------
+
+
+def test_module_seen_90_min_ago_does_not_alert_under_utc_plus_2(
+    watcher, fresh_db, utc_plus_2_tz
+):
+    """REGRESSION: last heard from 1.5 h ago, half the 3 h threshold.
+    Pre-fix, naive-local now() under UTC+2 added 2 h to the age
+    (1.5 h -> 3.5 h) and fired a false "down" alert for a healthy
+    module, every 15-minute scheduler tick, fleet-wide."""
+    _seed_module(fresh_db, last_seen_at=_utc_naive_now() - timedelta(minutes=90))
+
+    watcher.check_silence()
+
+    assert watcher.calls == []
+    assert _fetch_alert_stamp(fresh_db) is None
+
+
+def test_module_silent_4_h_still_alerts_under_utc_plus_2(
+    watcher, fresh_db, utc_plus_2_tz
+):
+    """True positive: a genuinely silent module (4 h > 3 h threshold)
+    must still alert with the UTC clock. Pins that the fix suppresses
+    the false positives above without muting real outages."""
+    _seed_module(fresh_db, last_seen_at=_utc_naive_now() - timedelta(hours=4))
+
+    watcher.check_silence()
+
+    assert len(watcher.calls) == 1
+    assert "Watched is down" in watcher.calls[0]
+
+
+def test_alert_stamp_is_utc_naive_not_local(watcher, fresh_db, utc_plus_2_tz):
+    """The ``last_silence_alert_at`` bookkeeping the watcher writes back
+    must follow the same UTC-naive discipline as every other writer; a
+    local-clock stamp would skew the ``REALERT_INTERVAL_S`` spacing and
+    the recovery-downtime arithmetic by the UTC offset."""
+    _seed_module(fresh_db, last_seen_at=_utc_naive_now() - timedelta(hours=4))
+
+    watcher.check_silence()
+
+    stamp = _fetch_alert_stamp(fresh_db)
+    assert stamp is not None
+    skew_s = abs((stamp - _utc_naive_now()).total_seconds())
+    assert skew_s < 300, (
+        f"last_silence_alert_at is {skew_s:.0f}s away from UTC now; "
+        "an offset-sized skew means the stamp came from the local clock"
+    )
+
+
+# ---------- baseline watcher behaviour (TZ-independent) ----------
+
+
+def test_recovered_module_fires_recovery_and_clears_state(watcher, fresh_db):
+    """A module that is alive again after an alert gets exactly one
+    recovery message, and the alert state clears so the next real
+    outage re-alerts from scratch."""
+    _seed_module(
+        fresh_db,
+        last_seen_at=_utc_naive_now(),
+        last_silence_alert_at=_utc_naive_now() - timedelta(hours=2),
+    )
+
+    watcher.check_silence()
+
+    assert len(watcher.calls) == 1
+    assert "Watched is back" in watcher.calls[0]
+    assert _fetch_alert_stamp(fresh_db) is None
+
+
+def test_recent_alert_is_not_refired_within_realert_interval(watcher, fresh_db):
+    """A module still silent but already alerted 2 h ago (inside the
+    6 h ``REALERT_INTERVAL_S``) must stay quiet, no Discord spam."""
+    _seed_module(
+        fresh_db,
+        last_seen_at=_utc_naive_now() - timedelta(hours=5),
+        last_silence_alert_at=_utc_naive_now() - timedelta(hours=2),
+    )
+    stamp_before = _fetch_alert_stamp(fresh_db)
+
+    watcher.check_silence()
+
+    assert watcher.calls == []
+    assert _fetch_alert_stamp(fresh_db) == stamp_before, (
+        "suppressed re-alert must not refresh last_silence_alert_at, "
+        "or the next re-alert keeps sliding forward"
+    )


### PR DESCRIPTION
## What changed

- `duckdb-service/services/silence_watcher.py`: `check_silence` now takes its clock from `datetime.now(timezone.utc).replace(tzinfo=None)` instead of naive-local `datetime.now()`, mirroring the `received_at` writer in `routes/heartbeats.py`.
- First tests for the watcher (`tests/test_silence_watcher.py`): flips the process TZ to a fixed UTC+2 zone (`Etc/GMT-2` + `time.tzset()`, POSIX-guarded) and pins that a module seen 1.5 h ago stays quiet, a 4 h-silent module still alerts, and `last_silence_alert_at` lands UTC-naive; plus recovery-fires-once and re-alert-suppression baselines. `conftest.py` purges `services.silence_watcher` alongside the other service modules so each test binds the fresh DB.
- Chapter 11: adds the lesson entry `record_image`'s comment promised ("chapter-11 entry to follow"), and that comment now points at it. ADR-005's four `silence_watcher.py:NN` citations converted to symbol style since this diff shifted them.

## Why

Every timestamp the watcher compares against is stamped UTC-naive by its writers, but the watcher's clock was container-local, which agrees only while the container TZ is UTC (the python-slim default). A `TZ=Europe/Berlin` override would inflate every liveness age 1-2 h against the 3 h threshold and fire false module-down Discord alerts on each 15-minute tick; a TZ behind UTC would suppress real outages. Reader-side twin of the chapter-11 `image_uploads.uploaded_at` incident. Acknowledged follow-up, deliberately not in this diff: `add_module`'s `last_seen_at = NOW()` and the schema's `DEFAULT CURRENT_TIMESTAMP` columns remain container-local timestamp sources (tracked in the new chapter-11 entry).

## How tested

- [ ] ESP32-CAM native (`pio test -e native`)
- [ ] End-to-end (`pytest tests/e2e`)
- [ ] Backend unit (Node 22 + TS)
- [ ] image-service unit (pytest, Python 3.10-3.14 matrix)
- [x] duckdb-service unit (pytest, Python 3.10-3.14 matrix)
- [ ] Homepage unit (React 19 + Vite)
- [ ] Manual / hardware-in-the-loop verification

237 passed locally (232 on `main` + new) on Python 3.14. The regression test fails against the unfixed watcher: false "down" alert for a module seen 90 min ago under UTC+2, and `last_silence_alert_at` lands 7200 s off UTC. `scripts/check-doc-citations.sh`: 3 OK, 0 problems. ruff check + format clean. Other suites untouched by this change.

## Checklist

- [x] Tests added or updated to cover the change
- [x] Documentation updated where applicable (chapter 11, ADR-005 citations)
- [x] No secrets, credentials, or large binaries committed
- [ ] CI is green on this branch
- [x] Breaking changes called out in the description (none)
